### PR TITLE
patch: Skip iteration of pending tests

### DIFF
--- a/packages/vest/docs/exclusion.md
+++ b/packages/vest/docs/exclusion.md
@@ -4,7 +4,7 @@ When performing validations in real world-scenarios, you may need to only run te
 
 `vest.skip()` and `vest.only()` are functions that take a name of the test, or a list of names to either include or exclude fields from being validated. They should be called from the body of suite callback, and in order for them to take effect, they should be called before anything else.
 
-!> **NOTE** When using `vest.only()` or `vest.skip()` you must place them before any of the tests defined in the suite. Hooks run in order of appearance, which means that if you place your `skip` hook after the filed you're skipping - it won't have any effect.
+!> **NOTE** When using `vest.only()` or `vest.skip()` you must place them before any of the tests defined in the suite. Hooks run in order of appearance, which means that if you place your `skip` hook after the field you're skipping - it won't have any effect.
 
 ### Only running specific tests (including)
 

--- a/packages/vest/src/core/createSuite/index.js
+++ b/packages/vest/src/core/createSuite/index.js
@@ -7,7 +7,6 @@ import { getSuite } from '../state';
 import getSuiteState from '../state/getSuiteState';
 import registerSuite from '../state/registerSuite';
 import mergeExcludedTests from '../test/lib/mergeExcludedTests';
-import runAsyncTest from '../test/runAsyncTest';
 
 /**
  * Initializes a validation suite, creates a validation context.
@@ -50,7 +49,6 @@ const createSuite = (name, tests) => {
         tests.apply(null, args);
         mergeExcludedTests(suiteId);
 
-        [...getSuiteState(suiteId).pending].forEach(runAsyncTest);
         return produce(getSuiteState(suiteId));
       });
       return output;

--- a/packages/vest/src/core/test/index.js
+++ b/packages/vest/src/core/test/index.js
@@ -5,6 +5,7 @@ import Context from '../Context';
 import patch from '../state/patch';
 import VestTest from './lib/VestTest';
 import { setPending } from './lib/pending';
+import runAsyncTest from './runAsyncTest';
 
 let cache;
 
@@ -58,7 +59,8 @@ const register = testObject => {
     // in case object is an enforce chain
     if (typeof result?.then === 'function') {
       testObject.asyncTest = result;
-      setPending(testObject.suiteId, testObject);
+      setPending(testObject);
+      runAsyncTest(testObject);
     }
   } catch {
     /* FUTURE: throw an error here in dev mode:
@@ -75,6 +77,9 @@ const register = testObject => {
  * @param {String} [statement]          The message returned in case of a failure.
  * @param {function} testFn             The actual test callback.
  * @return {VestTest}                 A VestTest instance.
+ *
+ * **IMPORTANT**
+ * Changes to this function need to reflect in test.memo as well
  */
 const test = (fieldName, ...args) => {
   const { length, [length - 2]: statement, [length - 1]: testFn } = args;
@@ -126,7 +131,8 @@ test.memo = (fieldName, ...args) => {
   addTestToState(testObject.suiteId, testObject);
 
   if (typeof testObject?.asyncTest?.then === 'function') {
-    setPending(testObject.suiteId, testObject);
+    setPending(testObject);
+    runAsyncTest(testObject);
   }
 
   return testObject;

--- a/packages/vest/src/core/test/lib/pending/index.js
+++ b/packages/vest/src/core/test/lib/pending/index.js
@@ -5,11 +5,10 @@ import { setCanceled } from '../canceled';
 
 /**
  * Sets a test as pending in the state.
- * @param {string} suiteId
  * @param {VestTest} testObject
  */
-export const setPending = (suiteId, testObject) => {
-  const { fieldName, groupName } = testObject;
+export const setPending = testObject => {
+  const { fieldName, groupName, suiteId } = testObject;
   const state = getSuiteState(suiteId);
   const { lagging, canceled } = state.lagging.reduce(
     ({ lagging, canceled }, testObject) => {

--- a/packages/vest/src/core/test/lib/pending/spec.js
+++ b/packages/vest/src/core/test/lib/pending/spec.js
@@ -83,7 +83,7 @@ describe('module: pending', () => {
 
     it('Should set supplied test object as pending', () => {
       expect(getSuiteState(suiteId).pending).not.toContain(testObjects[0]);
-      setPending(suiteId, testObjects[0]);
+      setPending(testObjects[0]);
       expect(getSuiteState(suiteId).pending).toContain(testObjects[0]);
     });
 
@@ -101,14 +101,14 @@ describe('module: pending', () => {
 
       it('Should remove test from lagging array', () => {
         expect(getSuiteState(suiteId).lagging).toContain(testObjects[0]);
-        setPending(suiteId, testObjects[0]);
+        setPending(testObjects[0]);
         expect(getSuiteState(suiteId).lagging).not.toContain(testObjects[0]);
         expect(getSuiteState(suiteId)).toMatchSnapshot();
       });
 
       it('Should add test to pending array', () => {
         expect(getSuiteState(suiteId).pending).not.toContain(testObjects[0]);
-        setPending(suiteId, testObjects[0]);
+        setPending(testObjects[0]);
         expect(getSuiteState(suiteId).pending).toContain(testObjects[0]);
       });
 
@@ -116,7 +116,7 @@ describe('module: pending', () => {
         expect(state.get()[KEY_CANCELED]).not.toMatchObject({
           [testObjects[0].id]: true,
         });
-        setPending(suiteId, testObjects[0]);
+        setPending(testObjects[0]);
         expect(state.get()[KEY_CANCELED]).toMatchObject({
           [testObjects[0].id]: true,
         });

--- a/packages/vest/src/core/test/memo.spec.js
+++ b/packages/vest/src/core/test/memo.spec.js
@@ -225,8 +225,8 @@ describe('test.memo', () => {
       it('Should only call test function once', async () => {
         expect(testCb1).not.toHaveBeenCalled();
         await validate('FAIL');
-        await validate('FAIL');
         expect(testCb1).toHaveBeenCalledTimes(1);
+        await validate('FAIL');
       });
 
       it('Should return same test object', async () => {

--- a/packages/vest/src/core/test/runAsyncTest/spec.js
+++ b/packages/vest/src/core/test/runAsyncTest/spec.js
@@ -53,7 +53,7 @@ describe.each([CASE_PASSING, CASE_FAILING])('runAsyncTest: %s', testCase => {
     });
     testObject.asyncTest =
       testCase === CASE_PASSING ? Promise.resolve() : Promise.reject();
-    setPending(suiteId, testObject);
+    setPending(testObject);
   });
 
   afterEach(() => {
@@ -162,7 +162,6 @@ describe.each([CASE_PASSING, CASE_FAILING])('runAsyncTest: %s', testCase => {
     describe('When there are more tests left', () => {
       beforeEach(() => {
         setPending(
-          suiteId,
           new VestTest({
             fieldName: 'pending_field',
             statement: STATEMENT,


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix?         | ✖                                                                        |
| New feature?     | ✖                                                                        |
| Breaking change? | ✖                                                                        |
| Deprecations?    | ✖                                                                        |
| Documentation?   | ✖                                                                        |
| Tests added?     | ✔️                                                                        |

<!-- Describe your changes below in detail. -->

Run async tests immediately after creating them, instead of collecting and then running.

This will simplify skipping them based on draft results.