### PR TITLE
added: [n4s] lazy evaluated enforcements

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,9 +2,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "anyOf": [
-        "./packages/__shared/src/anyOf.js"
-      ],
       "isFunction": [
         "./packages/__shared/src/isFunction.js"
       ],

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,6 +2,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "anyOf": [
+        "./packages/__shared/src/anyOf.js"
+      ],
       "isFunction": [
         "./packages/__shared/src/isFunction.js"
       ],

--- a/packages/n4s/src/enforce/__tests__/enforce.test.js
+++ b/packages/n4s/src/enforce/__tests__/enforce.test.js
@@ -80,6 +80,45 @@ const suite = ({ withProxy, requirePath }) =>
       });
     });
 
+    describe('lazy enforcements', () => {
+      it('Should expose all rules on top of the enforce function', () => {
+        allRules.forEach(rule => expect(typeof enforce[rule]).toBe('function'));
+
+        expect(enforce.isAbc).toBeUndefined();
+        enforce.extend({ isAbc: v => v === 'abc' });
+        expect(typeof enforce.isAbc).toBe('function');
+      });
+
+      test('Each rule returns a function', () => {
+        allRules.forEach(rule =>
+          expect(typeof enforce[rule]()).toBe('function')
+        );
+      });
+
+      test('Returned function returns a boolean value', () => {
+        expect(enforce.isArray()([])).toBe(true);
+        expect(enforce.isNumber()('not_a_number')).toBe(false);
+      });
+
+      it("Should use the second function's argument as the enforce value, and the first function's arguments as the ...rest", () => {
+        expect(enforce.isEmpty()([])).toBe(true);
+        expect(enforce.isEmpty()([1, 2, 3])).toBe(false);
+        expect(enforce.isNumeric()('555')).toBe(true);
+        expect(enforce.greaterThan(10)(20)).toBe(true);
+        expect(enforce.greaterThan(10)(4)).toBe(false);
+
+        const fn = jest.fn(() => true);
+
+        enforce.extend({
+          getArgs: fn,
+        });
+
+        enforce.getArgs(2, 3, 4, 5, 6, 7)(1);
+        // One should be first
+        expect(fn).toHaveBeenCalledWith(1, 2, 3, 4, 5, 6, 7);
+      });
+    });
+
     it('Should throw errors on failing enforces', () => {
       const isNumber = () => enforce('a').isNumber(true);
       expect(isNumber).toThrow(Error);

--- a/packages/n4s/src/enforce/enforceRunner.js
+++ b/packages/n4s/src/enforce/enforceRunner.js
@@ -1,4 +1,3 @@
-import isFunction from 'isFunction';
 import { transformResult } from 'transformResult';
 
 /**
@@ -10,10 +9,6 @@ import { transformResult } from 'transformResult';
  * @throws
  */
 function runner(rule, value, ...args) {
-  if (!isFunction(rule)) {
-    return;
-  }
-
   const ruleResult = rule(value, ...args);
   const result = transformResult(ruleResult, { rule, value });
   if (!result.pass) {

--- a/packages/n4s/src/lib/isRule.js
+++ b/packages/n4s/src/lib/isRule.js
@@ -1,18 +1,7 @@
 import isFunction from 'isFunction';
-import throwError from 'throwError';
 
 const isRule = (rulesObject, name) => {
-  const ruleExists =
-    Object.prototype.hasOwnProperty.call(rulesObject, name) &&
-    isFunction(rulesObject[name]);
-
-  if (!ruleExists) {
-    throwError(
-      `Rule "${name}" was not found in rules object. Make sure you typed it correctly.`
-    );
-  }
-
-  return ruleExists;
+  return rulesObject.hasOwnProperty(name) && isFunction(rulesObject[name]);
 };
 
 export default isRule;

--- a/packages/n4s/src/lib/transformResult.js
+++ b/packages/n4s/src/lib/transformResult.js
@@ -38,17 +38,15 @@ export function transformResult(result, { rule, value }) {
 
   // if result is boolean
   if (!!result === result) {
-    return { ...defaultResult, pass: result };
+    return (defaultResult.pass = result), defaultResult;
   } else {
-    const formattedResult = {
-      pass: result.pass,
-    };
+    defaultResult.pass = result.pass;
     if (result.message) {
-      formattedResult.message = formatResultMessage(
+      defaultResult.message = formatResultMessage(
         rule,
         isFunction(result.message) ? result.message() : result.message
       );
     }
-    return { ...defaultResult, ...formattedResult };
+    return defaultResult;
   }
 }

--- a/packages/vest/src/index.js
+++ b/packages/vest/src/index.js
@@ -1,6 +1,5 @@
-import enforce from 'n4s';
-
 import create from 'createSuite';
+import enforce from 'enforce';
 import { only, skip, warn, group } from 'hooks';
 import test from 'test';
 

--- a/packages/vest/src/index.mjs
+++ b/packages/vest/src/index.mjs
@@ -1,6 +1,5 @@
-import enforce from 'n4s';
-
 import create from 'createSuite';
+import enforce from 'enforce';
 import { only, skip, warn, group } from 'hooks';
 import test from 'test';
 


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix?         | ✖                                                                        |
| New feature?     | ✔                                                                        |
| Breaking change? | ✖                                                                        |
| Deprecations?    | ✖                                                                        |
| Documentation?   | ✖                                                                        |
| Tests added?     | ✔                                                                        |
| Fixed issues     | comma-separated list of issues fixed by the pull request, where applicable |

<!-- Describe your changes below in detail. -->

Lazy interface for enforce, this is created as preparation for the compound rules.

Useage:

```
enforce.equals(1)(0) // false
enforce.equals(1)(1) // true
```

Will be actually used like this:

```
enforce(x).any(
  enforce.greaterThan(5),
  enforce.lessThan(0)
);
```