### PR TITLE
added: test.memo for memoized tests

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -87,6 +87,28 @@ test('name', () =>
   }));
 ```
 
+## test.memo for memoized tests
+
+In order to improve performance and runtime in heavy or long-running tests (such as async tests that go to the server), tests individual test results can be cached and saved for a later time, so whenever the exact same params appear again in the same runtime, the test result will be used from cache, instead of having to be re-evaluated.
+
+### Usage:
+
+Memoized tests are almost identical to regular tests, only with the added dependency array as the last argument. The dependency array is an array of items, that when identical (strict equality, `===`) to a previously presented array in the same test, its previous result will be used. You can see it as your cache key to the test result.
+
+### Example:
+
+```js
+import vest, { test } from 'vest';
+export default vest.create('form-name', data => {
+  test.memo(
+    'username',
+    'username already exists',
+    () => doesUserExist(data.username),
+    [data.username]
+  );
+});
+```
+
 **Read next about:**
 
 - [Warn only tests](./warn).

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@babel/plugin-transform-runtime": "^7.10.4",
     "@babel/preset-env": "^7.10.4",
     "@babel/register": "^7.10.4",
+    "@lets/wait": "^1.0.0",
     "anyone": "^0.0.7",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.1.0",

--- a/packages/vest/config/jest/jest.setup.js
+++ b/packages/vest/config/jest/jest.setup.js
@@ -2,7 +2,7 @@ const { PACKAGE_VEST } = require('../../../../shared/constants');
 const { packageJson, packagePath } = require('../../../../util');
 
 const { version } = packageJson(PACKAGE_VEST);
-
+global.LIBRARY_NAME = PACKAGE_VEST;
 global.VEST_VERSION = version;
 
 // Registers global instance

--- a/packages/vest/src/core/state/remove/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/state/remove/__snapshots__/spec.js.snap
@@ -20,82 +20,170 @@ Object {
         "groups": Object {},
         "lagging": Array [
           m {
+            "asyncTest": Promise {},
             "failed": false,
             "fieldName": "field_1",
             "id": "0",
             "isWarning": false,
             "statement": undefined,
             "suiteId": "suite_id",
-            "testFn": Promise {},
+            "testFn": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Promise {},
+                },
+              ],
+            },
           },
           m {
+            "asyncTest": Promise {},
             "failed": false,
             "fieldName": "field_3",
             "id": "2",
             "isWarning": false,
             "statement": undefined,
             "suiteId": "suite_id",
-            "testFn": Promise {},
+            "testFn": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Promise {},
+                },
+              ],
+            },
           },
         ],
         "name": "suite_id",
         "pending": Array [
           m {
+            "asyncTest": Promise {},
             "failed": false,
             "fieldName": "field_2",
             "id": "5",
             "isWarning": false,
             "statement": undefined,
             "suiteId": "suite_id",
-            "testFn": Promise {},
+            "testFn": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Promise {},
+                },
+              ],
+            },
           },
           m {
+            "asyncTest": Promise {},
             "failed": false,
             "fieldName": "field_4",
             "id": "7",
             "isWarning": false,
             "statement": undefined,
             "suiteId": "suite_id",
-            "testFn": Promise {},
+            "testFn": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Promise {},
+                },
+              ],
+            },
           },
         ],
         "suiteId": "suite_id",
         "testObjects": Array [
           m {
+            "asyncTest": Promise {},
             "failed": false,
             "fieldName": "field_2",
             "id": "5",
             "isWarning": false,
             "statement": undefined,
             "suiteId": "suite_id",
-            "testFn": Promise {},
+            "testFn": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Promise {},
+                },
+              ],
+            },
           },
           m {
+            "asyncTest": Promise {},
             "failed": false,
             "fieldName": "field_4",
             "id": "7",
             "isWarning": false,
             "statement": undefined,
             "suiteId": "suite_id",
-            "testFn": Promise {},
+            "testFn": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Promise {},
+                },
+              ],
+            },
           },
           m {
+            "asyncTest": Promise {},
             "failed": false,
             "fieldName": "field_1",
             "id": "0",
             "isWarning": false,
             "statement": undefined,
             "suiteId": "suite_id",
-            "testFn": Promise {},
+            "testFn": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Promise {},
+                },
+              ],
+            },
           },
           m {
+            "asyncTest": Promise {},
             "failed": false,
             "fieldName": "field_3",
             "id": "2",
             "isWarning": false,
             "statement": undefined,
             "suiteId": "suite_id",
-            "testFn": Promise {},
+            "testFn": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Promise {},
+                },
+              ],
+            },
           },
         ],
         "tests": Object {},
@@ -116,31 +204,64 @@ Object {
         "suiteId": "suite_id",
         "testObjects": Array [
           m {
+            "asyncTest": Promise {},
             "failed": false,
             "fieldName": "field_1",
             "id": "0",
             "isWarning": false,
             "statement": undefined,
             "suiteId": "suite_id",
-            "testFn": Promise {},
+            "testFn": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Promise {},
+                },
+              ],
+            },
           },
           m {
+            "asyncTest": Promise {},
             "failed": false,
             "fieldName": "field_3",
             "id": "2",
             "isWarning": false,
             "statement": undefined,
             "suiteId": "suite_id",
-            "testFn": Promise {},
+            "testFn": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Promise {},
+                },
+              ],
+            },
           },
           m {
+            "asyncTest": Promise {},
             "failed": false,
             "fieldName": "field_4",
             "id": "3",
             "isWarning": false,
             "statement": undefined,
             "suiteId": "suite_id",
-            "testFn": Promise {},
+            "testFn": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Promise {},
+                },
+              ],
+            },
           },
         ],
         "tests": Object {},

--- a/packages/vest/src/core/test/__snapshots__/memo.spec.js.snap
+++ b/packages/vest/src/core/test/__snapshots__/memo.spec.js.snap
@@ -1,0 +1,173 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test.memo Async tests Cache miss Should run test functions normally 1`] = `
+Object {
+  "errorCount": 1,
+  "getErrors": [Function],
+  "getErrorsByGroup": [Function],
+  "getWarnings": [Function],
+  "getWarningsByGroup": [Function],
+  "groups": Object {},
+  "hasErrors": [Function],
+  "hasErrorsByGroup": [Function],
+  "hasWarnings": [Function],
+  "hasWarningsByGroup": [Function],
+  "name": "suite_1",
+  "testCount": 1,
+  "tests": Object {
+    "field_1": Object {
+      "errorCount": 1,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+  },
+  "warnCount": 0,
+}
+`;
+
+exports[`test.memo Sync tests On cache hit Should produce correct validation result 1`] = `
+Object {
+  "done": [Function],
+  "errorCount": 2,
+  "getErrors": [Function],
+  "getErrorsByGroup": [Function],
+  "getWarnings": [Function],
+  "getWarningsByGroup": [Function],
+  "groups": Object {},
+  "hasErrors": [Function],
+  "hasErrorsByGroup": [Function],
+  "hasWarnings": [Function],
+  "hasWarningsByGroup": [Function],
+  "name": "suite_0",
+  "testCount": 4,
+  "tests": Object {
+    "field_1": Object {
+      "errorCount": 1,
+      "errors": Array [
+        "message",
+      ],
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_2": Object {
+      "errorCount": 1,
+      "errors": Array [
+        "message",
+      ],
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_3": Object {
+      "errorCount": 0,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_4": Object {
+      "errorCount": 0,
+      "testCount": 1,
+      "warnCount": 1,
+      "warnings": Array [
+        "message",
+      ],
+    },
+  },
+  "warnCount": 1,
+}
+`;
+
+exports[`test.memo Sync tests On cache miss Should produce correct validation result 1`] = `
+Object {
+  "done": [Function],
+  "errorCount": 2,
+  "getErrors": [Function],
+  "getErrorsByGroup": [Function],
+  "getWarnings": [Function],
+  "getWarningsByGroup": [Function],
+  "groups": Object {},
+  "hasErrors": [Function],
+  "hasErrorsByGroup": [Function],
+  "hasWarnings": [Function],
+  "hasWarningsByGroup": [Function],
+  "name": "suite_0",
+  "testCount": 4,
+  "tests": Object {
+    "field_1": Object {
+      "errorCount": 1,
+      "errors": Array [
+        "message",
+      ],
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_2": Object {
+      "errorCount": 1,
+      "errors": Array [
+        "message",
+      ],
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_3": Object {
+      "errorCount": 0,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_4": Object {
+      "errorCount": 0,
+      "testCount": 1,
+      "warnCount": 1,
+      "warnings": Array [
+        "message",
+      ],
+    },
+  },
+  "warnCount": 1,
+}
+`;
+
+exports[`test.memo Sync tests On cache update Should produce fresh result 1`] = `
+Object {
+  "done": [Function],
+  "errorCount": 2,
+  "getErrors": [Function],
+  "getErrorsByGroup": [Function],
+  "getWarnings": [Function],
+  "getWarningsByGroup": [Function],
+  "groups": Object {},
+  "hasErrors": [Function],
+  "hasErrorsByGroup": [Function],
+  "hasWarnings": [Function],
+  "hasWarningsByGroup": [Function],
+  "name": "suite_0",
+  "testCount": 4,
+  "tests": Object {
+    "field_1": Object {
+      "errorCount": 1,
+      "errors": Array [
+        "message",
+      ],
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_2": Object {
+      "errorCount": 0,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_3": Object {
+      "errorCount": 1,
+      "errors": Array [
+        "message",
+      ],
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_4": Object {
+      "errorCount": 0,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+  },
+  "warnCount": 0,
+}
+`;

