### PR TITLE
fix: get/reset suite typings

### DIFF
--- a/packages/vest/src/typings/vest.d.ts
+++ b/packages/vest/src/typings/vest.d.ts
@@ -315,8 +315,8 @@ declare module 'vest' {
 
   interface ICreateResult {
     (...args: any[]): IVestResult;
-    get: Vest['get'];
-    reset: Vest['reset'];
+    get: () => ReturnType<Vest['get']>;
+    reset: () => ReturnType<Vest['reset']>;
   }
 
   interface Vest {


### PR DESCRIPTION
| Q                | A                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix?         | ✔                                                                        |
| New feature?     | ✖                                                                        |
| Breaking change? | ✖                                                                        |
| Deprecations?    | ✖                                                                        |
| Documentation?   | ✖                                                                        |
| Tests added?     | ✖                                                                        |
| Fixed issues     |  |

Hello,

I think the get/set of a suite don't have the suite name as parameter.

Gaspar.
