### PR TITLE
Skip caching when resolving done results.

### DIFF
--- a/packages/vest/src/core/produce/index.js
+++ b/packages/vest/src/core/produce/index.js
@@ -33,7 +33,11 @@ const done = (state, ...args) => {
     return output;
   }
 
-  const cb = () => callback(produce(state, { draft: true }));
+  // This won't be cached. Because we do not know where in the
+  // Lifecycle of our validations this produce will run, the test may be
+  // outdated and we might even not have a reference for it, so we're spreading
+  // to skip the cache.
+  const cb = () => callback(produce({ ...state }, { draft: true }));
   const isFinishedTest = fieldName && !hasRemainingTests(state, fieldName);
   const isSuiteFinished = !hasRemainingTests(state);
   const shouldRunCallback = isFinishedTest || isSuiteFinished;


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix?         | ✔                                                                        |
| New feature?     | ✖                                                                        |
| Breaking change? | ✖                                                                        |
| Deprecations?    | ✖                                                                        |
| Documentation?   | ✖                                                                        |
| Tests added?     | ✔                                                                        |

<!-- Describe your changes below in detail. -->
Fixing a bug in the next version (2.1) that causes results within the `done` callback to use an out of date cache value.