--- a/packages/vest/src/core/test/memo.spec.js
+++ b/packages/vest/src/core/test/memo.spec.js
@@ -1,0 +1,280 @@
+import wait from '@lets/wait';
+import vest from '../..';
+import enforce from '../../../../n4s/src/enforce';
+import test from '.';
+
+const suiteId = (n => () => `suite_${n++}`)(0);
+
+const genValidate = tests => vest.create(suiteId(), tests);
+const promisify = fn => (...args) =>
+  new Promise(resolve => fn(...args).done(resolve));
+
+describe('test.memo', () => {
+  describe('Sync tests', () => {
+    const testCb1 = jest.fn();
+    const testCb2 = jest.fn();
+    const testCb3 = jest.fn();
+    const testCb4 = jest.fn();
+
+    const test1Set = new Set();
+    const test2Set = new Set();
+    const test3Set = new Set();
+    const test4Set = new Set();
+
+    const validate = genValidate(value => {
+      test1Set.add(
+        test.memo(
+          'field_1',
+          'message',
+          () => {
+            testCb1();
+            return false;
+          },
+          [value]
+        )
+      );
+      test2Set.add(
+        test.memo(
+          'field_2',
+          'message',
+          () => {
+            testCb2();
+            enforce(value).equals(2);
+          },
+          [value]
+        )
+      );
+      test3Set.add(
+        test.memo(
+          'field_3',
+          'message',
+          () => {
+            testCb3();
+            enforce(value).equals(1);
+          },
+          [value]
+        )
+      );
+      test4Set.add(
+        test.memo(
+          'field_4',
+          'message',
+          () => {
+            testCb4();
+            vest.warn();
+            enforce(value).equals(2);
+          },
+          [value]
+        )
+      );
+    });
+
+    let res;
+
+    describe('On cache miss', () => {
+      it('Should run all test callbacks normally', () => {
+        expect(testCb1).not.toHaveBeenCalled();
+        expect(testCb2).not.toHaveBeenCalled();
+        expect(testCb3).not.toHaveBeenCalled();
+        expect(testCb4).not.toHaveBeenCalled();
+        validate(1);
+        expect(testCb1).toHaveBeenCalled();
+        expect(testCb2).toHaveBeenCalled();
+        expect(testCb3).toHaveBeenCalled();
+        expect(testCb4).toHaveBeenCalled();
+      });
+
+      it('Should produce correct validation result', () => {
+        res = validate(1);
+        expect(res.hasErrors('field_1')).toBe(true);
+        expect(res.hasErrors('field_2')).toBe(true);
+        expect(res.hasErrors('field_3')).toBe(false);
+        expect(res.hasErrors('field_4')).toBe(false);
+        expect(res.hasWarnings('field_4')).toBe(true);
+        expect(res).toMatchSnapshot();
+      });
+    });
+
+    describe('On cache hit', () => {
+      it('should return without running cached tests', () => {
+        validate(1);
+        expect(testCb1).not.toHaveBeenCalled();
+        expect(testCb2).not.toHaveBeenCalled();
+        expect(testCb3).not.toHaveBeenCalled();
+        expect(testCb4).not.toHaveBeenCalled();
+      });
+
+      it('Should produce correct validation result', () => {
+        const cachedRes = validate(1);
+        expect(cachedRes).isDeepCopyOf(res);
+        expect(res.hasErrors('field_1')).toBe(true);
+        expect(res.hasErrors('field_2')).toBe(true);
+        expect(res.hasErrors('field_3')).toBe(false);
+        expect(res.hasErrors('field_4')).toBe(false);
+        expect(res.hasWarnings('field_4')).toBe(true);
+        expect(cachedRes).toMatchSnapshot();
+      });
+
+      it('Returns the same VestTest object', () => {
+        validate(1);
+        expect(test1Set.size).toBe(1);
+        expect(test2Set.size).toBe(1);
+        expect(test3Set.size).toBe(1);
+        expect(test4Set.size).toBe(1);
+      });
+    });
+
+    describe('On cache update', () => {
+      it('Should call test functions again', () => {
+        expect(testCb1).not.toHaveBeenCalled();
+        expect(testCb2).not.toHaveBeenCalled();
+        expect(testCb3).not.toHaveBeenCalled();
+        expect(testCb4).not.toHaveBeenCalled();
+        validate(2);
+        expect(testCb1).toHaveBeenCalled();
+        expect(testCb2).toHaveBeenCalled();
+        expect(testCb3).toHaveBeenCalled();
+        expect(testCb4).toHaveBeenCalled();
+      });
+
+      it('Should produce fresh result', () => {
+        const newRes = validate(2);
+        expect(newRes).not.isDeepCopyOf(res);
+        expect(newRes.hasErrors('field_1')).toBe(true);
+        expect(newRes.hasErrors('field_2')).toBe(false);
+        expect(newRes.hasErrors('field_3')).toBe(true);
+        expect(newRes.hasErrors('field_4')).toBe(false);
+        expect(newRes.hasWarnings('field_4')).toBe(false);
+        expect(newRes).toMatchSnapshot();
+      });
+
+      it('Should return new VestTest instances', () => {
+        validate(2);
+        expect(test1Set.size).toBe(2);
+        expect(test2Set.size).toBe(2);
+        expect(test3Set.size).toBe(2);
+        expect(test4Set.size).toBe(2);
+      });
+    });
+  });
+
+  describe('Async tests', () => {
+    describe('Cache miss', () => {
+      const testCb1 = jest.fn();
+
+      const validate = genValidate(value => {
+        test.memo(
+          'field_1',
+          () =>
+            new Promise((resolve, reject) => {
+              testCb1();
+              setTimeout(() => {
+                if (value === 'FAIL') {
+                  reject();
+                } else {
+                  resolve();
+                }
+              }, 1000);
+            }),
+          [value]
+        );
+      });
+      it('Should run test functions normally', () =>
+        new Promise(done => {
+          const control = jest.fn();
+          expect(testCb1).not.toHaveBeenCalled();
+          validate('FAIL').done(res => {
+            expect(res.hasErrors('field_1')).toBe(true);
+            expect(res).toMatchSnapshot();
+            control();
+          });
+          expect(testCb1).toHaveBeenCalledTimes(1);
+          setTimeout(() => {
+            expect(control).toHaveBeenCalledTimes(1);
+            done();
+          }, 1000);
+        }));
+    });
+
+    describe('Cache hit', () => {
+      const testCb1 = jest.fn();
+      const test1Set = new Set();
+
+      const validate = promisify(
+        genValidate(value => {
+          test1Set.add(
+            test.memo(
+              'field_1',
+              () =>
+                new Promise((resolve, reject) => {
+                  testCb1();
+                  setTimeout(() => {
+                    if (value.startsWith('FAIL')) {
+                      reject();
+                    } else {
+                      resolve();
+                    }
+                  }, 1000);
+                }),
+              [value]
+            )
+          );
+        })
+      );
+
+      it('Should only call test function once', async () => {
+        expect(testCb1).not.toHaveBeenCalled();
+        await validate('FAIL');
+        await validate('FAIL');
+        expect(testCb1).toHaveBeenCalledTimes(1);
+      });
+
+      it('Should return same test object', async () => {
+        await validate('FAIL');
+        await validate('FAIL');
+        expect(test1Set.size).toBe(1);
+      });
+
+      it('Should produce the same result', async () => {
+        const res1 = await validate('FAIL');
+        const res2 = await validate('FAIL');
+        expect(res1).isDeepCopyOf(res2);
+      });
+
+      describe('When not fully awaited', () => {
+        const testCb1 = jest.fn();
+        const test1Set = new Set();
+
+        const validate = genValidate(value => {
+          test1Set.add(
+            test.memo(
+              'field_1',
+              () =>
+                new Promise((resolve, reject) => {
+                  testCb1();
+                  setTimeout(() => {
+                    if (value.startsWith('FAIL')) {
+                      reject();
+                    } else {
+                      resolve();
+                    }
+                  }, 1000);
+                }),
+              [value]
+            )
+          );
+        });
+        it('Should only call latest done', async () => {
+          const doneCb1 = jest.fn();
+          const doneCb2 = jest.fn();
+          validate('FAILURE').done(doneCb1);
+          await wait(50);
+          validate('FAILURE').done(doneCb2);
+          await wait(1000);
+          expect(doneCb1).not.toHaveBeenCalled();
+          expect(doneCb2).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});

--- a/packages/vest/src/core/test/runAsyncTest/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/test/runAsyncTest/__snapshots__/spec.js.snap
@@ -15,13 +15,14 @@ Object {
   "name": "suite_name_1",
   "pending": Array [
     VestTest {
+      "asyncTest": Promise {},
       "failed": false,
       "fieldName": "field_1",
       "id": "11",
       "isWarning": false,
       "statement": "some statement string",
       "suiteId": "suiteId_1",
-      "testFn": Promise {},
+      "testFn": [Function],
     },
   ],
   "suiteId": "suiteId_1",
@@ -45,13 +46,14 @@ Object {
   "name": "suite_name_1",
   "pending": Array [
     VestTest {
+      "asyncTest": Promise {},
       "failed": false,
       "fieldName": "field_1",
       "id": "0",
       "isWarning": false,
       "statement": "some statement string",
       "suiteId": "suiteId_1",
-      "testFn": Promise {},
+      "testFn": [Function],
     },
   ],
   "suiteId": "suiteId_1",

--- a/packages/vest/src/core/test/runAsyncTest/index.js
+++ b/packages/vest/src/core/test/runAsyncTest/index.js
@@ -33,7 +33,7 @@ const runDoneCallbacks = (suiteId, fieldName) => {
  * @param {VestTest} testObject A VestTest instance.
  */
 const runAsyncTest = testObject => {
-  const { testFn, statement, fieldName, id, suiteId } = testObject;
+  const { asyncTest, statement, fieldName, id, suiteId } = testObject;
   const { operationMode } = singleton.useContext();
   const done = cb => {
     const isCanceled = getState(KEY_CANCELED)[id];
@@ -79,7 +79,7 @@ const runAsyncTest = testObject => {
   };
   runWithContext({ currentTest: testObject }, () => {
     try {
-      testFn.then(done, fail);
+      asyncTest.then(done, fail);
     } catch (e) {
       fail();
     }

--- a/packages/vest/src/core/test/runAsyncTest/spec.js
+++ b/packages/vest/src/core/test/runAsyncTest/spec.js
@@ -49,8 +49,10 @@ describe.each([CASE_PASSING, CASE_FAILING])('runAsyncTest: %s', testCase => {
       fieldName,
       statement: STATEMENT,
       suiteId,
-      testFn: testCase === CASE_PASSING ? Promise.resolve() : Promise.reject(),
+      testFn: () => null,
     });
+    testObject.asyncTest =
+      testCase === CASE_PASSING ? Promise.resolve() : Promise.reject();
     setPending(suiteId, testObject);
   });
 
@@ -250,8 +252,8 @@ describe.each([CASE_PASSING, CASE_FAILING])('runAsyncTest: %s', testCase => {
       describe('When rejecting with a message', () => {
         const rejectionString = 'rejection string';
         beforeEach(() => {
-          testObject.testFn.catch(Function.prototype);
-          testObject.testFn = Promise.reject(rejectionString);
+          testObject.asyncTest.catch(Function.prototype);
+          testObject.asyncTest = Promise.reject(rejectionString);
         });
 
         it('Should set test statement to rejection string', () =>

--- a/packages/vest/src/lib/cache/index.js
+++ b/packages/vest/src/lib/cache/index.js
@@ -10,7 +10,7 @@ const createCache = (maxSize = 10) => {
    * @param {Any[]} deps  dependency array.
    * @param {Function}    cache action function.
    */
-  return (deps, cacheAction) => {
+  const cache = (deps, cacheAction) => {
     for (let i = 0; i < cacheStorage.length; i++) {
       const [cachedDeps, cachedResult] = cacheStorage[i];
 
@@ -24,7 +24,7 @@ const createCache = (maxSize = 10) => {
 
     const result = cacheAction();
 
-    cacheStorage.unshift([deps, result]);
+    cacheStorage.unshift([[...deps], result]);
 
     if (cacheStorage.length > maxSize) {
       cacheStorage.length = maxSize;
@@ -32,6 +32,21 @@ const createCache = (maxSize = 10) => {
 
     return result;
   };
+
+  /**
+   * Retrieves an item from the cache.
+   * @param {deps} deps Dependency array
+   */
+  cache.get = deps =>
+    cacheStorage[
+      cacheStorage.findIndex(
+        ([cachedDeps]) =>
+          deps.length === cachedDeps.length &&
+          deps.every((dep, i) => dep === cachedDeps[i])
+      )
+    ] ?? null;
+
+  return cache;
 };
 
 export default createCache;

--- a/packages/vest/src/lib/cache/spec.js
+++ b/packages/vest/src/lib/cache/spec.js
@@ -1,8 +1,12 @@
 import _ from 'lodash';
-
 import cache from '.';
 
 describe('lib: cache', () => {
+  let c;
+
+  beforeEach(() => {
+    c = cache();
+  });
   it('should return a function', () => {
     expect(typeof cache()).toBe('function');
   });
@@ -13,7 +17,6 @@ describe('lib: cache', () => {
 
   describe('on cache miss', () => {
     it('Should call passed cache action function and return its value', () => {
-      const c = cache();
       const cacheAction = jest.fn(() => ({}));
       const res = c([{}], cacheAction);
       expect(cacheAction).toHaveBeenCalledTimes(1);
@@ -23,7 +26,6 @@ describe('lib: cache', () => {
 
   describe('On cache hit', () => {
     it('Should return cached result', () => {
-      const c = cache();
       const cacheAction = jest.fn(() => {
         Math.random();
       });
@@ -35,7 +37,6 @@ describe('lib: cache', () => {
     });
 
     it('Should return without calling the cache action', () => {
-      const c = cache();
       const cacheAction = jest.fn();
       const depsArray = [Math.random()];
       c(depsArray, cacheAction);
@@ -79,5 +80,23 @@ describe('lib: cache', () => {
     expect(c([...deps])).toBe(res);
     const sliced = deps.slice(0, -1);
     expect(c(sliced, () => null)).toBeNull();
+  });
+
+  describe('cache.get', () => {
+    describe('On cache miss', () => {
+      it('Should return null', () => {
+        expect(c.get([1, 2, 3])).toBeNull();
+        c([1, 2, 3], Math.random);
+        expect(c.get([1, 2, '3'])).toBeNull();
+      });
+    });
+
+    describe('On cache hit', () => {
+      it('Should return cached key and item from cache storage', () => {
+        const res = c([1, 2, 3], Math.random);
+        expect(c.get([1, 2, 3])[0]).toEqual([1, 2, 3]);
+        expect(c.get([1, 2, 3])[1]).toEqual(res);
+      });
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,6 +1100,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz#3fdf5798f0b49e90155896f6291df186eac06c83"
   integrity sha512-9oLAnygRMi8Q5QkYEU4XWK04B+nuoXoxjRvRxgjuChkLZFBja0YPSgdZ7dZtwhncLBcQe/I/E+fLuk5qxcYVJA==
 
+"@lets/wait@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@lets/wait/-/wait-1.0.0.tgz#13204048062144a327d4967bdf38cac9df2f588e"
+  integrity sha512-rHjXHUF14M5tsqLwyfbpdHCQRzZL1vWPSmzOnYXx/SmkNvxL8n8zWA5iXxwwUYNJ05WjwR0NML8Y/r+p+8BgvQ==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix?         | ✖                                                                        |
| New feature?     | ✔                                                                        |
| Breaking change? | ✖                                                                        |
| Deprecations?    | ✖                                                                        |
| Documentation?   | ✔                                                                        |
| Tests added?     | ✔                                                                        |

<!-- Describe your changes below in detail. -->
## test.memo for memoized tests
In order to improve performance and runtime in heavy or long-running tests (such as async tests that go to the server), tests individual test results can be cached and saved for a later time, so whenever the exact same params appear again in the same runtime, the test result will be used from cache, instead of having to be re-evaluated.

### Usage:

Memoized tests are almost identical to regular tests, only with the added dependency array as the last argument. The dependency array is an array of items, that when identical (strict equality, `===`) to a previously presented array in the same test, its previous result will be used. You can see it as your cache key to the test result.

### Example:

```js
import vest, {test} from 'vest';
export default vest.create('form-name', (data) => {
    test.memo('username', 'username already exists', () => doesUserExist(data.username), [data.username])
});
```