### PR TITLE
patch: add error handling to  runWithContext

### DIFF
--- a/packages/vest/src/lib/runWithContext/index.js
+++ b/packages/vest/src/lib/runWithContext/index.js
@@ -9,9 +9,16 @@ import Context from '../../core/Context';
 const runWithContext = (ctxRef, fn) => {
   const context = new Context(ctxRef);
 
-  const res = fn(context);
+  let res;
+
+  try {
+    res = fn(context);
+  } catch {
+    /*  */
+  }
 
   Context.clear();
+
   return res;
 };
 

--- a/packages/vest/src/lib/runWithContext/spec.js
+++ b/packages/vest/src/lib/runWithContext/spec.js
@@ -36,6 +36,7 @@ describe('runWithContext', () => {
     runWithContext(parent, fn);
     expect(fn).toHaveBeenCalledTimes(1);
   });
+
   it('Should clear context after running callback', () => {
     const fn = jest.fn(context => {
       expect(singleton.useContext()).toMatchObject(context);
@@ -60,6 +61,38 @@ describe('runWithContext', () => {
     });
     it('Should create a new context with the parent object', () => {
       expect(mockContext).toHaveBeenCalledWith(parent);
+    });
+  });
+
+  describe('When an error is thrown inside the callback', () => {
+    let cb;
+
+    beforeEach(() => {
+      cb = jest.fn(() => {
+        throw new Error();
+      });
+    });
+
+    test('sanity', () => {
+      expect(() => cb()).toThrow();
+    });
+
+    it('Should catch error', () => {
+      expect(() => {
+        runWithContext({}, cb);
+      }).not.toThrow();
+
+      expect(cb).toHaveBeenCalled();
+    });
+
+    it('Should clear the context', () => {
+      const context = { [faker.random.word()]: faker.random.word() };
+
+      runWithContext(context, () => {
+        expect(singleton.useContext()).toMatchObject(context);
+        throw new Error();
+      });
+      expect(singleton.useContext()).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Handle errors in runWithContext so that context is always cleared regardless of what happens inside.