### PR TITLE
FEAT: get and reset as properties of createSuite result

### DIFF
--- a/packages/vest/src/core/createSuite/index.js
+++ b/packages/vest/src/core/createSuite/index.js
@@ -1,4 +1,5 @@
 import { OPERATION_MODE_STATEFUL } from '../../constants';
+import { get } from '../../hooks';
 import runWithContext from '../../lib/runWithContext';
 import validateSuiteParams from '../../lib/validateSuiteParams';
 import Context from '../Context';
@@ -59,7 +60,7 @@ const createSuite = (name, tests) => {
         value: name,
       },
       get: {
-        value: () => getSuite(name),
+        value: () => get(name),
       },
       reset: {
         value: () => reset(name),

--- a/packages/vest/src/core/createSuite/index.js
+++ b/packages/vest/src/core/createSuite/index.js
@@ -6,6 +6,7 @@ import produce from '../produce';
 import { getSuite } from '../state';
 import getSuiteState from '../state/getSuiteState';
 import registerSuite from '../state/registerSuite';
+import reset from '../state/reset';
 import mergeExcludedTests from '../test/lib/mergeExcludedTests';
 
 /**
@@ -41,7 +42,7 @@ const createSuite = (name, tests) => {
   // returns validator function
   // and sets the function name
   // to the name of the suite
-  return Object.defineProperty(
+  return Object.defineProperties(
     (...args) => {
       const output = runWithContext(ctxRef, context => {
         registerSuite();
@@ -53,8 +54,17 @@ const createSuite = (name, tests) => {
       });
       return output;
     },
-    'name',
-    { value: name }
+    {
+      name: {
+        value: name,
+      },
+      get: {
+        value: () => getSuite(name),
+      },
+      reset: {
+        value: () => reset(name),
+      },
+    }
   );
 };
 

--- a/packages/vest/src/core/createSuite/spec.js
+++ b/packages/vest/src/core/createSuite/spec.js
@@ -2,7 +2,9 @@ import faker from 'faker';
 import { noop } from 'lodash';
 import mock from '../../../../../shared/testUtils/mock';
 import resetState from '../../../testUtils/resetState';
+import { dummyTest } from '../../../testUtils/testDummy';
 import { OPERATION_MODE_STATELESS } from '../../constants';
+import { get } from '../../hooks';
 import runWithContext from '../../lib/runWithContext';
 import { getSuite } from '../state';
 import createSuite from '.';
@@ -92,6 +94,23 @@ describe('Test createSuite module', () => {
       expect(Object.keys(state[0].fieldCallbacks)).toHaveLength(0);
 
       expect(getSuite(suiteId)).toMatchSnapshot();
+    });
+
+    it('Should be able to get the suite from the result of createSuite', () => {
+      const testsCb = jest.fn();
+      const suiteId = 'test_get_suite';
+      expect(createSuite(suiteId, testsCb).get()).toBe(getSuite(suiteId));
+    });
+
+    it('Should be able to reset the suite from the result of createSuite', () => {
+      const suiteId = 'test_reset_suite';
+      const testSuite = createSuite(suiteId, () => {
+        dummyTest.failing('f1', 'm1');
+      });
+      testSuite();
+      expect(get(suiteId).hasErrors()).toBe(true);
+      testSuite.reset();
+      expect(get(suiteId).hasErrors()).toBe(false);
     });
 
     it('Should return without calling tests callback', () => {

--- a/packages/vest/src/core/createSuite/spec.js
+++ b/packages/vest/src/core/createSuite/spec.js
@@ -99,7 +99,7 @@ describe('Test createSuite module', () => {
     it('Should be able to get the suite from the result of createSuite', () => {
       const testsCb = jest.fn();
       const suiteId = 'test_get_suite';
-      expect(createSuite(suiteId, testsCb).get()).toBe(getSuite(suiteId));
+      expect(createSuite(suiteId, testsCb).get()).toBe(get(suiteId));
     });
 
     it('Should be able to reset the suite from the result of createSuite', () => {

--- a/packages/vest/src/core/createSuite/spec.js
+++ b/packages/vest/src/core/createSuite/spec.js
@@ -109,8 +109,10 @@ describe('Test createSuite module', () => {
       });
       testSuite();
       expect(get(suiteId).hasErrors()).toBe(true);
+      expect(get(suiteId).testCount).toBe(1);
       testSuite.reset();
       expect(get(suiteId).hasErrors()).toBe(false);
+      expect(get(suiteId).testCount).toBe(0);
     });
 
     it('Should return without calling tests callback', () => {

--- a/packages/vest/src/vest.d.ts
+++ b/packages/vest/src/vest.d.ts
@@ -315,8 +315,8 @@ declare module 'vest' {
 
   interface ICreateResult {
     (...args: any[]): IVestResult;
-    get: any;
-    reset: any;
+    get: Vest['get'];
+    reset: Vest['reset'];
   }
 
   interface Vest {

--- a/packages/vest/src/vest.d.ts
+++ b/packages/vest/src/vest.d.ts
@@ -313,6 +313,12 @@ declare module 'vest' {
     memo(fieldName: string, testFn: TestCB, dependencies: any[]): VestTest;
   }
 
+  interface ICreateResult {
+    (...args: any[]): IVestResult;
+    get: any;
+    reset: any;
+  }
+
   interface Vest {
     test: ITest;
     enforce: IEnforce;

--- a/packages/vest/src/vest.d.ts
+++ b/packages/vest/src/vest.d.ts
@@ -349,10 +349,7 @@ declare module 'vest' {
      *
      * const res = validate({username: 'example'});
      */
-    create(
-      suiteName: string,
-      tests: (...args: any[]) => void
-    ): (...args: any[]) => IVestResult;
+    create(suiteName: string, tests: (...args: any[]) => void): ICreateResult;
 
     /**
      * Allows grouping tests so you can handle them together


### PR DESCRIPTION
| Q                | A                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix?         | ✖                                                                        |
| New feature?     | ✔                                                                      |
| Breaking change? | ✖                                                                        |
| Deprecations?    | ✖                                                                        |
| Documentation?   | ✖                                                                        |
| Tests added?     | ✔                                                                        |
| Fixed issues     | #315  |

Hi, I followed your advice and load the properties into the function that is beign returned by createSuite, I'm a bit insecure about the changes in the definition file since it's my first contribution to an open source project and I couldn't find any type definition for the reset and get functions. Hope that it helped somehow 