### PR TITLE
minor: add vest.skip.group and vest.only.group

### DIFF
--- a/docs/exclusion.md
+++ b/docs/exclusion.md
@@ -4,11 +4,9 @@ When performing validations in real world-scenarios, you may need to only run te
 
 `vest.skip()` and `vest.only()` are functions that take a name of the test, or a list of names to either include or exclude fields from being validated. They should be called from the body of suite callback, and in order for them to take effect, they should be called before anything else.
 
-## Important to know before using exclusion hooks:
+!> **NOTE** When using `vest.only()` or `vest.skip()` you must place them before any of the tests defined in the suite. Hooks run in order of appearance, which means that if you place your `skip` hook after the filed you're skipping - it won't have any effect.
 
-When using `vest.only()` or `vest.skip()` you must place them before any of the tests defined in the suite. Hooks run in order of appearance, which means that if you place your `skip` hook after the filed you're skipping - it won't have any effect.
-
-### Only running specific tests
+### Only running specific tests (including)
 
 When validating upon user interactions, you will usually want to only validate the input the user currently interacts with to prevent errors appearing in unrelated places. For this, you can use `vest.only()` with the name of the test currently being validated.
 
@@ -56,6 +54,54 @@ const validate = vest.create('purchase', data => {
 
 const validationResult = validate(formData);
 ```
+
+## Including and excluding groups of tests
+
+Similar to the way you use `vest.skip` and `vest.only` to include and exclude tests, you can use `vest.skip.group` and `vest.only.group` to exclude and include whole groups.
+
+These two functions are very powerful and give you control of whole portions of your suite at once.
+
+```js
+import vest, { test, group, enforce } from 'vest';
+
+vest.create('authentication_form', data => {
+  vest.skip.group(data.userExists ? 'signUp' : 'signIn');
+
+  test('userName', "Can't be empty", () => {
+    enforce(data.username).isNotEmpty();
+  });
+  test('password', "Can't be empty", () => {
+    enforce(data.password).isNotEmpty();
+  });
+
+  group('signIn', () => {
+    test(
+      'userName',
+      'User not found. Please check if you typed it correctly.',
+      findUserName(data.username)
+    );
+  });
+
+  group('signUp', () => {
+    test('email', 'Email already registered', isEmailRegistered(data.email));
+
+    test('age', 'You must be at least 18 years old to join', () => {
+      enforce(data.age).largerThanOrEquals(18);
+    });
+  });
+});
+```
+
+## Things to know about how these functions work:
+
+**vest.only.group()**:
+When using `vest.only.group`, other groups won't be tested - but top level tests that aren't nested in any groups will. The reasoning is that the top level space is a shared are that will always be executed. If you want only your group to run, nest everything else under groups as well.
+
+If you combine `vest.only.group` with `vest.skip`, if you skip a field inside a group that is included, that field will be excluded during this run regardless of its group membership.
+
+**vest.skip.group()**
+
+If you combine `vest.skip.group` with `vest.only` your included field declared within the skipped tests will be ignored.
 
 **Read next about:**
 

--- a/docs/group.md
+++ b/docs/group.md
@@ -7,7 +7,7 @@ Similar to the `describe` and `context` features provided by unit testing framew
 import vest, { test, group, enforce } from 'vest';
 
 vest.create('authentication_form', data => {
-  vest.skip(data.userExists ? 'signUp' : 'signIn');
+  vest.skip.group(data.userExists ? 'signUp' : 'signIn');
 
   test('userName', "Can't be empty", () => {
     enforce(data.username).isNotEmpty();
@@ -49,7 +49,7 @@ You may have in your application a multi-screen form, in which you want to valid
 import vest, { test, group, enforce } from 'vest';
 
 const validate = vest.create('product-create', (data, currentTab) => {
-  vest.only(currentScreen);
+  vest.only.group(currentScreen);
 
   group('overview_tab', () => {
     test('productTitle', 'Must be at least 5 chars.', () => {
@@ -97,11 +97,11 @@ import vest, { test, group, enforce } from 'vest';
 
 const validate = vest.create('checkout_form', data => {
   if (!data.usedPromo) {
-    vest.skip('used_promo');
+    vest.skip.group('used_promo');
   }
 
   if (!data.paysWithBalance) {
-    vest.skip('balance');
+    vest.skip.group('balance');
   }
 
   test(

--- a/packages/vest/src/__snapshots__/spec.js.snap
+++ b/packages/vest/src/__snapshots__/spec.js.snap
@@ -14,6 +14,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "molestias-veritatis-deserunt",
+  "testCount": 2,
   "tests": Object {
     "doloribus-enim-quisquam": Object {
       "errorCount": 0,
@@ -39,6 +40,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "eveniet-maxime-ea",
+  "testCount": 2,
   "tests": Object {
     "non-rem-dolorem": Object {
       "errorCount": 0,
@@ -72,6 +74,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "inventore-quis-impedit",
+  "testCount": 1,
   "tests": Object {
     "doloribus-enim-quisquam": Object {
       "errorCount": 0,
@@ -97,6 +100,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "corrupti-alias-autem",
+  "testCount": 1,
   "tests": Object {
     "autem": Object {
       "errorCount": 0,
@@ -125,6 +129,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "corrupti-alias-autem",
+  "testCount": 2,
   "tests": Object {
     "autem": Object {
       "errorCount": 0,

--- a/packages/vest/src/core/createSuite/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/createSuite/__snapshots__/spec.js.snap
@@ -4,7 +4,10 @@ exports[`Test createSuite module Initial run Should initialize with an empty sta
 Array [
   Object {
     "doneCallbacks": Array [],
-    "exclusive": Object {},
+    "exclusion": Object {
+      "groups": Object {},
+      "tests": Object {},
+    },
     "fieldCallbacks": Object {},
     "groups": Object {},
     "lagging": Array [],

--- a/packages/vest/src/core/createSuite/spec.js
+++ b/packages/vest/src/core/createSuite/spec.js
@@ -82,7 +82,8 @@ describe('Test createSuite module', () => {
       expect(state[0].testObjects).toHaveLength(0);
       expect(state[0].pending).toHaveLength(0);
       expect(state[0].lagging).toHaveLength(0);
-      expect(Object.keys(state[0].exclusive)).toHaveLength(0);
+      expect(Object.keys(state[0].exclusion.groups)).toHaveLength(0);
+      expect(Object.keys(state[0].exclusion.tests)).toHaveLength(0);
       expect(Object.keys(state[0].tests)).toHaveLength(0);
       expect(Object.keys(state[0].groups)).toHaveLength(0);
       expect(Object.keys(state[0].doneCallbacks)).toHaveLength(0);

--- a/packages/vest/src/core/produce/genTestsSummary/index.js
+++ b/packages/vest/src/core/produce/genTestsSummary/index.js
@@ -53,9 +53,11 @@ const genTestObject = (stateKey, testObject) => {
 export const countFailures = state => {
   state[SEVERITY_COUNT_ERROR] = 0;
   state[SEVERITY_COUNT_WARN] = 0;
+  state[TEST_COUNT] = 0;
   for (const test in state.tests) {
     state[SEVERITY_COUNT_ERROR] += state.tests[test][SEVERITY_COUNT_ERROR];
     state[SEVERITY_COUNT_WARN] += state.tests[test][SEVERITY_COUNT_WARN];
+    state[TEST_COUNT] += state.tests[test][TEST_COUNT];
   }
   return state;
 };

--- a/packages/vest/src/core/state/registerSuite/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/state/registerSuite/__snapshots__/spec.js.snap
@@ -3,7 +3,10 @@
 exports[`registerSuite When suite does not exist in state Should create initial suite without prevState 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusive": Object {},
+  "exclusion": Object {
+    "groups": Object {},
+    "tests": Object {},
+  },
   "fieldCallbacks": Object {},
   "groups": Object {},
   "lagging": Array [],
@@ -19,7 +22,10 @@ exports[`registerSuite When suite exists in state Prev state data handling When 
 Array [
   Object {
     "doneCallbacks": Array [],
-    "exclusive": Object {},
+    "exclusion": Object {
+      "groups": Object {},
+      "tests": Object {},
+    },
     "fieldCallbacks": Object {},
     "groups": Object {},
     "lagging": Array [
@@ -38,7 +44,10 @@ Array [
   },
   Object {
     "doneCallbacks": Array [],
-    "exclusive": Object {},
+    "exclusion": Object {
+      "groups": Object {},
+      "tests": Object {},
+    },
     "fieldCallbacks": Object {},
     "groups": Object {},
     "lagging": null,
@@ -55,7 +64,10 @@ exports[`registerSuite When suite exists in state Should match snapshot 1`] = `
 Array [
   Object {
     "doneCallbacks": Array [],
-    "exclusive": Object {},
+    "exclusion": Object {
+      "groups": Object {},
+      "tests": Object {},
+    },
     "fieldCallbacks": Object {},
     "groups": Object {},
     "lagging": Array [],
@@ -67,7 +79,10 @@ Array [
   },
   Object {
     "doneCallbacks": Array [],
-    "exclusive": Object {},
+    "exclusion": Object {
+      "groups": Object {},
+      "tests": Object {},
+    },
     "fieldCallbacks": Object {},
     "groups": Object {},
     "lagging": null,

--- a/packages/vest/src/core/state/registerSuite/index.js
+++ b/packages/vest/src/core/state/registerSuite/index.js
@@ -1,4 +1,8 @@
 import { getSuite, setSuites } from '..';
+import {
+  EXCLUSION_ITEM_TYPE_TESTS,
+  EXCLUSION_ITEM_TYPE_GROUPS,
+} from '../../../hooks/exclusive/constants';
 import singleton from '../../../lib/singleton';
 
 /**
@@ -8,7 +12,10 @@ import singleton from '../../../lib/singleton';
  */
 const INITIAL_SUITE_STATE = (suiteId, name) => ({
   doneCallbacks: [],
-  exclusive: {},
+  exclusion: {
+    [EXCLUSION_ITEM_TYPE_TESTS]: {},
+    [EXCLUSION_ITEM_TYPE_GROUPS]: {},
+  },
   fieldCallbacks: {},
   groups: {},
   lagging: [],

--- a/packages/vest/src/core/state/reset/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/state/reset/__snapshots__/spec.js.snap
@@ -9,10 +9,11 @@ Object {
     "suite_id": Array [
       Object {
         "doneCallbacks": Array [],
-        "exclusive": Object {
-          "skip": Object {
-            "field_1": true,
-            "field_3": true,
+        "exclusion": Object {
+          "groups": Object {},
+          "tests": Object {
+            "field_1": false,
+            "field_3": false,
           },
         },
         "fieldCallbacks": Object {},
@@ -101,9 +102,10 @@ Object {
       },
       Object {
         "doneCallbacks": Array [],
-        "exclusive": Object {
-          "skip": Object {
-            "field_2": true,
+        "exclusion": Object {
+          "groups": Object {},
+          "tests": Object {
+            "field_2": false,
           },
         },
         "fieldCallbacks": Object {},
@@ -172,16 +174,17 @@ Object {
     "suite_id": Array [
       Object {
         "doneCallbacks": Array [],
-        "exclusive": Object {
-          "skip": Object {
-            "field_1": true,
-            "field_3": true,
+        "exclusion": Object {
+          "groups": Object {},
+          "tests": Object {
+            "field_1": false,
+            "field_3": false,
           },
         },
         "fieldCallbacks": Object {},
         "groups": Object {},
         "lagging": Array [
-          B {
+          A {
             "failed": false,
             "fieldName": "field_1",
             "id": "24",
@@ -190,7 +193,7 @@ Object {
             "suiteId": "suite_id",
             "testFn": Promise {},
           },
-          B {
+          A {
             "failed": false,
             "fieldName": "field_3",
             "id": "26",
@@ -202,7 +205,7 @@ Object {
         ],
         "name": "suite_id",
         "pending": Array [
-          B {
+          A {
             "failed": false,
             "fieldName": "field_2",
             "id": "29",
@@ -211,7 +214,7 @@ Object {
             "suiteId": "suite_id",
             "testFn": Promise {},
           },
-          B {
+          A {
             "failed": false,
             "fieldName": "field_4",
             "id": "31",
@@ -223,7 +226,7 @@ Object {
         ],
         "suiteId": "suite_id",
         "testObjects": Array [
-          B {
+          A {
             "failed": false,
             "fieldName": "field_2",
             "id": "29",
@@ -232,7 +235,7 @@ Object {
             "suiteId": "suite_id",
             "testFn": Promise {},
           },
-          B {
+          A {
             "failed": false,
             "fieldName": "field_4",
             "id": "31",
@@ -241,7 +244,7 @@ Object {
             "suiteId": "suite_id",
             "testFn": Promise {},
           },
-          B {
+          A {
             "failed": false,
             "fieldName": "field_1",
             "id": "24",
@@ -250,7 +253,7 @@ Object {
             "suiteId": "suite_id",
             "testFn": Promise {},
           },
-          B {
+          A {
             "failed": false,
             "fieldName": "field_3",
             "id": "26",
@@ -264,9 +267,10 @@ Object {
       },
       Object {
         "doneCallbacks": Array [],
-        "exclusive": Object {
-          "skip": Object {
-            "field_2": true,
+        "exclusion": Object {
+          "groups": Object {},
+          "tests": Object {
+            "field_2": false,
           },
         },
         "fieldCallbacks": Object {},
@@ -276,7 +280,7 @@ Object {
         "pending": null,
         "suiteId": "suite_id",
         "testObjects": Array [
-          B {
+          A {
             "failed": false,
             "fieldName": "field_1",
             "id": "24",
@@ -285,7 +289,7 @@ Object {
             "suiteId": "suite_id",
             "testFn": Promise {},
           },
-          B {
+          A {
             "failed": false,
             "fieldName": "field_3",
             "id": "26",
@@ -294,7 +298,7 @@ Object {
             "suiteId": "suite_id",
             "testFn": Promise {},
           },
-          B {
+          A {
             "failed": false,
             "fieldName": "field_4",
             "id": "27",
@@ -350,10 +354,11 @@ Object {
     "suite_id": Array [
       Object {
         "doneCallbacks": Array [],
-        "exclusive": Object {
-          "skip": Object {
-            "field_1": true,
-            "field_3": true,
+        "exclusion": Object {
+          "groups": Object {},
+          "tests": Object {
+            "field_1": false,
+            "field_3": false,
           },
         },
         "fieldCallbacks": Object {},
@@ -442,9 +447,10 @@ Object {
       },
       Object {
         "doneCallbacks": Array [],
-        "exclusive": Object {
-          "skip": Object {
-            "field_2": true,
+        "exclusion": Object {
+          "groups": Object {},
+          "tests": Object {
+            "field_2": false,
           },
         },
         "fieldCallbacks": Object {},
@@ -543,10 +549,11 @@ Object {
     "suite_id": Array [
       Object {
         "doneCallbacks": Array [],
-        "exclusive": Object {
-          "skip": Object {
-            "field_1": true,
-            "field_3": true,
+        "exclusion": Object {
+          "groups": Object {},
+          "tests": Object {
+            "field_1": false,
+            "field_3": false,
           },
         },
         "fieldCallbacks": Object {},
@@ -635,9 +642,10 @@ Object {
       },
       Object {
         "doneCallbacks": Array [],
-        "exclusive": Object {
-          "skip": Object {
-            "field_2": true,
+        "exclusion": Object {
+          "groups": Object {},
+          "tests": Object {
+            "field_2": false,
           },
         },
         "fieldCallbacks": Object {},

--- a/packages/vest/src/core/test/lib/mergeExcludedTests/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/test/lib/mergeExcludedTests/__snapshots__/spec.js.snap
@@ -3,9 +3,10 @@
 exports[`module: skipped export: mergeExcludedTests When previous state exists When no currently skipped fields or groups When skipped field exists in previous state Error field Should copy prev field state over 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusive": Object {
-    "skip": Object {
-      "field_2": true,
+  "exclusion": Object {
+    "groups": Object {},
+    "tests": Object {
+      "field_2": false,
     },
   },
   "fieldCallbacks": Object {},
@@ -64,9 +65,10 @@ Object {
 exports[`module: skipped export: mergeExcludedTests When previous state exists When no currently skipped fields or groups When skipped field exists in previous state Warning field Should copy prev field state over 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusive": Object {
-    "skip": Object {
-      "field_1": true,
+  "exclusion": Object {
+    "groups": Object {},
+    "tests": Object {
+      "field_1": false,
     },
   },
   "fieldCallbacks": Object {},
@@ -176,6 +178,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_1",
+  "testCount": 10,
   "tests": Object {
     "f1": Object {
       "errorCount": 2,
@@ -322,6 +325,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_1",
+  "testCount": 16,
   "tests": Object {
     "f1": Object {
       "errorCount": 3,
@@ -490,6 +494,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_1",
+  "testCount": 16,
   "tests": Object {
     "f1": Object {
       "errorCount": 3,
@@ -573,6 +578,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_1",
+  "testCount": 4,
   "tests": Object {
     "f1": Object {
       "errorCount": 1,

--- a/packages/vest/src/core/test/lib/mergeExcludedTests/spec.js
+++ b/packages/vest/src/core/test/lib/mergeExcludedTests/spec.js
@@ -84,7 +84,7 @@ describe('module: skipped', () => {
 
         const validation = () =>
           vest.create(SUITE_NAME, skip => {
-            vest.skip(skip);
+            vest.skip.group(skip);
             suiteId = singleton.useContext().suiteId;
 
             dummyTest.failing('f1', 'f1_msg');
@@ -126,10 +126,12 @@ describe('module: skipped', () => {
         test('sanity: skipped tests are not in initial state', () =>
           new Promise(done => {
             res = _.cloneDeep(validate([GROUP_NAME_1, GROUP_NAME_2]));
-            expect(res).toMatchSnapshot();
             expect(res.tests).toHaveProperty('f1');
             expect(res.tests).toHaveProperty('f2');
             expect(res.tests).toHaveProperty('f3');
+            expect(res.errorCount).toBe(3);
+            expect(res.warnCount).toBe(0);
+            expect(res.testCount).toBe(4);
             expect(res.tests.f1.errorCount).toBe(1);
             expect(res.tests.f1.warnCount).toBe(0);
             expect(res.tests.f1.errorCount).toBe(1);
@@ -139,8 +141,10 @@ describe('module: skipped', () => {
             expect(res.tests).not.toHaveProperty('f5');
             expect(res.tests).not.toHaveProperty('f6');
             expect(res.tests).not.toHaveProperty('f7');
+            expect(res).toMatchSnapshot();
             setTimeout(() => {
               res = produce(getSuiteState(suiteId));
+              expect(res.errorCount).toBe(4);
               expect(res.tests.f3.errorCount).toBe(2);
               done();
             });
@@ -150,7 +154,9 @@ describe('module: skipped', () => {
           new Promise(done => {
             // skipping group 2
             res = _.cloneDeep(validate(GROUP_NAME_2));
-            expect(res).toMatchSnapshot();
+            expect(res.errorCount).toBe(6);
+            expect(res.warnCount).toBe(1);
+            expect(res.testCount).toBe(10);
             expect(res.tests.f1.errorCount).toBe(2);
             expect(res.tests.f1.warnCount).toBe(0);
             expect(res.tests.f2.errorCount).toBe(1);
@@ -160,6 +166,7 @@ describe('module: skipped', () => {
             expect(res.tests.f4.warnCount).toBe(0);
             expect(res.tests.f5.errorCount).toBe(0);
             expect(res.tests.f5.warnCount).toBe(0);
+            expect(res).toMatchSnapshot();
             setTimeout(() => {
               res = produce(getSuiteState(suiteId));
               // both outer and inner async
@@ -173,7 +180,10 @@ describe('module: skipped', () => {
             _.cloneDeep(validate(GROUP_NAME_2));
 
             res = _.cloneDeep(validate(GROUP_NAME_1));
-            expect(res).toMatchSnapshot();
+
+            expect(res.errorCount).toBe(9);
+            expect(res.warnCount).toBe(2);
+            expect(res.testCount).toBe(16);
 
             expect(res.tests.f2.errorCount).toBe(1);
             expect(res.tests.f2.warnCount).toBe(1);
@@ -192,6 +202,7 @@ describe('module: skipped', () => {
 
             expect(res.tests.f7.errorCount).toBe(0);
             expect(res.tests.f7.warnCount).toBe(0);
+            expect(res).toMatchSnapshot();
 
             setTimeout(() => {
               res = produce(getSuiteState(suiteId));

--- a/packages/vest/src/core/test/lib/pending/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/test/lib/pending/__snapshots__/spec.js.snap
@@ -3,7 +3,10 @@
 exports[`module: pending export: removePending When testObject is either pending or lagging When in lagging Should remove test from lagging 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusive": Object {},
+  "exclusion": Object {
+    "groups": Object {},
+    "tests": Object {},
+  },
   "fieldCallbacks": Object {},
   "groups": Object {},
   "lagging": Array [],
@@ -18,7 +21,10 @@ Object {
 exports[`module: pending export: removePending When testObject is either pending or lagging When in pending Should remove test from pending 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusive": Object {},
+  "exclusion": Object {
+    "groups": Object {},
+    "tests": Object {},
+  },
   "fieldCallbacks": Object {},
   "groups": Object {},
   "lagging": Array [],
@@ -33,7 +39,10 @@ Object {
 exports[`module: pending export: setPending When a field of the same profile is in lagging array Should remove test from lagging array 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusive": Object {},
+  "exclusion": Object {
+    "groups": Object {},
+    "tests": Object {},
+  },
   "fieldCallbacks": Object {},
   "groups": Object {},
   "lagging": Array [

--- a/packages/vest/src/core/test/runAsyncTest/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/test/runAsyncTest/__snapshots__/spec.js.snap
@@ -3,7 +3,10 @@
 exports[`runAsyncTest: failing State updates Initial state matches snapshot (sanity) 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusive": Object {},
+  "exclusion": Object {
+    "groups": Object {},
+    "tests": Object {},
+  },
   "fieldCallbacks": Object {
     "field_1": Array [],
   },
@@ -30,7 +33,10 @@ Object {
 exports[`runAsyncTest: passing State updates Initial state matches snapshot (sanity) 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusive": Object {},
+  "exclusion": Object {
+    "groups": Object {},
+    "tests": Object {},
+  },
   "fieldCallbacks": Object {
     "field_1": Array [],
   },

--- a/packages/vest/src/hooks/exclusive/constants.js
+++ b/packages/vest/src/hooks/exclusive/constants.js
@@ -1,9 +1,12 @@
 /**
- * @type {String} Exclusivity group name: only.
+ * @type {String} Exclusion group name: only.
  */
-export const GROUP_NAME_ONLY = 'only';
+export const EXCLUSION_GROUP_NAME_ONLY = 'only';
 
 /**
- * @type {String} Exclusivity group name: skip.
+ * @type {String} Exclusion group name: skip.
  */
-export const GROUP_NAME_SKIP = 'skip';
+export const EXCLUSION_GROUP_NAME_SKIP = 'skip';
+
+export const EXCLUSION_ITEM_TYPE_TESTS = 'tests';
+export const EXCLUSION_ITEM_TYPE_GROUPS = 'groups';

--- a/packages/vest/src/hooks/get/__snapshots__/spec.js.snap
+++ b/packages/vest/src/hooks/get/__snapshots__/spec.js.snap
@@ -13,6 +13,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "form-name",
+  "testCount": 3,
   "tests": Object {
     "f1": Object {
       "errorCount": 0,

--- a/packages/vest/src/spec/__snapshots__/integration.base.test.js.snap
+++ b/packages/vest/src/spec/__snapshots__/integration.base.test.js.snap
@@ -14,6 +14,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 5,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -63,6 +64,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 5,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -112,6 +114,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 5,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,

--- a/packages/vest/src/spec/__snapshots__/integration.stateful-async.test.js.snap
+++ b/packages/vest/src/spec/__snapshots__/integration.stateful-async.test.js.snap
@@ -14,6 +14,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 5,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -51,6 +52,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 5,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -101,6 +103,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 7,
   "tests": Object {
     "field_1": Object {
       "errorCount": 2,
@@ -147,6 +150,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 5,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -184,6 +188,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 5,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -234,6 +239,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 7,
   "tests": Object {
     "field_1": Object {
       "errorCount": 2,
@@ -280,6 +286,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 5,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -317,6 +324,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 5,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -367,6 +375,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 7,
   "tests": Object {
     "field_1": Object {
       "errorCount": 2,

--- a/packages/vest/src/spec/__snapshots__/integration.stateful-tests.test.js.snap
+++ b/packages/vest/src/spec/__snapshots__/integration.stateful-tests.test.js.snap
@@ -14,6 +14,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 1,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -42,6 +43,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 3,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -79,6 +81,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 7,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -137,6 +140,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 1,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -165,6 +169,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 3,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -202,6 +207,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 7,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -260,6 +266,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 1,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -288,6 +295,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 3,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -325,6 +333,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 7,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,

--- a/packages/vest/src/spec/__snapshots__/integration.stateless-tests.test.js.snap
+++ b/packages/vest/src/spec/__snapshots__/integration.stateless-tests.test.js.snap
@@ -14,6 +14,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 1,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -42,6 +43,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 2,
   "tests": Object {
     "field_5": Object {
       "errorCount": 2,
@@ -71,6 +73,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 7,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -132,6 +135,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 1,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -160,6 +164,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 2,
   "tests": Object {
     "field_5": Object {
       "errorCount": 2,
@@ -189,6 +194,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 7,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -250,6 +256,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 1,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,
@@ -278,6 +285,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 2,
   "tests": Object {
     "field_5": Object {
       "errorCount": 2,
@@ -307,6 +315,7 @@ Object {
   "hasWarnings": [Function],
   "hasWarningsByGroup": [Function],
   "name": "suite_name",
+  "testCount": 7,
   "tests": Object {
     "field_1": Object {
       "errorCount": 1,

--- a/packages/vest/src/spec/integration.exclusive.test.js
+++ b/packages/vest/src/spec/integration.exclusive.test.js
@@ -5,6 +5,7 @@ runSpec(vest => {
     vest.validate('suite_name', () => {
       vest.skip(exclusion.skip);
       vest.only(exclusion.only);
+      vest.skip(exclusion.skip_last);
 
       vest.test('field_1', 'msg', Function.prototype);
       vest.test('field_2', 'msg', Function.prototype);
@@ -63,11 +64,16 @@ runSpec(vest => {
   });
 
   describe('Combined', () => {
-    test('skip takes precedence over only', () => {
-      const res = validator({ only: ['field_1', 'field_2'], skip: 'field_1' });
+    test('Last declaration wins', () => {
+      const res = validator({
+        only: ['field_1', 'field_2', 'field_3'],
+        skip: ['field_1'],
+        skip_last: 'field_3',
+      });
 
-      expect(res.tests).not.toHaveProperty('field_1');
+      expect(res.tests).toHaveProperty('field_1');
       expect(res.tests).toHaveProperty('field_2');
+      expect(res.tests).not.toHaveProperty('field_3');
     });
   });
 });

--- a/packages/vest/testUtils/resetState/__snapshots__/spec.js.snap
+++ b/packages/vest/testUtils/resetState/__snapshots__/spec.js.snap
@@ -11,7 +11,10 @@ exports[`resetState When invoked with suite name Should add a new suite to the s
 Array [
   Object {
     "doneCallbacks": Array [],
-    "exclusive": Object {},
+    "exclusion": Object {
+      "groups": Object {},
+      "tests": Object {},
+    },
     "fieldCallbacks": Object {},
     "groups": Object {},
     "lagging": Array [],


### PR DESCRIPTION
| Q                | A                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix?         | ✖                                                                        |
| New feature?     | ✔                                                                        |
| Breaking change? | ✖                                                                        |
| Deprecations?    | ✖                                                                        |
| Documentation?   | ✔                                                                        |
| Tests added?     | ✔                                                                        |


ACTUAL CODE CHANGE IS IN:
`packages/vest/src/hooks/exclusive/index.js`


## Including and excluding groups of tests

Similar to the way you use `vest.skip` and `vest.only` to include and exclude tests, you can use `vest.skip.group` and `vest.only.group` to exclude and include whole groups.

These two functions are very powerful and give you control of whole portions of your suite at once.

```js
import vest, { test, group, enforce } from 'vest';

vest.create('authentication_form', data => {
  vest.skip.group(data.userExists ? 'signUp' : 'signIn');

  test('userName', "Can't be empty", () => {
    enforce(data.username).isNotEmpty();
  });
  test('password', "Can't be empty", () => {
    enforce(data.password).isNotEmpty();
  });

  group('signIn', () => {
    test(
      'userName',
      'User not found. Please check if you typed it correctly.',
      findUserName(data.username)
    );
  });

  group('signUp', () => {
    test('email', 'Email already registered', isEmailRegistered(data.email));

    test('age', 'You must be at least 18 years old to join', () => {
      enforce(data.age).largerThanOrEquals(18);
    });
  });
});
```

## Things to know about how these functions work:

**vest.only.group()**:
When using `vest.only.group`, other groups won't be tested - but top level tests that aren't nested in any groups will. The reasoning is that the top level space is a shared are that will always be executed. If you want only your group to run, nest everything else under groups as well.

If you combine `vest.only.group` with `vest.skip`, if you skip a field inside a group that is included, that field will be excluded during this run regardless of its group membership.

**vest.skip.group()**

If you combine `vest.skip.group` with `vest.only` your included field declared within the skipped tests will be ignored.