### PR TITLE
patch: Move exclusion to context

### DIFF
--- a/packages/vest/src/core/Context/index.js
+++ b/packages/vest/src/core/Context/index.js
@@ -1,3 +1,7 @@
+import {
+  EXCLUSION_ITEM_TYPE_TESTS,
+  EXCLUSION_ITEM_TYPE_GROUPS,
+} from '../../hooks/exclusive/constants';
 import singleton from '../../lib/singleton';
 
 class Context {
@@ -53,6 +57,19 @@ class Context {
 
   set groupName(groupName) {
     this.group_name = groupName;
+  }
+
+  get exclusion() {
+    let key = this.lookup('_exclusion');
+
+    if (key === undefined) {
+      key = this._exclusion = {
+        [EXCLUSION_ITEM_TYPE_TESTS]: {},
+        [EXCLUSION_ITEM_TYPE_GROUPS]: {},
+      };
+    }
+
+    return key;
   }
 
   lookup(key) {

--- a/packages/vest/src/core/createSuite/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/createSuite/__snapshots__/spec.js.snap
@@ -4,10 +4,6 @@ exports[`Test createSuite module Initial run Should initialize with an empty sta
 Array [
   Object {
     "doneCallbacks": Array [],
-    "exclusion": Object {
-      "groups": Object {},
-      "tests": Object {},
-    },
     "fieldCallbacks": Object {},
     "groups": Object {},
     "lagging": Array [],

--- a/packages/vest/src/core/createSuite/spec.js
+++ b/packages/vest/src/core/createSuite/spec.js
@@ -86,8 +86,6 @@ describe('Test createSuite module', () => {
       expect(state[0].testObjects).toHaveLength(0);
       expect(state[0].pending).toHaveLength(0);
       expect(state[0].lagging).toHaveLength(0);
-      expect(Object.keys(state[0].exclusion.groups)).toHaveLength(0);
-      expect(Object.keys(state[0].exclusion.tests)).toHaveLength(0);
       expect(Object.keys(state[0].tests)).toHaveLength(0);
       expect(Object.keys(state[0].groups)).toHaveLength(0);
       expect(Object.keys(state[0].doneCallbacks)).toHaveLength(0);

--- a/packages/vest/src/core/state/registerSuite/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/state/registerSuite/__snapshots__/spec.js.snap
@@ -3,10 +3,6 @@
 exports[`registerSuite When suite does not exist in state Should create initial suite without prevState 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusion": Object {
-    "groups": Object {},
-    "tests": Object {},
-  },
   "fieldCallbacks": Object {},
   "groups": Object {},
   "lagging": Array [],
@@ -22,10 +18,6 @@ exports[`registerSuite When suite exists in state Prev state data handling When 
 Array [
   Object {
     "doneCallbacks": Array [],
-    "exclusion": Object {
-      "groups": Object {},
-      "tests": Object {},
-    },
     "fieldCallbacks": Object {},
     "groups": Object {},
     "lagging": Array [
@@ -44,10 +36,6 @@ Array [
   },
   Object {
     "doneCallbacks": Array [],
-    "exclusion": Object {
-      "groups": Object {},
-      "tests": Object {},
-    },
     "fieldCallbacks": Object {},
     "groups": Object {},
     "lagging": null,
@@ -64,10 +52,6 @@ exports[`registerSuite When suite exists in state Should match snapshot 1`] = `
 Array [
   Object {
     "doneCallbacks": Array [],
-    "exclusion": Object {
-      "groups": Object {},
-      "tests": Object {},
-    },
     "fieldCallbacks": Object {},
     "groups": Object {},
     "lagging": Array [],
@@ -79,10 +63,6 @@ Array [
   },
   Object {
     "doneCallbacks": Array [],
-    "exclusion": Object {
-      "groups": Object {},
-      "tests": Object {},
-    },
     "fieldCallbacks": Object {},
     "groups": Object {},
     "lagging": null,

--- a/packages/vest/src/core/state/registerSuite/index.js
+++ b/packages/vest/src/core/state/registerSuite/index.js
@@ -1,8 +1,4 @@
 import { getSuite, setSuites } from '..';
-import {
-  EXCLUSION_ITEM_TYPE_TESTS,
-  EXCLUSION_ITEM_TYPE_GROUPS,
-} from '../../../hooks/exclusive/constants';
 import singleton from '../../../lib/singleton';
 
 /**
@@ -12,10 +8,6 @@ import singleton from '../../../lib/singleton';
  */
 const INITIAL_SUITE_STATE = (suiteId, name) => ({
   doneCallbacks: [],
-  exclusion: {
-    [EXCLUSION_ITEM_TYPE_TESTS]: {},
-    [EXCLUSION_ITEM_TYPE_GROUPS]: {},
-  },
   fieldCallbacks: {},
   groups: {},
   lagging: [],

--- a/packages/vest/src/core/state/remove/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/state/remove/__snapshots__/spec.js.snap
@@ -9,13 +9,6 @@ Object {
     "suite_id": Array [
       Object {
         "doneCallbacks": Array [],
-        "exclusion": Object {
-          "groups": Object {},
-          "tests": Object {
-            "field_1": false,
-            "field_3": false,
-          },
-        },
         "fieldCallbacks": Object {},
         "groups": Object {},
         "lagging": Array [
@@ -190,12 +183,6 @@ Object {
       },
       Object {
         "doneCallbacks": Array [],
-        "exclusion": Object {
-          "groups": Object {},
-          "tests": Object {
-            "field_2": false,
-          },
-        },
         "fieldCallbacks": Object {},
         "groups": Object {},
         "lagging": null,

--- a/packages/vest/src/core/test/index.js
+++ b/packages/vest/src/core/test/index.js
@@ -2,7 +2,6 @@ import { isExcluded } from '../../hooks/exclusive';
 import createCache from '../../lib/cache';
 import runWithContext from '../../lib/runWithContext';
 import singleton from '../../lib/singleton';
-import getSuiteState from '../state/getSuiteState';
 import patch from '../state/patch';
 import VestTest from './lib/VestTest';
 import { setPending } from './lib/pending';
@@ -90,7 +89,7 @@ const test = (fieldName, ...args) => {
     testFn,
   });
 
-  if (isExcluded(getSuiteState(ctx.suiteId), testObject)) {
+  if (isExcluded(testObject)) {
     return testObject;
   }
 
@@ -120,7 +119,7 @@ test.memo = (fieldName, ...args) => {
 
   const [, testObject] = cached;
 
-  if (isExcluded(getSuiteState(ctx.suiteId), testObject)) {
+  if (isExcluded(testObject)) {
     return testObject;
   }
 

--- a/packages/vest/src/core/test/lib/mergeExcludedTests/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/test/lib/mergeExcludedTests/__snapshots__/spec.js.snap
@@ -3,12 +3,6 @@
 exports[`module: skipped export: mergeExcludedTests When previous state exists When no currently skipped fields or groups When skipped field exists in previous state Error field Should copy prev field state over 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusion": Object {
-    "groups": Object {},
-    "tests": Object {
-      "field_2": false,
-    },
-  },
   "fieldCallbacks": Object {},
   "groups": Object {
     "group_1": Object {},
@@ -65,12 +59,6 @@ Object {
 exports[`module: skipped export: mergeExcludedTests When previous state exists When no currently skipped fields or groups When skipped field exists in previous state Warning field Should copy prev field state over 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusion": Object {
-    "groups": Object {},
-    "tests": Object {
-      "field_1": false,
-    },
-  },
   "fieldCallbacks": Object {},
   "groups": Object {
     "group_1": Object {},

--- a/packages/vest/src/core/test/lib/mergeExcludedTests/index.js
+++ b/packages/vest/src/core/test/lib/mergeExcludedTests/index.js
@@ -16,7 +16,7 @@ const mergeExcludedTests = suiteId => {
     nextState.testObjects = nextState.testObjects.concat(
       prevState.testObjects.reduce((movedTests, testObject) => {
         // Checking prev-test object against current state;
-        if (isExcluded(state, testObject)) {
+        if (isExcluded(testObject)) {
           return movedTests.concat(testObject);
         }
 

--- a/packages/vest/src/core/test/lib/pending/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/test/lib/pending/__snapshots__/spec.js.snap
@@ -3,10 +3,6 @@
 exports[`module: pending export: removePending When testObject is either pending or lagging When in lagging Should remove test from lagging 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusion": Object {
-    "groups": Object {},
-    "tests": Object {},
-  },
   "fieldCallbacks": Object {},
   "groups": Object {},
   "lagging": Array [],
@@ -21,10 +17,6 @@ Object {
 exports[`module: pending export: removePending When testObject is either pending or lagging When in pending Should remove test from pending 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusion": Object {
-    "groups": Object {},
-    "tests": Object {},
-  },
   "fieldCallbacks": Object {},
   "groups": Object {},
   "lagging": Array [],
@@ -39,10 +31,6 @@ Object {
 exports[`module: pending export: setPending When a field of the same profile is in lagging array Should remove test from lagging array 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusion": Object {
-    "groups": Object {},
-    "tests": Object {},
-  },
   "fieldCallbacks": Object {},
   "groups": Object {},
   "lagging": Array [

--- a/packages/vest/src/core/test/runAsyncTest/__snapshots__/spec.js.snap
+++ b/packages/vest/src/core/test/runAsyncTest/__snapshots__/spec.js.snap
@@ -3,10 +3,6 @@
 exports[`runAsyncTest: failing State updates Initial state matches snapshot (sanity) 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusion": Object {
-    "groups": Object {},
-    "tests": Object {},
-  },
   "fieldCallbacks": Object {
     "field_1": Array [],
   },
@@ -34,10 +30,6 @@ Object {
 exports[`runAsyncTest: passing State updates Initial state matches snapshot (sanity) 1`] = `
 Object {
   "doneCallbacks": Array [],
-  "exclusion": Object {
-    "groups": Object {},
-    "tests": Object {},
-  },
   "fieldCallbacks": Object {
     "field_1": Array [],
   },

--- a/packages/vest/src/hooks/exclusive/spec.js
+++ b/packages/vest/src/hooks/exclusive/spec.js
@@ -2,9 +2,8 @@ import mock from '../../../../../shared/testUtils/mock';
 import resetState from '../../../testUtils/resetState';
 import runSpec from '../../../testUtils/runSpec';
 import testDummy from '../../../testUtils/testDummy';
-import getSuiteState from '../../core/state/getSuiteState';
 import VestTest from '../../core/test/lib/VestTest';
-import singleton from '../../lib/singleton';
+import runWithContext from '../../lib/runWithContext';
 
 const faker = require('faker');
 const { ERROR_HOOK_CALLED_OUTSIDE } = require('../constants');
@@ -50,10 +49,8 @@ runSpec(vest => {
           testObject1 = testDummy(vest).failing();
         });
 
-        const ctx = singleton.useContext();
-        const state = getSuiteState(ctx.suiteId);
-        res = isExcluded(state, testObject);
-        res1 = isExcluded(state, testObject1);
+        res = isExcluded(testObject);
+        res1 = isExcluded(testObject1);
       })();
 
       expect(res).toBe(false);
@@ -65,9 +62,7 @@ runSpec(vest => {
         test('isExcluded returns false for included field', () => {
           vest.create(faker.lorem.word(), () => {
             vest.only(field1.fieldName);
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
-            res = isExcluded(state, field1);
+            res = isExcluded(field1);
           })();
           expect(res).toBe(false);
         });
@@ -77,9 +72,7 @@ runSpec(vest => {
             vest.only('group_name');
 
             group('group_name', () => {
-              const ctx = singleton.useContext();
-              const state = getSuiteState(ctx.suiteId);
-              res = isGroupExcluded(state, 'group_name');
+              res = isGroupExcluded('group_name');
             });
           })();
           expect(res).toBe(false);
@@ -88,10 +81,8 @@ runSpec(vest => {
         test('isExcluded returns true for non included field', () => {
           vest.create(faker.lorem.word(), () => {
             vest.only(field1.fieldName);
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
-            res1 = isExcluded(state, field1);
-            res = isExcluded(state, field2);
+            res1 = isExcluded(field1);
+            res = isExcluded(field2);
           })();
           expect(res1).toBe(false);
           expect(res).toBe(true);
@@ -101,13 +92,11 @@ runSpec(vest => {
           vest.create(faker.lorem.word(), () => {
             vest.only.group('group_1');
 
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
             group('group_1', Function.prototype);
             group('group_2', Function.prototype);
 
-            res1 = isGroupExcluded(state, 'group_1');
-            res = isGroupExcluded(state, 'group_2');
+            res1 = isGroupExcluded('group_1');
+            res = isGroupExcluded('group_2');
           })();
 
           expect(res1).toBe(false);
@@ -119,10 +108,8 @@ runSpec(vest => {
         test('isExcluded returns false for included field', () => {
           vest.create(faker.lorem.word(), () => {
             vest.only([field1.fieldName, field2.fieldName]);
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
-            res = isExcluded(state, field1);
-            res1 = isExcluded(state, field2);
+            res = isExcluded(field1);
+            res1 = isExcluded(field2);
           })();
           expect(res).toBe(false);
           expect(res1).toBe(false);
@@ -136,13 +123,10 @@ runSpec(vest => {
             group('group_2', Function.prototype);
             group('group_3', Function.prototype);
 
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
-
             res = [
-              isGroupExcluded(state, 'group_1'),
-              isGroupExcluded(state, 'group_2'),
-              isGroupExcluded(state, 'group_3'),
+              isGroupExcluded('group_1'),
+              isGroupExcluded('group_2'),
+              isGroupExcluded('group_3'),
             ];
           })();
           expect(res).toEqual([false, false, true]);
@@ -150,19 +134,9 @@ runSpec(vest => {
 
         test('isExcluded returns true for non included field', () => {
           vest.create(faker.lorem.word(), () => {
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
-            res = [
-              isExcluded(state, field1),
-              isExcluded(state, field2),
-              isExcluded(state, field3),
-            ];
+            res = [isExcluded(field1), isExcluded(field2), isExcluded(field3)];
             vest.only([field1.fieldName, field2.fieldName]);
-            res1 = [
-              isExcluded(state, field1),
-              isExcluded(state, field2),
-              isExcluded(state, field3),
-            ];
+            res1 = [isExcluded(field1), isExcluded(field2), isExcluded(field3)];
           })();
           expect(res).toEqual([false, false, false]);
           expect(res1).toEqual([false, false, true]);
@@ -171,14 +145,12 @@ runSpec(vest => {
         test('isGroupExcluded returns true for non included groups', () => {
           vest.create(faker.lorem.word(), () => {
             vest.only.group(['group_1', 'group_2']);
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
 
             group('group_3', Function.prototype);
             res = [
-              isGroupExcluded(state, 'group_1'),
-              isGroupExcluded(state, 'group_2'),
-              isGroupExcluded(state, 'group_3'),
+              isGroupExcluded('group_1'),
+              isGroupExcluded('group_2'),
+              isGroupExcluded('group_3'),
             ];
           })();
           expect(res).toEqual([false, false, true]);
@@ -191,9 +163,7 @@ runSpec(vest => {
         test('isExcluded returns true for excluded field', () => {
           vest.create(faker.lorem.word(), () => {
             vest.skip(field1.fieldName);
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
-            res = isExcluded(state, field1);
+            res = isExcluded(field1);
           })();
           expect(res).toBe(true);
         });
@@ -201,10 +171,8 @@ runSpec(vest => {
         test('isGroupExcluded returns true for excluded groups', () => {
           vest.create(faker.lorem.word(), () => {
             vest.skip.group('group_1');
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
-            res = isGroupExcluded(state, 'group_1');
-            res1 = isGroupExcluded(state, 'group_2');
+            res = isGroupExcluded('group_1');
+            res1 = isGroupExcluded('group_2');
           })();
 
           expect(res).toBe(true);
@@ -214,9 +182,7 @@ runSpec(vest => {
         test('isExcluded returns false for non excluded field', () => {
           vest.create(faker.lorem.word(), () => {
             vest.skip(field1.fieldName);
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
-            res = isExcluded(state, field2);
+            res = isExcluded(field2);
           })();
           expect(res).toBe(false);
         });
@@ -225,9 +191,7 @@ runSpec(vest => {
       test('isGroupExcluded returns false for non excluded groups', () => {
         vest.create(faker.lorem.word(), () => {
           vest.skip('group_1');
-          const ctx = singleton.useContext();
-          const state = getSuiteState(ctx.suiteId);
-          res = isExcluded(state, 'group_2');
+          res = isExcluded('group_2');
         })();
         expect(res).toBe(false);
       });
@@ -236,11 +200,9 @@ runSpec(vest => {
         test('isExcluded returns true for excluded field', () => {
           vest.create(faker.lorem.word(), () => {
             vest.skip([field1.fieldName, field2.fieldName]);
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
 
-            res = isExcluded(state, field1);
-            res1 = isExcluded(state, field2);
+            res = isExcluded(field1);
+            res1 = isExcluded(field2);
           })();
           expect(res).toBe(true);
           expect(res1).toBe(true);
@@ -249,12 +211,7 @@ runSpec(vest => {
         test('isGroupExcluded returns true for excluded groups', () => {
           vest.create(faker.lorem.word(), () => {
             vest.skip.group(['group_1', 'group_2']);
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
-            res = [
-              isGroupExcluded(state, 'group_1'),
-              isGroupExcluded(state, 'group_2'),
-            ];
+            res = [isGroupExcluded('group_1'), isGroupExcluded('group_2')];
           })();
           expect(res).toEqual([true, true]);
         });
@@ -262,9 +219,7 @@ runSpec(vest => {
         test('isExcluded returns false for non included field', () => {
           vest.create(faker.lorem.word(), () => {
             vest.skip([field1.fieldName, field2.fieldName]);
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
-            res = isExcluded(state, field3);
+            res = isExcluded(field3);
           })();
           expect(res).toBe(false);
         });
@@ -272,9 +227,7 @@ runSpec(vest => {
         test('isGroupExcluded returns false for non excluded groups', () => {
           vest.create(faker.lorem.word(), () => {
             vest.skip(['group_1', 'group_2']);
-            const ctx = singleton.useContext();
-            const state = getSuiteState(ctx.suiteId);
-            res = isGroupExcluded(state, 'group_3');
+            res = isGroupExcluded('group_3');
           })();
           expect(res).toEqual(false);
         });
@@ -304,60 +257,68 @@ runSpec(vest => {
 });
 
 describe('isExcluded', () => {
-  let state;
+  let ctx;
 
-  const genState = ({ tests = {}, groups = {} }) => ({
-    exclusion: { tests, groups },
+  const genCtx = ({ tests = {}, groups = {} }) => ({
+    _exclusion: { tests, groups },
   });
+
+  const runIsExcluded = (ctx, ...args) =>
+    runWithContext(ctx, () => {
+      const res = isExcluded(...args);
+
+      return res;
+    });
+
   const genTest = (fieldName, groupName) => ({ fieldName, groupName });
   describe('skip', () => {
     beforeEach(() => {
-      state = genState({ tests: { field_1: false, field_2: false } });
+      ctx = genCtx({ tests: { field_1: false, field_2: false } });
     });
     it('returns true for skipped field', () => {
-      expect(isExcluded(state, genTest('field_1'))).toBe(true);
-      expect(isExcluded(state, genTest('field_2', 'group_1'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_1'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_1'))).toBe(true);
     });
     it('returns false for non skipped field', () => {
-      expect(isExcluded(state, genTest('field_3'))).toBe(false);
-      expect(isExcluded(state, genTest('field_4', 'group_1'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_3'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_4', 'group_1'))).toBe(false);
     });
   });
   describe('only', () => {
     beforeEach(() => {
-      state = genState({ tests: { field_1: true, field_2: true } });
+      ctx = genCtx({ tests: { field_1: true, field_2: true } });
     });
     it('returns false for included field', () => {
-      expect(isExcluded(state, genTest('field_1'))).toBe(false);
-      expect(isExcluded(state, genTest('field_2', 'group_1'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_1'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_1'))).toBe(false);
     });
     it('returns true for non included field', () => {
-      expect(isExcluded(state, genTest('field_3'))).toBe(true);
-      expect(isExcluded(state, genTest('field_4', 'group_1'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_3'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_4', 'group_1'))).toBe(true);
     });
   });
   describe('only+skip', () => {
     beforeEach(() => {
-      state = genState({
+      ctx = genCtx({
         tests: { field_1: true, field_2: true, field_3: false, field_4: false },
       });
     });
     it('returns false for included tests', () => {
-      expect(isExcluded(state, genTest('field_1'))).toBe(false);
-      expect(isExcluded(state, genTest('field_2', 'group_1'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_1'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_1'))).toBe(false);
     });
     it('returns true excluded tests', () => {
-      expect(isExcluded(state, genTest('field_3'))).toBe(true);
-      expect(isExcluded(state, genTest('field_4', 'group_1'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_3'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_4', 'group_1'))).toBe(true);
     });
     it('returns true for non included field', () => {
-      expect(isExcluded(state, genTest('field_5'))).toBe(true);
-      expect(isExcluded(state, genTest('field_6', 'group_1'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_5'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_6', 'group_1'))).toBe(true);
     });
   });
   describe('skip.group', () => {
     beforeEach(() => {
-      state = genState({
+      ctx = genCtx({
         groups: {
           group_1: false,
           group_2: false,
@@ -366,21 +327,21 @@ describe('isExcluded', () => {
     });
 
     it('Returns true for tests in skipped group', () => {
-      expect(isExcluded(state, genTest('field_1', 'group_1'))).toBe(true);
-      expect(isExcluded(state, genTest('field_2', 'group_2'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_1', 'group_1'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_2'))).toBe(true);
     });
     it('Returns false for tests in non skipped groups', () => {
-      expect(isExcluded(state, genTest('field_3', 'group_3'))).toBe(false);
-      expect(isExcluded(state, genTest('field_4', 'group_4'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_3', 'group_3'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_4', 'group_4'))).toBe(false);
     });
     it('Returns false for tests outside of any group', () => {
-      expect(isExcluded(state, genTest('field_3'))).toBe(false);
-      expect(isExcluded(state, genTest('field_4'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_3'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_4'))).toBe(false);
     });
   });
   describe('only.group', () => {
     beforeEach(() => {
-      state = genState({
+      ctx = genCtx({
         groups: {
           group_1: true,
           group_2: true,
@@ -389,24 +350,24 @@ describe('isExcluded', () => {
     });
 
     it('returns false for tests in included groups', () => {
-      expect(isExcluded(state, genTest('field_1', 'group_1'))).toBe(false);
-      expect(isExcluded(state, genTest('field_1', 'group_2'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_1', 'group_1'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_1', 'group_2'))).toBe(false);
     });
 
     it('returns true for groups in non included groups', () => {
-      expect(isExcluded(state, genTest('field_1', 'group_3'))).toBe(true);
-      expect(isExcluded(state, genTest('field_2', 'group_4'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_1', 'group_3'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_4'))).toBe(true);
     });
 
     it('returns false for tests outside of any group', () => {
-      expect(isExcluded(state, genTest('field_1'))).toBe(false);
-      expect(isExcluded(state, genTest('field_2'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_1'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_2'))).toBe(false);
     });
   });
 
   describe('only.group + only', () => {
     beforeEach(() => {
-      state = genState({
+      ctx = genCtx({
         groups: {
           group_1: true,
           group_2: true,
@@ -416,34 +377,34 @@ describe('isExcluded', () => {
     });
 
     it('returns false for included tests', () => {
-      expect(isExcluded(state, genTest('field_1'))).toBe(false);
-      expect(isExcluded(state, genTest('field_2'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_1'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_2'))).toBe(false);
     });
 
     it('returns false for included tests in included groups', () => {
-      expect(isExcluded(state, genTest('field_1', 'group_1'))).toBe(false);
-      expect(isExcluded(state, genTest('field_2', 'group_2'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_1', 'group_1'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_2'))).toBe(false);
     });
 
     it('returns true for included test in non included group', () => {
-      expect(isExcluded(state, genTest('field_1', 'group_3'))).toBe(true);
-      expect(isExcluded(state, genTest('field_2', 'group_4'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_1', 'group_3'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_4'))).toBe(true);
     });
 
     it('returns true for non included test in included group', () => {
-      expect(isExcluded(state, genTest('field_3', 'group_1'))).toBe(true);
-      expect(isExcluded(state, genTest('field_4', 'group_2'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_3', 'group_1'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_4', 'group_2'))).toBe(true);
     });
 
     it('returns true for non included tests', () => {
-      expect(isExcluded(state, genTest('field_3'))).toBe(true);
-      expect(isExcluded(state, genTest('field_4'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_3'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_4'))).toBe(true);
     });
   });
 
   describe('skip.group + only', () => {
     beforeEach(() => {
-      state = genState({
+      ctx = genCtx({
         groups: {
           group_1: false,
           group_2: false,
@@ -453,35 +414,35 @@ describe('isExcluded', () => {
     });
 
     it('returns true for tests in excluded groups', () => {
-      expect(isExcluded(state, genTest('field_1', 'group_1'))).toBe(true);
-      expect(isExcluded(state, genTest('field_2', 'group_1'))).toBe(true);
-      expect(isExcluded(state, genTest('field_3', 'group_1'))).toBe(true);
-      expect(isExcluded(state, genTest('field_1', 'group_2'))).toBe(true);
-      expect(isExcluded(state, genTest('field_2', 'group_2'))).toBe(true);
-      expect(isExcluded(state, genTest('field_3', 'group_2'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_1', 'group_1'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_1'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_3', 'group_1'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_1', 'group_2'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_2'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_3', 'group_2'))).toBe(true);
     });
 
     it('returns false for tests in included tests in non excluded groups', () => {
-      expect(isExcluded(state, genTest('field_1', 'group_3'))).toBe(false);
-      expect(isExcluded(state, genTest('field_2', 'group_3'))).toBe(false);
-      expect(isExcluded(state, genTest('field_1', 'group_4'))).toBe(false);
-      expect(isExcluded(state, genTest('field_2', 'group_4'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_1', 'group_3'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_3'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_1', 'group_4'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_4'))).toBe(false);
     });
 
     it('returns true for non included tests', () => {
-      expect(isExcluded(state, genTest('field_3'))).toBe(true);
-      expect(isExcluded(state, genTest('field_4'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_3'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_4'))).toBe(true);
     });
 
     it('returns false for included tests', () => {
-      expect(isExcluded(state, genTest('field_1'))).toBe(false);
-      expect(isExcluded(state, genTest('field_2'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_1'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_2'))).toBe(false);
     });
   });
 
   describe('only.group + skip', () => {
     beforeEach(() => {
-      state = genState({
+      ctx = genCtx({
         groups: {
           group_1: true,
           group_2: true,
@@ -491,28 +452,28 @@ describe('isExcluded', () => {
     });
 
     it('returns true for excluded tests', () => {
-      expect(isExcluded(state, genTest('field_1'))).toBe(true);
-      expect(isExcluded(state, genTest('field_2'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_1'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_2'))).toBe(true);
     });
     it('returns false for non excluded tests', () => {
-      expect(isExcluded(state, genTest('field_3'))).toBe(false);
-      expect(isExcluded(state, genTest('field_4'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_3'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_4'))).toBe(false);
     });
     it('returns true for excluded test in included group', () => {
-      expect(isExcluded(state, genTest('field_1', 'group_1'))).toBe(true);
-      expect(isExcluded(state, genTest('field_2', 'group_2'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_1', 'group_1'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_2'))).toBe(true);
     });
     it('returns true for excluded test in non included group', () => {
-      expect(isExcluded(state, genTest('field_1', 'group_3'))).toBe(true);
-      expect(isExcluded(state, genTest('field_2', 'group_4'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_1', 'group_3'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_2', 'group_4'))).toBe(true);
     });
     it('returns false for non excluded test in included group', () => {
-      expect(isExcluded(state, genTest('field_3', 'group_1'))).toBe(false);
-      expect(isExcluded(state, genTest('field_4', 'group_2'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_3', 'group_1'))).toBe(false);
+      expect(runIsExcluded(ctx, genTest('field_4', 'group_2'))).toBe(false);
     });
     it('returns true for non excluded test in non included group', () => {
-      expect(isExcluded(state, genTest('field_3', 'group_3'))).toBe(true);
-      expect(isExcluded(state, genTest('field_4', 'group_4'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_3', 'group_3'))).toBe(true);
+      expect(runIsExcluded(ctx, genTest('field_4', 'group_4'))).toBe(true);
     });
   });
 });

--- a/packages/vest/testUtils/resetState/__snapshots__/spec.js.snap
+++ b/packages/vest/testUtils/resetState/__snapshots__/spec.js.snap
@@ -11,10 +11,6 @@ exports[`resetState When invoked with suite name Should add a new suite to the s
 Array [
   Object {
     "doneCallbacks": Array [],
-    "exclusion": Object {
-      "groups": Object {},
-      "tests": Object {},
-    },
     "fieldCallbacks": Object {},
     "groups": Object {},
     "lagging": Array [],


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix?         | ✖                                                                        |
| New feature?     | ✖                                                                        |
| Breaking change? | ✖                                                                        |
| Deprecations?    | ✖                                                                        |
| Documentation?   | ✖                                                                        |
| Tests added?     | ✔                                                                        |

<!-- Describe your changes below in detail. -->

Add exclusion directly into context, this will allow using the only/skip hooks from within `runWithContext` even outside of a running suite, allowing better composability.