### PR TITLE
fix: edge case when calling done after delay

### DIFF
--- a/packages/vest/src/core/produce/spec.js
+++ b/packages/vest/src/core/produce/spec.js
@@ -582,6 +582,30 @@ runSpec(vest => {
             });
           });
         });
+
+        describe('When delayed', () => {
+          const validate = vest.create('delayed_done', () => {
+            testDummy(vest).failing('field_1', 'error_1:a');
+            testDummy(vest).failingAsync('field_2', 'error_1:b');
+            testDummy(vest).failingAsync('field_3', 'error_1:c', { time: 100 });
+          });
+
+          afterEach(() => {
+            resetState();
+          });
+
+          it('Should call done callback immediately when delayed', () => {
+            const res = validate();
+            return new Promise(done => {
+              setTimeout(() => {
+                const doneCb = jest.fn();
+                res.done(doneCb);
+                expect(doneCb).toHaveBeenCalled();
+                done();
+              }, 500);
+            });
+          });
+        });
       });
     });
     describe('method: getErrorsByGroup', () => {

--- a/packages/vest/src/core/test/lib/pending/index.js
+++ b/packages/vest/src/core/test/lib/pending/index.js
@@ -1,3 +1,4 @@
+import removeElementFromArray from '../../../../lib/removeElementFromArray';
 import getSuiteState from '../../../state/getSuiteState';
 import patch from '../../../state/patch';
 import { setCanceled } from '../canceled';
@@ -46,7 +47,7 @@ export const setPending = (suiteId, testObject) => {
 export const removePending = testObject => {
   patch(testObject.suiteId, state => ({
     ...state,
-    pending: state.pending.filter(tO => tO !== testObject),
-    lagging: state.lagging.filter(tO => tO !== testObject),
+    pending: removeElementFromArray(state.pending, testObject),
+    lagging: removeElementFromArray(state.lagging, testObject),
   }));
 };

--- a/packages/vest/src/lib/removeElementFromArray/index.js
+++ b/packages/vest/src/lib/removeElementFromArray/index.js
@@ -1,0 +1,17 @@
+/**
+ * Removes first found element from array
+ * WARNING: Mutates array
+ *
+ * @param {any[]} array
+ * @param {any} element
+ */
+const removeElementFromArray = (array, element) => {
+  const index = array.findIndex(item => item === element);
+  if (index !== -1) {
+    array.splice(index, 1);
+  }
+
+  return array;
+};
+
+export default removeElementFromArray;

--- a/packages/vest/src/lib/removeElementFromArray/spec.js
+++ b/packages/vest/src/lib/removeElementFromArray/spec.js
@@ -1,0 +1,32 @@
+import _ from 'lodash';
+import removeElementFromArray from '.';
+
+describe('Tests removeElementFromArray', () => {
+  describe('When found', () => {
+    it('Should return the same array', () => {
+      const arr = [1, 2, 3];
+
+      expect(removeElementFromArray(arr, 3)).toBe(arr);
+    });
+
+    it('Should remove found element', () => {
+      const foundElement = {};
+
+      const arr = [1, 2, foundElement];
+      expect(removeElementFromArray(arr, foundElement)).toEqual([1, 2]);
+    });
+  });
+
+  describe('When not found', () => {
+    it('Should keep array unchanged', () => {
+      const arr = [1, 2, {}, null];
+
+      expect(removeElementFromArray(_.cloneDeep(arr), 777)).toEqual(arr);
+    });
+
+    it('Should return the same array', () => {
+      const arr = [1, 2, {}, null];
+      expect(removeElementFromArray(arr, 777)).toBe(arr);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix?         | ✔                                                                        |
| New feature?     | ✖                                                                        |
| Breaking change? | ✖                                                                        |
| Deprecations?    | ✖                                                                        |
| Documentation?   | ✖                                                                        |
| Tests added?     | ✔                                                                        |

<!-- Describe your changes below in detail. -->

Fixes an edge case where done is called after delay. Before fixing the bug, it wouldn't be called. This is due to the pending and lagging arrays being reassigned. The array reference used by done was not up to date, and there always seemed to be more pending tests, even though there weren't.
