### PR TITLE
patch: remove global counters from "live" state.

### DIFF
--- a/packages/vest/src/core/produce/index.js
+++ b/packages/vest/src/core/produce/index.js
@@ -60,13 +60,25 @@ const done = (state, ...args) => {
 /**
  * @returns {Object} with only public properties.
  */
-const extract = ({ groups, errorCount, warnCount, tests, name }) => ({
+const extract = ({ groups, tests, name }) => ({
   groups,
-  errorCount,
-  warnCount,
   tests,
   name,
 });
+
+/**
+ * Counts the failed tests and adds global counters
+ * @param {Object} state
+ */
+const countFailures = state => {
+  state[SEVERITY_COUNT_ERROR] = 0;
+  state[SEVERITY_COUNT_WARN] = 0;
+  for (const test in state.tests) {
+    state[SEVERITY_COUNT_ERROR] += state.tests[test][SEVERITY_COUNT_ERROR];
+    state[SEVERITY_COUNT_WARN] += state.tests[test][SEVERITY_COUNT_WARN];
+  }
+  return state;
+};
 
 /**
  * @param {string} suiteId
@@ -77,6 +89,7 @@ const produce = (state, { draft } = {}) =>
   state
   |> extract
   |> copy
+  |> countFailures
   |> (transformedState =>
     Object.defineProperties(
       transformedState,

--- a/packages/vest/src/core/produce/spec.js
+++ b/packages/vest/src/core/produce/spec.js
@@ -91,6 +91,32 @@ runSpec(vest => {
       );
     });
 
+    it('Should add global failure counters from test object', () => {
+      const res = produce({
+        tests: {
+          f1: {
+            errorCount: 1,
+            warnCount: 0,
+          },
+          f2: {
+            errorCount: 1,
+            warnCount: 1,
+          },
+          f3: {
+            errorCount: 2,
+            warnCount: 3,
+          },
+          f4: {
+            errorCount: 0,
+            warnCount: 2,
+          },
+        },
+      });
+
+      expect(res.errorCount).toBe(4);
+      expect(res.warnCount).toBe(6);
+    });
+
     it.each(GENERATED_METHODS)(
       'Should add `%s` method to the output object',
       name => {

--- a/packages/vest/src/core/state/registerSuite/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/state/registerSuite/__snapshots__/spec.js.snap
@@ -3,7 +3,6 @@
 exports[`registerSuite When suite does not exist in state Should create initial suite without prevState 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "errorCount": 0,
   "exclusive": Object {},
   "fieldCallbacks": Object {},
   "groups": Object {},
@@ -14,7 +13,6 @@ Object {
   "skippedTests": Object {},
   "suiteId": "suiteId_1",
   "tests": Object {},
-  "warnCount": 0,
 }
 `;
 
@@ -22,7 +20,6 @@ exports[`registerSuite When suite exists in state Prev state data handling When 
 Array [
   Object {
     "doneCallbacks": Array [],
-    "errorCount": 0,
     "exclusive": Object {},
     "fieldCallbacks": Object {},
     "groups": Object {},
@@ -40,11 +37,9 @@ Array [
     "skippedTests": Object {},
     "suiteId": "suiteId_1",
     "tests": Object {},
-    "warnCount": 0,
   },
   Object {
     "doneCallbacks": Array [],
-    "errorCount": 0,
     "exclusive": Object {},
     "fieldCallbacks": Object {},
     "groups": Object {},
@@ -55,7 +50,6 @@ Array [
     "skippedTests": Object {},
     "suiteId": "suiteId_1",
     "tests": Object {},
-    "warnCount": 0,
   },
 ]
 `;
@@ -64,7 +58,6 @@ exports[`registerSuite When suite exists in state Should match snapshot 1`] = `
 Array [
   Object {
     "doneCallbacks": Array [],
-    "errorCount": 0,
     "exclusive": Object {},
     "fieldCallbacks": Object {},
     "groups": Object {},
@@ -75,11 +68,9 @@ Array [
     "skippedTests": Object {},
     "suiteId": "suiteId_1",
     "tests": Object {},
-    "warnCount": 0,
   },
   Object {
     "doneCallbacks": Array [],
-    "errorCount": 0,
     "exclusive": Object {},
     "fieldCallbacks": Object {},
     "groups": Object {},
@@ -90,7 +81,6 @@ Array [
     "skippedTests": Object {},
     "suiteId": "suiteId_1",
     "tests": Object {},
-    "warnCount": 0,
   },
 ]
 `;

--- a/packages/vest/src/core/state/registerSuite/index.js
+++ b/packages/vest/src/core/state/registerSuite/index.js
@@ -18,8 +18,6 @@ const INITIAL_SUITE_STATE = (suiteId, name) => ({
   tests: {},
   groups: {},
   exclusive: {},
-  errorCount: 0,
-  warnCount: 0,
 });
 
 /**

--- a/packages/vest/src/core/state/reset/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/state/reset/__snapshots__/spec.js.snap
@@ -6,7 +6,6 @@ Object {
     "suite_id": Array [
       Object {
         "doneCallbacks": Array [],
-        "errorCount": 0,
         "exclusive": Object {
           "skip": Object {
             "field_1": true,
@@ -84,11 +83,9 @@ Object {
             "warnCount": 0,
           },
         },
-        "warnCount": 0,
       },
       Object {
         "doneCallbacks": Array [],
-        "errorCount": 0,
         "exclusive": Object {
           "skip": Object {
             "field_2": true,
@@ -118,7 +115,6 @@ Object {
             "warnCount": 0,
           },
         },
-        "warnCount": 0,
       },
     ],
   },
@@ -134,7 +130,6 @@ Object {
     "suite_id": Array [
       Object {
         "doneCallbacks": Array [],
-        "errorCount": 0,
         "exclusive": Object {
           "skip": Object {
             "field_1": true,
@@ -212,11 +207,9 @@ Object {
             "warnCount": 0,
           },
         },
-        "warnCount": 0,
       },
       Object {
         "doneCallbacks": Array [],
-        "errorCount": 0,
         "exclusive": Object {
           "skip": Object {
             "field_2": true,
@@ -246,7 +239,6 @@ Object {
             "warnCount": 0,
           },
         },
-        "warnCount": 0,
       },
     ],
   },
@@ -277,7 +269,6 @@ Object {
     "suite_id": Array [
       Object {
         "doneCallbacks": Array [],
-        "errorCount": 0,
         "exclusive": Object {
           "skip": Object {
             "field_1": true,
@@ -355,11 +346,9 @@ Object {
             "warnCount": 0,
           },
         },
-        "warnCount": 0,
       },
       Object {
         "doneCallbacks": Array [],
-        "errorCount": 0,
         "exclusive": Object {
           "skip": Object {
             "field_2": true,
@@ -389,7 +378,6 @@ Object {
             "warnCount": 0,
           },
         },
-        "warnCount": 0,
       },
     ],
   },
@@ -435,7 +423,6 @@ Object {
     "suite_id": Array [
       Object {
         "doneCallbacks": Array [],
-        "errorCount": 0,
         "exclusive": Object {
           "skip": Object {
             "field_1": true,
@@ -513,11 +500,9 @@ Object {
             "warnCount": 0,
           },
         },
-        "warnCount": 0,
       },
       Object {
         "doneCallbacks": Array [],
-        "errorCount": 0,
         "exclusive": Object {
           "skip": Object {
             "field_2": true,
@@ -547,7 +532,6 @@ Object {
             "warnCount": 0,
           },
         },
-        "warnCount": 0,
       },
     ],
   },

--- a/packages/vest/src/core/test/lib/VestTest/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/test/lib/VestTest/__snapshots__/spec.js.snap
@@ -15,7 +15,6 @@ VestTest {
 
 exports[`VestTest testObject.fail When severity = error Should bump error counters and messages 1`] = `
 Object {
-  "errorCount": 1,
   "groups": Object {},
   "tests": Object {
     "unicycle": Object {
@@ -27,13 +26,11 @@ Object {
       "warnings": Array [],
     },
   },
-  "warnCount": 0,
 }
 `;
 
 exports[`VestTest testObject.fail When severity = warn Should bump error counters and messages 1`] = `
 Object {
-  "errorCount": 0,
   "groups": Object {},
   "tests": Object {
     "unicycle": Object {
@@ -45,7 +42,6 @@ Object {
       ],
     },
   },
-  "warnCount": 1,
 }
 `;
 

--- a/packages/vest/src/core/test/lib/VestTest/index.js
+++ b/packages/vest/src/core/test/lib/VestTest/index.js
@@ -74,8 +74,6 @@ VestTest.prototype.fail = function () {
       obj[severityCount]++;
     });
 
-    nextState[severityCount]++;
-
     return nextState;
   });
 

--- a/packages/vest/src/core/test/lib/VestTest/spec.js
+++ b/packages/vest/src/core/test/lib/VestTest/spec.js
@@ -59,8 +59,6 @@ describe('VestTest', () => {
         },
       },
       groups: {},
-      errorCount: 0,
-      warnCount: 0,
     });
 
     const initialState = stateMock();
@@ -94,8 +92,6 @@ describe('VestTest', () => {
         expect(res.tests[fieldName].warnCount).toBe(
           initialState.tests[fieldName].warnCount
         );
-        expect(res.errorCount).toBe(initialState.errorCount + 1);
-        expect(res.warnCount).toBe(initialState.warnCount);
         expect(res).toMatchSnapshot();
       });
     });
@@ -113,8 +109,6 @@ describe('VestTest', () => {
         expect(res.tests[fieldName].errorCount).toBe(
           initialState.tests[fieldName].errorCount
         );
-        expect(res.warnCount).toBe(initialState.warnCount + 1);
-        expect(res.errorCount).toBe(initialState.errorCount);
         expect(res).toMatchSnapshot();
       });
     });

--- a/packages/vest/src/core/test/lib/pending/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/test/lib/pending/__snapshots__/spec.js.snap
@@ -3,7 +3,6 @@
 exports[`module: pending export: removePending When testObject is either pending or lagging When in lagging Should remove test from lagging 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "errorCount": 0,
   "exclusive": Object {},
   "fieldCallbacks": Object {},
   "groups": Object {},
@@ -14,14 +13,12 @@ Object {
   "skippedTests": Object {},
   "suiteId": "suite_1",
   "tests": Object {},
-  "warnCount": 0,
 }
 `;
 
 exports[`module: pending export: removePending When testObject is either pending or lagging When in pending Should remove test from pending 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "errorCount": 0,
   "exclusive": Object {},
   "fieldCallbacks": Object {},
   "groups": Object {},
@@ -32,14 +29,12 @@ Object {
   "skippedTests": Object {},
   "suiteId": "suite_1",
   "tests": Object {},
-  "warnCount": 0,
 }
 `;
 
 exports[`module: pending export: setPending When field is in lagging array Should remove test from lagging array 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "errorCount": 0,
   "exclusive": Object {},
   "fieldCallbacks": Object {},
   "groups": Object {},
@@ -82,6 +77,5 @@ Object {
   "skippedTests": Object {},
   "suiteId": "suite_1",
   "tests": Object {},
-  "warnCount": 0,
 }
 `;

--- a/packages/vest/src/core/test/lib/skipped/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/test/lib/skipped/__snapshots__/spec.js.snap
@@ -3,7 +3,6 @@
 exports[`module: skipped export: mergeSkipped When previous state exists When skipped fields exist When skipped field exists in previous state Error field Should copy prev field state over 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "errorCount": 1,
   "exclusive": Object {},
   "fieldCallbacks": Object {},
   "groups": Object {},
@@ -25,14 +24,12 @@ Object {
       "warnings": Array [],
     },
   },
-  "warnCount": 0,
 }
 `;
 
 exports[`module: skipped export: mergeSkipped When previous state exists When skipped fields exist When skipped field exists in previous state Warning field Should copy prev field state over 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "errorCount": 0,
   "exclusive": Object {},
   "fieldCallbacks": Object {},
   "groups": Object {},
@@ -54,14 +51,12 @@ Object {
       ],
     },
   },
-  "warnCount": 1,
 }
 `;
 
 exports[`module: skipped export: setSkippedGroup When group is not yet skipped Should mark group as skipped 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "errorCount": 0,
   "exclusive": Object {},
   "fieldCallbacks": Object {},
   "groups": Object {},
@@ -74,14 +69,12 @@ Object {
   "skippedTests": Object {},
   "suiteId": "suiteId_1",
   "tests": Object {},
-  "warnCount": 0,
 }
 `;
 
 exports[`module: skipped export: setSkippedTest When field is not yet skipped Should mark field as skipped 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "errorCount": 0,
   "exclusive": Object {},
   "fieldCallbacks": Object {},
   "groups": Object {},
@@ -94,6 +87,5 @@ Object {
   },
   "suiteId": "suiteId_1",
   "tests": Object {},
-  "warnCount": 0,
 }
 `;

--- a/packages/vest/src/core/test/lib/skipped/index.js
+++ b/packages/vest/src/core/test/lib/skipped/index.js
@@ -47,8 +47,6 @@ export const mergeSkipped = suiteId => {
     for (const fieldName in state.skippedTests) {
       if (prevState.tests[fieldName] && !state.tests[fieldName]) {
         nextState.tests[fieldName] = { ...prevState.tests[fieldName] };
-        nextState.errorCount += prevState.tests[fieldName].errorCount;
-        nextState.warnCount += prevState.tests[fieldName].warnCount;
       }
     }
 

--- a/packages/vest/src/core/test/lib/skipped/spec.js
+++ b/packages/vest/src/core/test/lib/skipped/spec.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import resetState from '../../../../../testUtils/resetState';
 import runRegisterSuite from '../../../../../testUtils/runRegisterSuite';
+import produce from '../../../produce';
 import getSuiteState from '../../../state/getSuiteState';
 import patch from '../../../state/patch';
 import { setSkippedTest, setSkippedGroup, mergeSkipped } from '.';
@@ -140,10 +141,12 @@ describe('module: skipped', () => {
               expect(getSuiteState(suiteId).tests[FIELD_NAME_1]).toEqual(
                 mock.tests[FIELD_NAME_1]
               );
-              expect(getSuiteState(suiteId).warnCount).toBe(
-                state.warnCount + mock.tests[FIELD_NAME_1].warnCount
+              expect(produce(getSuiteState(suiteId)).warnCount).toBe(
+                produce(state).warnCount + mock.tests[FIELD_NAME_1].warnCount
               );
-              expect(getSuiteState(suiteId).errorCount).toBe(state.errorCount);
+              expect(produce(getSuiteState(suiteId)).errorCount).toBe(
+                produce(state).errorCount
+              );
               expect(getSuiteState(suiteId)).toMatchSnapshot();
             });
           });
@@ -157,10 +160,13 @@ describe('module: skipped', () => {
               expect(getSuiteState(suiteId).tests[FIELD_NAME_2]).toEqual(
                 mock.tests[FIELD_NAME_2]
               );
-              expect(getSuiteState(suiteId).errorCount).toBe(
-                state.errorCount + mock.tests[FIELD_NAME_2].errorCount
+
+              expect(produce(getSuiteState(suiteId)).errorCount).toBe(
+                produce(state).errorCount + mock.tests[FIELD_NAME_2].errorCount
               );
-              expect(getSuiteState(suiteId).warnCount).toBe(state.warnCount);
+              expect(produce(getSuiteState(suiteId)).warnCount).toBe(
+                produce(state).warnCount
+              );
               expect(getSuiteState(suiteId)).toMatchSnapshot();
             });
           });

--- a/packages/vest/src/core/test/runAsyncTest/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/test/runAsyncTest/__snapshots__/spec.js.snap
@@ -3,7 +3,6 @@
 exports[`runAsyncTest: failing State updates Initial state matches snapshot (sanity) 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "errorCount": 0,
   "exclusive": Object {},
   "fieldCallbacks": Object {
     "field_1": Array [],
@@ -27,14 +26,12 @@ Object {
   "skippedTests": Object {},
   "suiteId": "suiteId_1",
   "tests": Object {},
-  "warnCount": 0,
 }
 `;
 
 exports[`runAsyncTest: passing State updates Initial state matches snapshot (sanity) 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "errorCount": 0,
   "exclusive": Object {},
   "fieldCallbacks": Object {
     "field_1": Array [],
@@ -58,6 +55,5 @@ Object {
   "skippedTests": Object {},
   "suiteId": "suiteId_1",
   "tests": Object {},
-  "warnCount": 0,
 }
 `;

--- a/packages/vest/testUtils/resetState/__snapshots__/spec.js.snap
+++ b/packages/vest/testUtils/resetState/__snapshots__/spec.js.snap
@@ -11,7 +11,6 @@ exports[`resetState When invoked with suite name Should add a new suite to the s
 Array [
   Object {
     "doneCallbacks": Array [],
-    "errorCount": 0,
     "exclusive": Object {},
     "fieldCallbacks": Object {},
     "groups": Object {},
@@ -22,7 +21,6 @@ Array [
     "skippedTests": Object {},
     "suiteId": "test-suite",
     "tests": Object {},
-    "warnCount": 0,
   },
   undefined,
 ]


### PR DESCRIPTION
Remove global counters from state, and instead calculate them in the "produce" stage. It's preferred to only have a single source of truth.