### PR TITLE
added: [vest] hook vest.get

### DIFF
--- a/config/jest/jest.setup.js
+++ b/config/jest/jest.setup.js
@@ -1,5 +1,8 @@
 const glob = require('glob');
 
+const {
+  default: isDeepCopy,
+} = require('../../packages/vest/testUtils/isDeepCopy');
 const { packagePath } = require('../../util');
 
 global.isWatchMode = (process.argv || []).some(
@@ -16,4 +19,8 @@ test.skipOnWatch = (...args) => {
 
   return test(...args);
 };
+
+expect.extend({
+  isDeepCopyOf: isDeepCopy,
+});
 /* eslint-enable */

--- a/docs/result.md
+++ b/docs/result.md
@@ -6,19 +6,46 @@ A result object would look somewhat like this:
 
 ```js
 {
-  'name': 'formName',       // The name of the validation suite
-  'errorCount': 0,          // Overall count of errors in the suite
-  'warnCount': 0,           // Overall count of warnings in the suite
-  'tests': Object {         // An object containing all non-skipped tests
-    'fieldName': Object {   // Name of each field
-      'errorCount': 0,      // Error count per field
-      'errors': Array [],   // Array of error messages fer field (may be undefined)
-      'warnings': Array [], // Array of warning messages fer field (may be undefined)
-      'warnCount': 0,       // Warning count per field
+  'name': 'formName',              // The name of the validation suite
+  'errorCount': Number 0,          // Overall count of errors in the suite
+  'warnCount': Number 0,           // Overall count of warnings in the suite
+  'testCount': Number 0,           // Overall test count for the suite (passing, failing and warning)
+  'tests': Object {                // An object containing all non-skipped tests
+    'fieldName': Object {          // Name of each field
+      'errorCount': Number 0,      // Error count per field
+      'errors': Array [],          // Array of error messages fer field (may be undefined)
+      'warnings': Array [],        // Array of warning messages fer field (may be undefined)
+      'warnCount': Number 0,       // Warning count per field
+      'testCount': Number 0,       // Overall test count for the field (passing, failing and warning)
     },
+    'groups': Object {             // An object containing groups declared in the suite
+      'fieldName': Object {        // Subset of res.tests[fieldName] only containing tests
+        /*... */                   // only containing tests that ran within the group
+      }
+    }
   }
 }
 ```
+
+## Accessing the last result object with `vest.get`
+
+Alternatively, if you need to access your validation results out of context - for example, from a different UI component or function, you can use `vest.get`.
+
+Vest exposes the `vest.get` function that is able to retrieve the most recent validation result of [**stateful**](./state) suites (suites created using vest.create()).
+
+In case your validations did not run yet, `vest.get` returns an empty validation result object - which can be helpful when trying to access validation result object when rendering the initial UI, or setting it in the initial state of your components.
+
+vest.get takes a single argument: the suite name. It is used to identify which validation result to retrieve.
+
+```js
+import vest from 'vest';
+
+const res = vest.get('suite_name');
+
+res.hasErrors('fieldName');
+```
+
+# Result Object Methods:
 
 Along with these values, the result object exposes the following methods:
 

--- a/packages/vest/src/__snapshots__/spec.js.snap
+++ b/packages/vest/src/__snapshots__/spec.js.snap
@@ -141,11 +141,11 @@ Object {
 
 exports[`Vest exports All vest exports exist 1`] = `
 Object {
-  "Enforce": undefined,
   "VERSION": Any<String>,
   "create": [Function],
   "draft": [Function],
   "enforce": [Function],
+  "get": [Function],
   "group": [Function],
   "only": [Function],
   "reset": [Function],

--- a/packages/vest/src/core/createSuite/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/createSuite/__snapshots__/spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test createSuite module Initial run Should initialize with an empty state object 1`] = `
+Array [
+  Object {
+    "doneCallbacks": Array [],
+    "exclusive": Object {},
+    "fieldCallbacks": Object {},
+    "groups": Object {},
+    "lagging": Array [],
+    "name": "initial_run_spec",
+    "pending": Array [],
+    "suiteId": "initial_run_spec",
+    "testObjects": Array [],
+    "tests": Object {},
+  },
+  undefined,
+]
+`;

--- a/packages/vest/src/core/produce/spec.js
+++ b/packages/vest/src/core/produce/spec.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import collector from '../../../testUtils/collector';
-import isDeepCopy from '../../../testUtils/isDeepCopy';
 import resetState from '../../../testUtils/resetState';
 import runRegisterSuite from '../../../testUtils/runRegisterSuite';
 import runSpec from '../../../testUtils/runSpec';
@@ -87,8 +86,7 @@ runSpec(vest => {
     });
 
     it('Should create a deep copy of subset of the state', () => {
-      isDeepCopy(
-        _.pick(getSuiteState(suiteId), KEPT_PROPERTIES),
+      expect(_.pick(getSuiteState(suiteId), KEPT_PROPERTIES)).isDeepCopyOf(
         _.pick(produced, KEPT_PROPERTIES)
       );
     });
@@ -444,12 +442,16 @@ runSpec(vest => {
 
           it('Should pass produced result to callback', () => {
             produced.done(doneCallback_1).done(doneCallback_2);
-            isDeepCopy(doneCallback_1.mock.calls[0][0], produce(state));
-            isDeepCopy(doneCallback_2.mock.calls[0][0], produce(state));
+            expect(doneCallback_1.mock.calls[0][0]).isDeepCopyOf(
+              produce(state)
+            );
+            expect(doneCallback_2.mock.calls[0][0]).isDeepCopyOf(
+              produce(state)
+            );
           });
 
           it('Should return produced result', () => {
-            isDeepCopy(produced.done(doneCallback_1), produce(state));
+            expect(produced.done(doneCallback_1)).isDeepCopyOf(produce(state));
           });
         });
 
@@ -466,13 +468,16 @@ runSpec(vest => {
           it('Should pass produced result to callback', () => {
             produced.done('field_1', doneCallback_1).done(doneCallback_2);
 
-            isDeepCopy(doneCallback_1.mock.calls[0][0], produce(state));
-            isDeepCopy(doneCallback_2.mock.calls[0][0], produce(state));
+            expect(doneCallback_1.mock.calls[0][0]).isDeepCopyOf(
+              produce(state)
+            );
+            expect(doneCallback_2.mock.calls[0][0]).isDeepCopyOf(
+              produce(state)
+            );
           });
 
           it('Should return produced result', () => {
-            isDeepCopy(
-              produced.done('field_1', doneCallback_1),
+            expect(produced.done('field_1', doneCallback_1)).isDeepCopyOf(
               produce(state)
             );
           });
@@ -516,7 +521,7 @@ runSpec(vest => {
             expect(doneCallback_1).not.toHaveBeenCalled();
           });
           it('Should return produced output', () => {
-            isDeepCopy(produced.done(doneCallback_1), produce(state));
+            expect(produced.done(doneCallback_1)).isDeepCopyOf(produce(state));
           });
 
           it('Should add callback to `doneCallBacks` array', () =>

--- a/packages/vest/src/core/state/registerSuite/spec.js
+++ b/packages/vest/src/core/state/registerSuite/spec.js
@@ -1,5 +1,4 @@
 import { getState } from '..';
-import isDeepCopy from '../../../../testUtils/isDeepCopy';
 import resetState from '../../../../testUtils/resetState';
 import runRegisterSuite from '../../../../testUtils/runRegisterSuite';
 import { OPERATION_MODE_STATEFUL } from '../../../constants';
@@ -58,7 +57,7 @@ describe('registerSuite', () => {
           runRegisterSuite(context);
         });
         it('Should merge previous pending and lagging into lagging', () => {
-          isDeepCopy(suite[0].lagging, [...pending, ...lagging]);
+          expect(suite[0].lagging).isDeepCopyOf([...pending, ...lagging]);
         });
 
         it('Should match snapshot', () => {

--- a/packages/vest/src/hooks/draft/index.js
+++ b/packages/vest/src/hooks/draft/index.js
@@ -1,8 +1,7 @@
-import produce from '../../core/produce';
-import getSuiteState from '../../core/state/getSuiteState';
 import singleton from '../../lib/singleton';
 import throwError from '../../lib/throwError';
 import { ERROR_HOOK_CALLED_OUTSIDE } from '../constants';
+import get from '../get';
 
 /**
  * @returns {Object} Current output object.
@@ -14,8 +13,8 @@ const draft = () => {
     throwError('draft ' + ERROR_HOOK_CALLED_OUTSIDE);
     return;
   }
-  const state = getSuiteState(ctx.suiteId);
-  return produce(state, { draft: true });
+
+  return get(ctx.suiteId);
 };
 
 export default draft;

--- a/packages/vest/src/hooks/draft/spec.js
+++ b/packages/vest/src/hooks/draft/spec.js
@@ -1,5 +1,4 @@
 import faker from 'faker';
-import isDeepCopy from '../../../testUtils/isDeepCopy';
 import runSpec from '../../../testUtils/runSpec';
 
 runSpec(vest => {
@@ -20,7 +19,7 @@ runSpec(vest => {
       createSuite(() => {
         const a = vest.draft();
         const b = vest.draft();
-        isDeepCopy(a, b);
+        expect(a).isDeepCopyOf(b);
       });
     });
     it('Should only contain has/get callbacks', () => {

--- a/packages/vest/src/hooks/get/__snapshots__/spec.js.snap
+++ b/packages/vest/src/hooks/get/__snapshots__/spec.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`hook: vest.get() When suite exists Should return produced result 1`] = `
+Object {
+  "errorCount": 1,
+  "getErrors": [Function],
+  "getErrorsByGroup": [Function],
+  "getWarnings": [Function],
+  "getWarningsByGroup": [Function],
+  "groups": Object {},
+  "hasErrors": [Function],
+  "hasErrorsByGroup": [Function],
+  "hasWarnings": [Function],
+  "hasWarningsByGroup": [Function],
+  "name": "form-name",
+  "tests": Object {
+    "f1": Object {
+      "errorCount": 0,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "f2": Object {
+      "errorCount": 1,
+      "errors": Array [
+        "msg",
+      ],
+      "testCount": 2,
+      "warnCount": 1,
+      "warnings": Array [
+        "msg",
+      ],
+    },
+  },
+  "warnCount": 1,
+}
+`;

--- a/packages/vest/src/hooks/get/index.js
+++ b/packages/vest/src/hooks/get/index.js
@@ -1,0 +1,18 @@
+import produce from '../../core/produce';
+import getSuiteState from '../../core/state/getSuiteState';
+import throwError from '../../lib/throwError';
+
+/**
+ * @param {String} suiteId Suite id to find
+ * @returns {Object} Up to date state copy.
+ */
+const get = suiteId => {
+  if (!suiteId) {
+    throwError('`get` hook was called without a suite name.');
+  }
+
+  const state = getSuiteState(suiteId);
+  return produce(state, { draft: true });
+};
+
+export default get;

--- a/packages/vest/src/hooks/get/spec.js
+++ b/packages/vest/src/hooks/get/spec.js
@@ -1,0 +1,51 @@
+import { dummyTest } from '../../../testUtils/testDummy';
+import createSuite from '../../core/createSuite';
+import produce from '../../core/produce';
+import getSuiteState from '../../core/state/getSuiteState';
+import reset from '../../core/state/reset';
+import get from '.';
+
+const suiteId = 'form-name';
+
+const validation = () =>
+  createSuite(suiteId, () => {
+    dummyTest.passing('f1', 'msg');
+    dummyTest.failing('f2', 'msg');
+    dummyTest.failingWarning('f2', 'msg');
+  });
+
+describe('hook: vest.get()', () => {
+  describe('When called without suite id', () => {
+    it('Should throw an error', () => {
+      expect(get).toThrow(
+        '[Vest]: `get` hook was called without a suite name.'
+      );
+    });
+  });
+
+  describe('When suite id does not exist', () => {
+    it('Should throw an error', () => {
+      expect(() => get('I do not exist')).toThrow();
+    });
+  });
+
+  describe('When suite exists', () => {
+    let validate;
+
+    beforeEach(() => {
+      validate = validation();
+    });
+
+    afterEach(() => {
+      reset(suiteId);
+    });
+
+    it('Should return produced result', () => {
+      validate();
+      expect(produce(getSuiteState(suiteId), { draft: true })).isDeepCopyOf(
+        get(suiteId)
+      );
+      expect(get(suiteId)).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/vest/src/hooks/index.js
+++ b/packages/vest/src/hooks/index.js
@@ -1,4 +1,5 @@
 export { default as draft } from './draft';
 export { only, skip } from './exclusive';
 export { default as warn } from './warn';
+export { default as get } from './get';
 export { default as group } from './group';

--- a/packages/vest/src/index.js
+++ b/packages/vest/src/index.js
@@ -9,10 +9,8 @@ import runWithContext from './lib/runWithContext';
 import singleton from './lib/singleton';
 
 const VERSION = VEST_VERSION;
-const Enforce = enforce.Enforce;
 
 export default {
-  Enforce,
   VERSION,
   create,
   enforce,

--- a/packages/vest/src/lib/copy/spec.js
+++ b/packages/vest/src/lib/copy/spec.js
@@ -1,4 +1,4 @@
-import isDeepCopy, { SAMPLE_DEEP_OBJECT } from '../../../testUtils/isDeepCopy';
+import { SAMPLE_DEEP_OBJECT } from '../../../testUtils/isDeepCopy';
 import copy from '.';
 
 describe('copy', () => {
@@ -9,8 +9,8 @@ describe('copy', () => {
   it('Should deep copy source object', () => {
     const clone = copy(SAMPLE_DEEP_OBJECT);
 
-    isDeepCopy(SAMPLE_DEEP_OBJECT, clone);
-    isDeepCopy(SAMPLE_DEEP_OBJECT[0].range, clone[0].range);
-    isDeepCopy(SAMPLE_DEEP_OBJECT[1].range[0].b, clone[1].range[0].b);
+    expect(SAMPLE_DEEP_OBJECT).isDeepCopyOf(clone);
+    expect(SAMPLE_DEEP_OBJECT[0].range).isDeepCopyOf(clone[0].range);
+    expect(SAMPLE_DEEP_OBJECT[1].range[0].b).isDeepCopyOf(clone[1].range[0].b);
   });
 });

--- a/packages/vest/src/spec/integration.stateless-tests.test.js
+++ b/packages/vest/src/spec/integration.stateless-tests.test.js
@@ -1,4 +1,3 @@
-import isDeepCopy from '../../testUtils/isDeepCopy';
 import resetState from '../../testUtils/resetState';
 import runSpec from '../../testUtils/runSpec';
 
@@ -58,7 +57,7 @@ runSpec(vest => {
             expect(callback_4).not.toHaveBeenCalled();
             result.done(callback_4);
             expect(callback_4).toHaveBeenCalled();
-            isDeepCopy(callback_4.mock.calls[0][0], result);
+            expect(callback_4.mock.calls[0][0]).isDeepCopyOf(result);
             done();
           });
         })

--- a/packages/vest/testUtils/isDeepCopy/index.js
+++ b/packages/vest/testUtils/isDeepCopy/index.js
@@ -6,14 +6,52 @@ const isDeepCopy = (source, clone) => {
 
     if (!source || typeof source !== 'object') {
       if (typeof clone !== 'function') {
-        expect(clone).toBe(source);
+        if (clone !== source) {
+          return {
+            pass: false,
+            message: () => 'Source and clone are not identical',
+          };
+        }
       }
       continue;
     }
 
-    expect(clone).not.toBe(source);
+    if (clone === source) {
+      return {
+        pass: false,
+        message: () =>
+          `Source and clone are the same object. Expected a deep copy. ${JSON.stringify(
+            source
+          )}===${JSON.stringify(clone)}`,
+      };
+    }
+
+    // Short circuit
+    if (
+      (clone && !source) ||
+      (source && !clone) ||
+      typeof source !== typeof clone
+    ) {
+      return {
+        pass: false,
+        message: () =>
+          `Source and clone are not of the same type: ${JSON.stringify(
+            source
+          )} does not equal ${JSON.stringify(clone)}`,
+      };
+    }
 
     if (Array.isArray(source)) {
+      // Short circuit
+      if (!Array.isArray(clone) || source.length !== clone.length) {
+        return {
+          pass: false,
+          message: () =>
+            `source and clone arrays are not identical. ${JSON.stringify(
+              source
+            )} does not equal ${JSON.stringify(clone)}`,
+        };
+      }
       source.forEach((v, i) => {
         queue.push([source[i], clone[i]]);
       });
@@ -23,6 +61,8 @@ const isDeepCopy = (source, clone) => {
 
     continue outer;
   }
+
+  return { pass: true };
 };
 
 export const SAMPLE_DEEP_OBJECT = [

--- a/packages/vest/testUtils/isDeepCopy/spec.js
+++ b/packages/vest/testUtils/isDeepCopy/spec.js
@@ -2,19 +2,19 @@ import _ from 'lodash';
 import isDeepCopy, { SAMPLE_DEEP_OBJECT } from '.';
 
 describe('Sanity (testing isDeepCopy)', () => {
-  it('Should throw an error', () => {
-    expect(() => isDeepCopy(SAMPLE_DEEP_OBJECT, SAMPLE_DEEP_OBJECT)).toThrow();
+  it('Should fail when same value', () => {
+    expect(isDeepCopy(SAMPLE_DEEP_OBJECT, SAMPLE_DEEP_OBJECT).pass).toBe(false);
   });
-  it('Should throw an error', () => {
-    expect(() =>
-      isDeepCopy(SAMPLE_DEEP_OBJECT, { ...SAMPLE_DEEP_OBJECT })
-    ).toThrow();
+  it('Should fail when shallow copy', () => {
+    expect(isDeepCopy(SAMPLE_DEEP_OBJECT, { ...SAMPLE_DEEP_OBJECT }).pass).toBe(
+      false
+    );
   });
-  it('Should throw for non equal primitives', () => {
-    expect(() =>
-      isDeepCopy(SAMPLE_DEEP_OBJECT[0], _.cloneDeep(SAMPLE_DEEP_OBJECT)[1])
-    ).toThrow();
-    expect(() =>
+  it('Should fail for non equal primitives', () => {
+    expect(
+      isDeepCopy(SAMPLE_DEEP_OBJECT[0], _.cloneDeep(SAMPLE_DEEP_OBJECT)[1]).pass
+    ).toBe(false);
+    expect(
       isDeepCopy(
         {
           a: [1, { b: 2 }],
@@ -22,7 +22,12 @@ describe('Sanity (testing isDeepCopy)', () => {
         {
           a: [1, { b: 1 }],
         }
-      )
-    ).toThrow();
+      ).pass
+    ).toBe(false);
+  });
+  it('Should pass for deeply equal objects', () => {
+    expect(
+      isDeepCopy(SAMPLE_DEEP_OBJECT, _.cloneDeep(SAMPLE_DEEP_OBJECT)).pass
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | ✖
| New feature?     | ✔
| Breaking change? | ✖
| Deprecations?    | ✖
| Documentation?   | ✔
| Tests added?     | ✔

<!-- Describe your changes below in detail. -->

# Added
new vest hook: vest.get

If you need to access your validation results out of context - for example, from a different UI component or function, you can use `vest.get`.

Vest exposes the `vest.get` function that is able to retrieve the most recent validation result of [**stateful**](./state) suites (suites created using vest.create()).

In case your validations did not run yet, `vest.get` returns an empty validation result object - which can be helpful when trying to access validation result object when rendering the initial UI, or setting it in the initial state of your components.

vest.get takes a single argument: the suite name. It is used to identify which validation result to retrieve.

# Changed

- When using vest.create, an empty validation state is created so that `get` will always return a value.

# Unrelated

- Modified the isDeepCopy, turned it into a jest matcher.
