### PR TITLE
conf: skip release on pr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jobs:
         - yarn test
         - yarn lint
     - stage: Release
+      if: type = push AND fork = false
       install: yarn install --frozen-lockfile
       script:
         - echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > ~/.npmrc


### PR DESCRIPTION
Take less time when issuing a pr, avoid needlessly creating a new version.