### PR TITLE
minor: Add shape validator

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,6 +2,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "asArray": [
+        "./packages/__shared/src/asArray.js"
+      ],
       "isFunction": [
         "./packages/__shared/src/isFunction.js"
       ],
@@ -10,6 +13,15 @@
       ],
       "throwError": [
         "./packages/__shared/src/throwError.js"
+      ],
+      "compounds": [
+        "./packages/n4s/src/enforce/compounds/compounds.js"
+      ],
+      "optional": [
+        "./packages/n4s/src/enforce/compounds/optional.js"
+      ],
+      "shape": [
+        "./packages/n4s/src/enforce/compounds/shape.js"
       ],
       "enforce": [
         "./packages/n4s/src/enforce/enforce.js"

--- a/packages/__shared/src/asArray.js
+++ b/packages/__shared/src/asArray.js
@@ -1,0 +1,3 @@
+export default function asArray(possibleArg) {
+  return [].concat(possibleArg);
+}

--- a/packages/n4s/docs/_sidebar.md
+++ b/packages/n4s/docs/_sidebar.md
@@ -1,5 +1,6 @@
 - [Main](./)
 - [List of Enforce Rules](./rules)
 - [Business reated rules](./business_rules)
+- [Schema validations](./shape)
 - [Custom Enforce Rules](./custom)
 - [Non throwing validations (ensure)](./ensure)

--- a/packages/n4s/docs/custom.md
+++ b/packages/n4s/docs/custom.md
@@ -16,8 +16,6 @@ enforce.extend({
 ```
 
 ```js
-import { enforce } from 'n4s';
-
 enforce.extend({
   isValidEmail: value => value.indexOf('@') > -1,
   hasKey: (value, key) => value.hasOwnProperty(key),

--- a/packages/n4s/docs/shape.md
+++ b/packages/n4s/docs/shape.md
@@ -1,0 +1,80 @@
+# Shape validations
+
+Enforce (only, not ensure) comes with a built-in lean schema validator rule called `shape`. It allows you to use all the existing and custom rules of enforce to validate the shape of an object.
+
+When using enforce rules inside your shape, use the rules that exist as properties on enforce itself (`enforce.isString()`). For rules used like this, rule chaining is not possible.
+
+## Example
+
+```js
+enforce({
+  firstName: 'Rick',
+  lastName: 'Sanchez',
+  age: 70
+}).shape({
+  firstName: enforce.isString(),
+  lastName: enforce.isString(),
+  age: enforce.isNumber()
+});
+```
+
+## Testing multiple rules for the same key
+
+To test multiple rules with the same key use an array of rules:
+
+```js
+enforce({
+  age: 22
+}).shape({
+  age: [enforce.isNumber(), enforce.isBetween(0, 150)]
+});
+```
+
+## Deeply nested data objects:
+
+To deeply nest shape calls, just use them as any other rules inside shape:
+
+```js
+enforce({
+  user: {
+    name: {
+      first: 'Joseph',
+      last: 'Weil',
+    }
+  }
+}).shape({
+  user: enforce.shape({
+    name: enforce.shape({
+      first: enforce.isString(),
+      last: enforce.isString()
+    })
+  })
+});
+```
+
+## Marking a field as optional
+
+In regular cases, a missing key in the data object would cause an error to be thrown. To prevent that from happening, mark your optional keys with `enforce.optional`.
+
+enforce.optional will pass a key that's either not defined, undefined or null.
+
+`enforce.optional` takes as its arguments all the rules that the value should pass - only if it is present. If it is not present in the data object.
+
+```js
+enforce({
+  user: {
+    name: {
+      first: 'Joseph',
+      last: 'Weil',
+    }
+  }
+}).shape({
+  user: enforce.shape({
+    name: enforce.shape({
+      first: enforce.isString(),
+      last: enforce.isString(),
+      middle: enforce.optional(enforce.isString(), enforce.longerThan(3))
+    })
+  })
+});
+```

--- a/packages/n4s/docs/shape.md
+++ b/packages/n4s/docs/shape.md
@@ -56,7 +56,7 @@ enforce({
 
 In regular cases, a missing key in the data object would cause an error to be thrown. To prevent that from happening, mark your optional keys with `enforce.optional`.
 
-enforce.optional will pass a key that's either not defined, undefined or null.
+enforce.optional will pass validations of a key that's either not defined, undefined or null.
 
 `enforce.optional` takes as its arguments all the rules that the value should pass - only if it is present. If it is not present in the data object.
 

--- a/packages/n4s/src/enforce/compounds/__tests__/shape.test.js
+++ b/packages/n4s/src/enforce/compounds/__tests__/shape.test.js
@@ -1,0 +1,321 @@
+import faker from 'faker';
+
+import enforce from 'enforce';
+import shape from 'shape';
+
+describe('Shape validation', () => {
+  describe('Base behavior', () => {
+    it('Should fail when encountered a mis-shapen property', () => {
+      expect(
+        shape(
+          { name: 99 },
+          {
+            name: enforce.isString(),
+          }
+        )
+      ).toBe(false);
+      expect(
+        shape(
+          { count: 500 },
+          {
+            count: enforce.isBetween(10, 20),
+          }
+        )
+      ).toBe(false);
+      expect(
+        shape(
+          { count: 500, isOnline: true },
+          {
+            count: enforce.equals(500),
+            isOnline: enforce.equals(false),
+          }
+        )
+      ).toBe(false);
+    });
+
+    it('Should pass when no mis-shapen property', () => {
+      expect(
+        shape(
+          { name: '99' },
+          {
+            name: enforce.isString(),
+          }
+        )
+      ).toBe(true);
+      expect(
+        shape(
+          { count: 500 },
+          {
+            count: enforce.isBetween(400, 600),
+          }
+        )
+      ).toBe(true);
+      expect(
+        shape(
+          { count: 500, isOnline: true },
+          {
+            count: enforce.equals(500),
+            isOnline: enforce.equals(true),
+          }
+        )
+      ).toBe(true);
+    });
+
+    it('Allows array of enforcements per field', () => {
+      expect(
+        shape(
+          {
+            friendCount: 200,
+          },
+          {
+            friendCount: [
+              enforce.isNumber(),
+              enforce.greaterThan(150),
+              enforce.equals(200),
+            ],
+          }
+        )
+      ).toBe(true);
+      expect(
+        shape(
+          {
+            friendCount: 200,
+          },
+          {
+            friendCount: [
+              enforce.isNumber(),
+              enforce.greaterThan(150),
+              enforce.equals(300),
+            ],
+          }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('shape nesting', () => {
+    it('Should allow deeply nested shape calls', () => {
+      expect(
+        shape(
+          {
+            user: {
+              id: '000',
+              details: {
+                age: 99,
+                name: {
+                  first: 'John',
+                  last: 'Doe',
+                },
+              },
+            },
+          },
+          {
+            user: enforce.shape({
+              id: enforce.equals('000'),
+              details: enforce.shape({
+                age: enforce.isNumber(),
+                name: enforce.shape({
+                  first: enforce.isString(),
+                  last: enforce.isString(),
+                }),
+              }),
+            }),
+          }
+        )
+      ).toBe(true);
+      expect(
+        shape(
+          {
+            user: {
+              id: '000',
+              details: {
+                age: 99,
+                name: {
+                  first: 'John',
+                  last: null,
+                },
+              },
+            },
+          },
+          {
+            user: enforce.shape({
+              id: enforce.equals('000'),
+              details: enforce.shape({
+                age: enforce.isNumber(),
+                name: enforce.shape({
+                  first: enforce.isString(),
+                  last: enforce.isString(),
+                }),
+              }),
+            }),
+          }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('When field is in data but not in shape', () => {
+    it('Should fail', () => {
+      expect(
+        shape(
+          { user: 'example', password: 'x123' },
+          { user: enforce.isString(), password: enforce.endsWith('23') }
+        )
+      ).toBe(true);
+      expect(
+        shape(
+          { user: 'example', password: 'x123' },
+          { user: enforce.isString() }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('When field is in shape but not in data', () => {
+    it('Should fail', () => {
+      expect(
+        shape(
+          { user: 'example' },
+          { user: enforce.isString(), password: enforce.startsWith('x') }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('Handling of optional fields', () => {
+    it('Should allow optional fields to not be defined', () => {
+      expect(
+        shape(
+          { user: 'example', confirm: 'example' },
+          {
+            user: enforce.isString(),
+            password: enforce.optional(),
+            confirm: enforce.optional(),
+          }
+        )
+      ).toBe(true);
+    });
+
+    it('Should allow optional fields to be undefined', () => {
+      expect(
+        shape(
+          { user: 'example', confirm: undefined },
+          {
+            user: enforce.isString(),
+            confirm: enforce.optional(),
+          }
+        )
+      ).toBe(true);
+    });
+    it('Should allow optional fields to be null', () => {
+      expect(
+        shape(
+          { user: 'example', confirm: null },
+          {
+            user: enforce.isString(),
+            confirm: enforce.optional(),
+          }
+        )
+      ).toBe(true);
+    });
+
+    it('enforces rules on optional when value is defined', () => {
+      expect(
+        shape(
+          { user: 'example', nickname: '1111' },
+          {
+            user: enforce.isString(),
+            nickname: enforce.optional(
+              enforce.isString(),
+              enforce.isNotNumeric()
+            ),
+          }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('As part of enforce', () => {
+    it('Should validate object shape correctly', () => {
+      enforce({
+        user: {
+          age: faker.random.number(10),
+          friends: [1, 2, 3, 4, 5],
+          id: faker.random.uuid(),
+          name: {
+            first: faker.name.firstName(),
+            last: faker.name.lastName(),
+          },
+          username: faker.internet.userName(),
+        },
+      }).shape(shapeRules());
+
+      enforce({
+        user: {
+          age: faker.random.number(5),
+          id: faker.random.uuid(),
+          name: {
+            first: faker.name.firstName(),
+            middle: 'some name',
+            last: faker.name.lastName(),
+          },
+          username: faker.internet.userName(),
+        },
+      }).shape(shapeRules());
+
+      expect(() =>
+        enforce({
+          user: {
+            age: 55, // 55 is not between 0-10
+            id: faker.random.uuid(),
+            name: {
+              first: faker.name.firstName(),
+              middle: 'some name',
+              last: faker.name.lastName(),
+            },
+            username: faker.internet.userName(),
+          },
+        }).shape(shapeRules())
+      ).toThrow();
+
+      expect(() =>
+        enforce({
+          user: {
+            age: 5,
+            id: faker.random.uuid(),
+            name: {
+              first: faker.name.firstName(),
+              middle: 'some name',
+              last: faker.name.lastName(),
+            },
+            username: [1, 2, 3], // array instead of a string
+          },
+        }).shape(shapeRules())
+      ).toThrow();
+
+      expect(() =>
+        enforce({
+          user: {
+            age: 5,
+            id: faker.random.uuid(),
+            username: 'example',
+          },
+        }).shape(shapeRules())
+      ).toThrow();
+    });
+  });
+});
+
+const shapeRules = () => ({
+  user: enforce.shape({
+    age: [enforce.isNumber(), enforce.isBetween(0, 10)],
+    friends: enforce.optional(enforce.isArray()),
+    id: enforce.isString(),
+    name: enforce.shape({
+      first: enforce.isString(),
+      last: enforce.isString(),
+      middle: enforce.optional(enforce.isString()),
+    }),
+    username: enforce.isString(),
+  }),
+});

--- a/packages/n4s/src/enforce/compounds/compounds.js
+++ b/packages/n4s/src/enforce/compounds/compounds.js
@@ -1,0 +1,7 @@
+import optional from 'optional';
+import shape from 'shape';
+
+export default {
+  optional,
+  shape,
+};

--- a/packages/n4s/src/enforce/compounds/optional.js
+++ b/packages/n4s/src/enforce/compounds/optional.js
@@ -1,0 +1,17 @@
+import { isNull } from 'isNull';
+import { isUndefined } from 'isUndefined';
+
+/**
+ * @param {Array} ObjectEntry   Object and key leading to current value
+ * @param {Function[]} rules    Rules to validate the value with
+ */
+export default function optional([obj, key], ...rules) {
+  if (
+    !Object.prototype.hasOwnProperty.call(obj, key) ||
+    isUndefined(obj[key] || isNull(obj[key]))
+  ) {
+    return true;
+  }
+
+  return rules.every(fn => fn(obj[key]));
+}

--- a/packages/n4s/src/enforce/compounds/shape.js
+++ b/packages/n4s/src/enforce/compounds/shape.js
@@ -1,0 +1,29 @@
+import asArray from 'asArray';
+import optional from 'optional';
+
+/**
+ * @param {Object} obj  Data object that gets validated
+ * @param {*} shapeObj  Shape definition
+ */
+export default function shape(obj, shapeObj) {
+  for (const key in shapeObj) {
+    const current = shapeObj[key];
+    const value = obj[key];
+
+    if (
+      !asArray(current).every(fn =>
+        fn(fn.name === optional.name ? [obj, key] : value)
+      )
+    ) {
+      return false;
+    }
+  }
+
+  for (const key in obj) {
+    if (!shapeObj[key]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/n4s/src/enforce/enforce.js
+++ b/packages/n4s/src/enforce/enforce.js
@@ -1,14 +1,21 @@
+import compounds from 'compounds';
+
 import runner from 'enforceRunner';
 import isRule from 'isRule';
 import proxySupported from 'proxySupported';
 import rules from 'rules';
 
-const rulesObject = rules();
+const rulesObject = Object.assign(rules(), compounds);
 
 let enforce, rulesList;
 
-const bindLazyRule = ruleName => (...args) => value =>
-  rulesObject[ruleName](value, ...args);
+const bindLazyRule = ruleName => (...args) => {
+  return Object.defineProperty(
+    value => rulesObject[ruleName](value, ...args),
+    'name',
+    { value: ruleName }
+  );
+};
 
 const bindLazyRules = rules =>
   rules.reduce(

--- a/packages/n4s/src/enforce/enforce.js
+++ b/packages/n4s/src/enforce/enforce.js
@@ -1,5 +1,4 @@
 import compounds from 'compounds';
-
 import runner from 'enforceRunner';
 import isRule from 'isRule';
 import proxySupported from 'proxySupported';

--- a/packages/n4s/src/lib/transformResult.js
+++ b/packages/n4s/src/lib/transformResult.js
@@ -18,7 +18,7 @@ export function getDefaultResult(value, rule) {
 }
 
 export function formatResultMessage(rule, msg) {
-  return `[${LIBRARY_NAME}]/${rule.name} ${msg}`;
+  return `[${LIBRARY_NAME}]:${rule.name} ${msg}`;
 }
 
 /**

--- a/packages/vest/README.md
+++ b/packages/vest/README.md
@@ -2,16 +2,23 @@
 
 # Vest 🦺 Declarative Validation Testing
 
+![Github Stars](https://githubbadges.com/star.svg?user=ealush&repo=vest&style=flat)
+![Npm downloads](https://img.shields.io/npm/dt/vest?label=Downloads&logo=npm)
+
 [![npm version](https://badge.fury.io/js/vest.svg)](https://badge.fury.io/js/vest) [![Build Status](https://travis-ci.org/ealush/vest.svg?branch=latest)](https://travis-ci.org/ealush/vest) [![Known Vulnerabilities](https://snyk.io/test/npm/vest/badge.svg)](https://snyk.io/test/npm/vest)
+![minifiedSize](https://img.shields.io/bundlephobia/min/vest?color=blue&logo=npm)
+
+![Join discord](https://img.shields.io/discord/757686103292641312?label=Join%20Discord&logo=discord&logoColor=green)
 
 - [Documentation homepage](https://ealush.github.io/vest)
 - **Try vest live**
   - [Vanilla JS Example](https://stackblitz.com/edit/vest-vanilla-support-example?file=validation.js)
   - ReactJS Examples:
     - [Example 1 (groups)](https://codesandbox.io/s/ecstatic-waterfall-4i2ne?file=/src/validate.js)
-    - [Exmaple 2 (Async)](https://codesandbox.io/s/youthful-williamson-loijb?file=/src/validate.js)
+    - [Example 2 (Async)](https://codesandbox.io/s/youthful-williamson-loijb?file=/src/validate.js)
     - [Example 3](https://stackblitz.com/edit/vest-react-support-example?file=validation.js)
     - [Example 4](https://stackblitz.com/edit/vest-react-registration?file=validate.js)
+    - [Example 5 (Password validator)](https://codesandbox.io/s/password-validator-example-6puvy?file=/src/validate.js)
   - [VueJS Example](https://codesandbox.io/s/vest-vue-example-1j6r8?file=/src/validations.js)
 
 ## Tutorials
@@ -27,7 +34,7 @@ It works great with user-input validation and with validating upon user interact
 
 The idea behind Vest is that your validations can be described as a 'spec' or a contract that reflects your form or feature structure. Your validations run in production, and they are framework agnostic - meaning Vest works well with React, Angular, Vue, or even without a framework at all.
 
-Using Vest for form validation can reduce bloat, improve feature redability and maintainability.
+Using Vest for form validation can reduce bloat, improve feature readability and maintainability.
 
 **Basic Example**
 ![full](https://cdn.jsdelivr.net/gh/ealush/vest@assets/demos/full_3.gif 'full')

--- a/packages/vest/docs/README.md
+++ b/packages/vest/docs/README.md
@@ -2,16 +2,23 @@
 
 # Vest 🦺 Declarative Validation Testing
 
+![Github Stars](https://githubbadges.com/star.svg?user=ealush&repo=vest&style=flat)
+![Npm downloads](https://img.shields.io/npm/dt/vest?label=Downloads&logo=npm)
+
 [![npm version](https://badge.fury.io/js/vest.svg)](https://badge.fury.io/js/vest) [![Build Status](https://travis-ci.org/ealush/vest.svg?branch=latest)](https://travis-ci.org/ealush/vest) [![Known Vulnerabilities](https://snyk.io/test/npm/vest/badge.svg)](https://snyk.io/test/npm/vest)
+![minifiedSize](https://img.shields.io/bundlephobia/min/vest?color=blue&logo=npm)
+
+![Join discord](https://img.shields.io/discord/757686103292641312?label=Join%20Discord&logo=discord&logoColor=green)
 
 - [Documentation homepage](https://ealush.github.io/vest)
 - **Try vest live**
   - [Vanilla JS Example](https://stackblitz.com/edit/vest-vanilla-support-example?file=validation.js)
   - ReactJS Examples:
     - [Example 1 (groups)](https://codesandbox.io/s/ecstatic-waterfall-4i2ne?file=/src/validate.js)
-    - [Exmaple 2 (Async)](https://codesandbox.io/s/youthful-williamson-loijb?file=/src/validate.js)
+    - [Example 2 (Async)](https://codesandbox.io/s/youthful-williamson-loijb?file=/src/validate.js)
     - [Example 3](https://stackblitz.com/edit/vest-react-support-example?file=validation.js)
     - [Example 4](https://stackblitz.com/edit/vest-react-registration?file=validate.js)
+    - [Example 5 (Password validator)](https://codesandbox.io/s/password-validator-example-6puvy?file=/src/validate.js)
   - [VueJS Example](https://codesandbox.io/s/vest-vue-example-1j6r8?file=/src/validations.js)
 
 ## Tutorials
@@ -27,7 +34,7 @@ It works great with user-input validation and with validating upon user interact
 
 The idea behind Vest is that your validations can be described as a 'spec' or a contract that reflects your form or feature structure. Your validations run in production, and they are framework agnostic - meaning Vest works well with React, Angular, Vue, or even without a framework at all.
 
-Using Vest for form validation can reduce bloat, improve feature redability and maintainability.
+Using Vest for form validation can reduce bloat, improve feature readability and maintainability.
 
 **Basic Example**
 ![full](https://cdn.jsdelivr.net/gh/ealush/vest@assets/demos/full_3.gif 'full')

--- a/packages/vest/docs/enforce.md
+++ b/packages/vest/docs/enforce.md
@@ -22,11 +22,13 @@ enforce(4)
 
 - [List of Enforce rules](#list-of-enforce-rules) - All default enforce rules
 - [Custom Enforce Rules](#custom-enforce-rules) - How to extend enforce with your rules
+- [Shape (schema) validation](#shape-validations) - Validating she shape of an object
 - [Business Related Rules](#business-related-rules) - Using more rules such as isEmail and isCreditCard
 
 Enforce exposes all predefined and custom rules. You may use chaining to make multiple enfocements for the same value.
 
-# List of Enforce rules
+
+## List of Enforce rules
 
 Enforce rules are functions that allow you to test your data against different criteria. The following rules are supported out-of-the-box.
 
@@ -76,9 +78,9 @@ Enforce rules are functions that allow you to test your data against different c
 - [isNegative](#isnegative)
 - [isPositive](#ispositive)
 
-## equals
+### equals
 
-### Description
+#### Description
 
 Checks if your enforced value <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#Strict_equality_using" target="_blank">strictly equals</a> (`===`) another.
 
@@ -86,11 +88,11 @@ It is not recommended to use this rule to compare arrays or objects, as it does 
 
 For numeric value comparison, you should use `numberEquals`, which coerces numeric strings into numbers before comparing.
 
-### Arguments
+#### Arguments
 
 - `value`: Any value you wish to check your enforced value against
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(1).equals(1);
@@ -109,15 +111,15 @@ enforce([1, 2, 3]).equals([1, 2, 3]);
 // throws
 ```
 
-## notEquals
+### notEquals
 
-### Description
+#### Description
 
 Checks if your enforced value does not <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#Strict_equality_using" target="_blank">strictly equal</a> (`===`) another.
 
 Reverse implementation of `equals`.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce('1').notEquals(1);
@@ -135,9 +137,9 @@ enforce(a).notEquals(a);
 // throws
 ```
 
-## isEmpty
+### isEmpty
 
-### Description
+#### Description
 
 Checks if your enforced value is empty, false, zero, null or undefined.
 
@@ -149,7 +151,7 @@ Expected results are:
 - boolean: `false` is empty.
 - undefined/null: are both empty.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce([]).isEmpty();
@@ -172,14 +174,14 @@ enforce(true).isEmpty();
 // throws
 ```
 
-## isNotEmpty
+### isNotEmpty
 
-### Description
+#### Description
 
 Checks that your enforced value is not empty, false, or zero.
 Reverse implementation of `isEmpty`.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce([1]).isNotEmpty();
@@ -196,13 +198,13 @@ enforce(0).isNotEmpty();
 // throws
 ```
 
-## isNumeric
+### isNumeric
 
-### Description
+#### Description
 
 Checks if a value is a representation of a real number
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(143).isNumeric();
@@ -217,14 +219,14 @@ enforce('hi').isNumeric();
 // throws
 ```
 
-## isNotNumeric
+### isNotNumeric
 
-### Description
+#### Description
 
 Checks if a value is not a representation of a real number.
 Reverse implementation of `isNumeric`.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(NaN).isNotNumeric();
@@ -238,21 +240,21 @@ enforce('42').isNotNumeric();
 // throws
 ```
 
-## greaterThan
+### greaterThan
 
 - alias: `gt`
 
-### Description
+#### Description
 
 Checks that your numeric enforced value is larger than a given numeric value.
 
-### Arguments
+#### Arguments
 
 - `value`: `number | string` | A numeric value against which you want to check your enforced value.
 
 Strings are parsed using `Number()`, values which are not fully numeric always return false;
 
-### Usage
+#### Usage
 
 ```js
 enforce(1).greaterThan(0);
@@ -268,21 +270,21 @@ enforce([100]).gt(1);
 // throws
 ```
 
-## greaterThanOrEquals
+### greaterThanOrEquals
 
 - alias: `gte()`
 
-### Description
+#### Description
 
 Checks that your numeric enforced value is larger than or equals to a given numeric value.
 
-### Arguments
+#### Arguments
 
 - `value`: `number | string` | A numeric value against which you want to check your enforced value.
 
 Strings are parsed using `Number()`, values which are not fully numeric always return false;
 
-### Usage
+#### Usage
 
 ```js
 enforce(1).greaterThanOrEquals(0);
@@ -301,13 +303,13 @@ enforce([100]).gte(1);
 // throws
 ```
 
-## lengthEquals
+### lengthEquals
 
-### Description
+#### Description
 
 Checks that your enforced value is equal to the given number.
 
-### Arguments
+#### Arguments
 
 - `size`: `number` | the number which you would like your initial value to be tested against.
 
@@ -316,7 +318,7 @@ The `value` argument can be of the following types:
 - array: checks against length.
 - string: checks against length.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce([1]).lengthEquals(1);
@@ -330,14 +332,14 @@ enforce('').lengthEquals(1);
 // throws
 ```
 
-## lengthNotEquals
+### lengthNotEquals
 
-### Description
+#### Description
 
 Checks that your enforced value is not equal to the given number.
 Reverse implementation of `lengthEquals`.
 
-### Arguments
+#### Arguments
 
 - `size`: `number` | the number which you would like your initial value to be tested against.
 
@@ -346,7 +348,7 @@ The `value` argument can be of the following types:
 - array: checks against length.
 - string: checks against length.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce([1]).lengthNotEquals(0);
@@ -360,21 +362,21 @@ enforce('').lengthNotEquals(0);
 // throws
 ```
 
-## lessThan
+### lessThan
 
 - alias: `lt()`
 
-### Description
+#### Description
 
 Checks that your numeric enforced value is smaller than a given numeric value.
 
-### Arguments
+#### Arguments
 
 - `value`: `number | string` | A numeric value against which you want to check your enforced value.
 
 Strings are parsed using `Number()`, values which are not fully numeric always return false;
 
-### Usage
+#### Usage
 
 ```js
 enforce(0).lessThan(1);
@@ -390,21 +392,21 @@ enforce([0]).lt(1);
 // throws
 ```
 
-## lessThanOrEquals
+### lessThanOrEquals
 
 - alias: `lte()`
 
-### Description
+#### Description
 
 Checks that your numeric enforced value is smaller than or equals to a given numeric value.
 
-### Arguments
+#### Arguments
 
 - `value`: `number | string` | A numeric value against which you want to check your enforced value.
 
 Strings are parsed using `Number()`, values which are not fully numeric always return false;
 
-### Usage
+#### Usage
 
 ```js
 enforce(0).lessThanOrEquals(1);
@@ -421,13 +423,13 @@ enforce([0]).lte(1);
 // throws
 ```
 
-## longerThan
+### longerThan
 
-### Description
+#### Description
 
 Checks that your enforced value is longer than a given number.
 
-### Arguments
+#### Arguments
 
 - `size`: `number` | the number which you would like your initial value to be tested against.
 
@@ -436,7 +438,7 @@ The `value` argument can be of the following types:
 - array: checks against length.
 - string: checks against length.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce([1]).longerThan(0);
@@ -450,13 +452,13 @@ enforce('').longerThan(0);
 // throws
 ```
 
-## longerThanOrEquals
+### longerThanOrEquals
 
-### Description
+#### Description
 
 Checks that your enforced value is longer than or equals to a given number.
 
-### Arguments
+#### Arguments
 
 - `size`: `number` | the number which you would like your initial value to be tested against.
 
@@ -465,7 +467,7 @@ The `value` argument can be of the following types:
 - array: checks against length.
 - string: checks against length.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce([1]).longerThanOrEquals(0);
@@ -481,19 +483,19 @@ enforce('').longerThanOrEquals(1);
 // throws
 ```
 
-## numberEquals
+### numberEquals
 
-### Description
+#### Description
 
 Checks that your numeric enforced value is equals another value.
 
-### Arguments
+#### Arguments
 
 - `value`: `number | string` | A numeric value against which you want to check your enforced value.
 
 Strings are parsed using `Number()`, values which are not fully numeric always return false;
 
-### Usage
+#### Usage
 
 ```js
 enforce(0).numberEquals(0);
@@ -508,20 +510,20 @@ enforce([0]).numberEquals(1);
 // throws
 ```
 
-## numberNotEquals
+### numberNotEquals
 
-### Description
+#### Description
 
 Checks that your numeric enforced value does not equal another value.
 Reverse implementation of `numberEquals`.
 
-### Arguments
+#### Arguments
 
 - `value`: `number | string` | A numeric value against which you want to check your enforced value.
 
 Strings are parsed using `Number()`, values which are not fully numeric always return false;
 
-### Usage
+#### Usage
 
 ```js
 enforce(2).numberNotEquals(0);
@@ -535,13 +537,13 @@ enforce('110').numberNotEquals(100);
 // throws
 ```
 
-## shorterThan
+### shorterThan
 
-### Description
+#### Description
 
 Checks that your enforced value is shorter than a given number.
 
-### Arguments
+#### Arguments
 
 - `size`: `number` | the number which you would like your initial value to be tested against.
 
@@ -550,7 +552,7 @@ The `value` argument can be of the following types:
 - array: checks against length.
 - string: checks against length.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce([]).shorterThan(1);
@@ -564,13 +566,13 @@ enforce('').shorterThan(0);
 // throws
 ```
 
-## shorterThanOrEquals
+### shorterThanOrEquals
 
-### Description
+#### Description
 
 Checks that your enforced value is shorter than or equals to a given number.
 
-### Arguments
+#### Arguments
 
 - `size`: `number` | the number which you would like your initial value to be tested against.
 
@@ -579,9 +581,9 @@ The `value` argument can be of the following types:
 - array: checks against length.
 - string: checks against length.
 
-### Usage examples:
+#### Usage examples:
 
-#### Passing examples:
+##### Passing examples:
 
 ```js
 enforce([]).shorterThanOrEquals(1);
@@ -597,17 +599,17 @@ enforce('ab').shorterThanOrEquals(1);
 // throws
 ```
 
-## matches
+### matches
 
-### Description
+#### Description
 
 Checks if a value contains a regex match.
 
-### Arguments
+#### Arguments
 
 - `regexp`: either a `RegExp` object, or a RegExp valid string
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(1984).matches(/[0-9]/);
@@ -625,14 +627,14 @@ enforce('ninety eighty four').matches('[0-9]');
 // throws
 ```
 
-## notMatches
+### notMatches
 
-### Description
+#### Description
 
 Checks if a value does not contain a regex match.
 Reverse implementation of `matches`.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(1984).notMatches(/[0-9]/);
@@ -644,9 +646,9 @@ enforce('ninety eighty four').notMatches('[0-9]');
 // passes
 ```
 
-## inside
+### inside
 
-### Description
+#### Description
 
 Checks if your enforced value is contained in another array or string.
 Your enforced value can be of the following types:
@@ -655,13 +657,13 @@ Your enforced value can be of the following types:
 - `number`
 - `boolean`
 
-### Arguments
+#### Arguments
 
 - `container`: a `string` or an `array` which may contain the value specified.
 
-### Usage examples:
+#### Usage examples:
 
-#### inside: array
+##### inside: array
 
 Checks for membership in an array.
 
@@ -701,7 +703,7 @@ enforce(true).inside([1, 2, 3]);
 // throws
 ```
 
-#### inside: string
+##### inside: string
 
 - string: checks if a string is inside another string
 
@@ -715,14 +717,14 @@ enforce('ad').inside('tru dat.');
 // throws
 ```
 
-## notInside
+### notInside
 
-### Description
+#### Description
 
 Checks if a given value is not contained in another array or string.
 Reverse implementation of `inside`.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce('ad').notInside('tru dat.');
@@ -736,9 +738,9 @@ enforce('da').notInside('tru dat.');
 // throws
 ```
 
-## isTruthy
+### isTruthy
 
-### Description
+#### Description
 
 Checks if a value is truthy; Meaning: if it can be coerced into boolean `true`.
 Anything not in the following list is considered to be truthy.
@@ -750,7 +752,7 @@ Anything not in the following list is considered to be truthy.
 - `NaN`
 - empty string (`""`)
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce('hello').isTruthy();
@@ -769,9 +771,9 @@ enforce('').isTruthy();
 // throws
 ```
 
-## isFalsy
+### isFalsy
 
-### Description
+#### Description
 
 Checks if a value is falsy; Meaning: if it can be coerced into boolean `false`.
 Reverse implementation of `isTruthy`.
@@ -785,7 +787,7 @@ Anything not in the following list is considered to be truthy:
 - `NaN`
 - empty string (`""`)
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(false).isFalsy();
@@ -801,13 +803,13 @@ enforce('hi').isFalsy();
 // throws
 ```
 
-## isArray
+### isArray
 
-### Description
+#### Description
 
 Checks if a value is of type `Array`.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(['hello']).isArray();
@@ -819,14 +821,14 @@ enforce('hello').isArray();
 // throws
 ```
 
-## isNotArray
+### isNotArray
 
-### Description
+#### Description
 
 Checks if a value is of any type other than `Array`.
 Reverse implementation of `isArray`.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(['hello']).isNotArray();
@@ -838,14 +840,14 @@ enforce('hello').isNotArray();
 // passes
 ```
 
-## isNumber
+### isNumber
 
-### Description
+#### Description
 
 Checks if a value is of type `number`.
 Equals to `typeof value === 'number'`
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(143).isNumber();
@@ -859,16 +861,16 @@ enforce('143').isNumber();
 // throws
 ```
 
-## isNotNumber
+### isNotNumber
 
-### Description
+#### Description
 
 Checks if a value is of any type other than `number`.
 Reverse implementation of `isNumber`.
 
 **note** isNotNumber does not check for `NaN` value. For NaN values, use [isNaN](#isNaN).
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce('143').isNotNumber();
@@ -882,13 +884,13 @@ enforce(NaN).isNotNumber(); // throws (NaN is of type 'number!')
 // throws
 ```
 
-## isNaN
+### isNaN
 
-### Description
+#### Description
 
 A wrapper around JavaScripts Number.isNaN() function. Checks if a value is NaN.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(NaN).isNaN();
@@ -903,13 +905,13 @@ enforce('1984').isNaN();
 // throws
 ```
 
-## isNotNaN
+### isNotNaN
 
-### Description
+#### Description
 
 Reverse implementation of `isNaN`. Checks that a value is not NaN.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(null * null).isNaN(); // null*null = 0
@@ -924,13 +926,13 @@ enforce('A' / 'B').isNaN();
 // throws
 ```
 
-## isNull
+### isNull
 
-### Description
+#### Description
 
 Enforces that a specified value is `null`.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(null).isNull();
@@ -943,13 +945,13 @@ enforce(true).isNull();
 // throws
 ```
 
-## isNotNull
+### isNotNull
 
-### Description
+#### Description
 
 Reverse implementation of `isNull`. Checks that a value is not null.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce('hello').isNull();
@@ -962,13 +964,13 @@ enforce(null).isNull();
 // throws
 ```
 
-## isString
+### isString
 
-### Description
+#### Description
 
 Checks if a value is of type `String`.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce('hello').isString();
@@ -981,14 +983,14 @@ enforce(1984).isString();
 // throws
 ```
 
-## isNotString
+### isNotString
 
-### Description
+#### Description
 
 Checks if a value is of any type other than `String`.
 Reverse implementation of `isString`.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce('hello').isNotString();
@@ -1000,13 +1002,13 @@ enforce(['hello']).isNotString();
 // passes
 ```
 
-## isUndefined
+### isUndefined
 
-### Description
+#### Description
 
 Enforces that a given value is (`===`) undefined.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce().isUndefined();
@@ -1020,13 +1022,13 @@ enforce(true).isUndefined();
 // throws
 ```
 
-## isOdd
+### isOdd
 
-### Description
+#### Description
 
 Checks if a value is an odd numeric value.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce('1').isOdd();
@@ -1042,13 +1044,13 @@ enforce([1]).isOdd();
 // throws
 ```
 
-## isEven
+### isEven
 
-### Description
+#### Description
 
 Checks if a value is an even numeric value.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(0).isEven();
@@ -1064,13 +1066,13 @@ enforce([0]).isEven();
 // throws
 ```
 
-## isBetween
+### isBetween
 
-### Description
+#### Description
 
 Checks if a number is in range of two numbers (edges of range included)
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(5).isBetween(0, 5);
@@ -1090,13 +1092,13 @@ enforce(false).isBetween(0, 2);
 // throws
 ```
 
-## isNotBetween
+### isNotBetween
 
-### Description
+#### Description
 
 Checks if a number **is not** in range of two numbers (edges of range excluded)
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(5).isNotBetween(0, 4);
@@ -1117,13 +1119,13 @@ enforce(false).isNotBetween(0, 2);
 // throws
 ```
 
-## endsWith
+### endsWith
 
-### Description
+#### Description
 
 Determines whether a string ends with the characters of a specified string.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce('aba').endsWith('ba');
@@ -1143,20 +1145,20 @@ enforce(true).endsWith(100);
 // throws
 ```
 
-## doesNotEndWith
+### doesNotEndWith
 
-### Description
+#### Description
 
 Determines whether a string does not end with the characters of a specified string.
 Reverse implementation of `endsWith`.
 
-## startsWith
+### startsWith
 
-### Description
+#### Description
 
 Determines whether a string starts with the characters of a specified string.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce('aba').startsWith('ab');
@@ -1176,14 +1178,14 @@ enforce(true).startsWith(100);
 // throws
 ```
 
-## doesNotStartWith
+### doesNotStartWith
 
-### Description
+#### Description
 
 Determines whether a string does not start with the characters of a specified string.
 Reverse implementation of `startsWith`.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce('for').doesNotStartWith('tor');
@@ -1203,13 +1205,13 @@ enforce('aaaa     ').doesNotStartWith('aaaa ');
 // throws
 ```
 
-## isNegative
+### isNegative
 
-### Description
+#### Description
 
 Determines whether a numeric value is negative or not.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(-10).isNegative(); //passes
@@ -1219,13 +1221,13 @@ enforce(10).isNegative(); // throws
 enforce('10').isNegative(); // throws
 ```
 
-## isPositive
+### isPositive
 
-### Description
+#### Description
 
 Determines whether a numeric value is positive or not.
 
-### Usage examples:
+#### Usage examples:
 
 ```js
 enforce(10).isPositive(); //passes
@@ -1235,7 +1237,8 @@ enforce(-10).isPositive(); // throws
 enforce('-10.12').isPositive(); // throws
 ```
 
-# Custom enforce rules
+
+## Custom enforce rules
 
 To make it easier to reuse logic across your application, sometimes you would want to encapsulate bits of logic in rules that you can use later on, for example, "what's considered a valid email".
 
@@ -1253,8 +1256,6 @@ enforce.extend({
 ```
 
 ```js
-import { enforce } from 'vest';
-
 enforce.extend({
   isValidEmail: value => value.indexOf('@') > -1,
   hasKey: (value, key) => value.hasOwnProperty(key),
@@ -1265,7 +1266,7 @@ enforce.extend({
 enforce(user.email).isValidEmail();
 ```
 
-## Custom rules return value
+### Custom rules return value
 
 Rules can either return boolean indicating success or failure, or an object with two keys. `pass` indicates whether the validation is successful or not, and message provides a function with no arguments that return an error message in case of failure. Thus, when pass is false, message should return the error message for when enforce(x).yourRule() fails.
 
@@ -1287,6 +1288,88 @@ enforce.extend({
       };
     }
   },
+});
+```
+
+
+## Shape validations
+
+Enforce (only, not ensure) comes with a built-in lean schema validator rule called `shape`. It allows you to use all the existing and custom rules of enforce to validate the shape of an object.
+
+When using enforce rules inside your shape, use the rules that exist as properties on enforce itself (`enforce.isString()`). For rules used like this, rule chaining is not possible.
+
+### Example
+
+```js
+enforce({
+  firstName: 'Rick',
+  lastName: 'Sanchez',
+  age: 70
+}).shape({
+  firstName: enforce.isString(),
+  lastName: enforce.isString(),
+  age: enforce.isNumber()
+});
+```
+
+### Testing multiple rules for the same key
+
+To test multiple rules with the same key use an array of rules:
+
+```js
+enforce({
+  age: 22
+}).shape({
+  age: [enforce.isNumber(), enforce.isBetween(0, 150)]
+});
+```
+
+### Deeply nested data objects:
+
+To deeply nest shape calls, just use them as any other rules inside shape:
+
+```js
+enforce({
+  user: {
+    name: {
+      first: 'Joseph',
+      last: 'Weil',
+    }
+  }
+}).shape({
+  user: enforce.shape({
+    name: enforce.shape({
+      first: enforce.isString(),
+      last: enforce.isString()
+    })
+  })
+});
+```
+
+### Marking a field as optional
+
+In regular cases, a missing key in the data object would cause an error to be thrown. To prevent that from happening, mark your optional keys with `enforce.optional`.
+
+enforce.optional will pass a key that's either not defined, undefined or null.
+
+`enforce.optional` takes as its arguments all the rules that the value should pass - only if it is present. If it is not present in the data object.
+
+```js
+enforce({
+  user: {
+    name: {
+      first: 'Joseph',
+      last: 'Weil',
+    }
+  }
+}).shape({
+  user: enforce.shape({
+    name: enforce.shape({
+      first: enforce.isString(),
+      last: enforce.isString(),
+      middle: enforce.optional(enforce.isString(), enforce.longerThan(3))
+    })
+  })
 });
 ```
 

--- a/packages/vest/docs/enforce.md.bak
+++ b/packages/vest/docs/enforce.md.bak
@@ -22,66 +22,12 @@ enforce(4)
 
 - [List of Enforce rules](#list-of-enforce-rules) - All default enforce rules
 - [Custom Enforce Rules](#custom-enforce-rules) - How to extend enforce with your rules
+- [Shape (schema) validation](#shape-validations) - Validating she shape of an object
 - [Business Related Rules](#business-related-rules) - Using more rules such as isEmail and isCreditCard
 
 Enforce exposes all predefined and custom rules. You may use chaining to make multiple enfocements for the same value.
 
-{{LIST_OF_ENFORCE_RULES}}
-
-# Custom enforce rules
-
-To make it easier to reuse logic across your application, sometimes you would want to encapsulate bits of logic in rules that you can use later on, for example, "what's considered a valid email".
-
-Rules are called with the argument passed to enforce(x) followed by the arguments passed to `.yourRule(y, z)`.
-
-```js
-enforce.extend({
-  yourRule(x, y, z) {
-    return {
-      pass: true,
-      message: () => '',
-    };
-  },
-});
-```
-
-```js
-import { enforce } from 'vest';
-
-enforce.extend({
-  isValidEmail: value => value.indexOf('@') > -1,
-  hasKey: (value, key) => value.hasOwnProperty(key),
-  passwordsMatch: (passConfirm, options) =>
-    passConfirm === options.passConfirm && options.passIsValid,
-});
-
-enforce(user.email).isValidEmail();
-```
-
-## Custom rules return value
-
-Rules can either return boolean indicating success or failure, or an object with two keys. `pass` indicates whether the validation is successful or not, and message provides a function with no arguments that return an error message in case of failure. Thus, when pass is false, message should return the error message for when enforce(x).yourRule() fails.
-
-```js
-enforce.extend({
-  isWithinRange(received, floor, ceiling) {
-    const pass = received >= floor && received <= ceiling;
-    if (pass) {
-      return {
-        message: () =>
-          `expected ${received} not to be within range ${floor} - ${ceiling}`,
-        pass: true,
-      };
-    } else {
-      return {
-        message: () =>
-          `expected ${received} to be within range ${floor} - ${ceiling}`,
-        pass: false,
-      };
-    }
-  },
-});
-```
+{{COPIED_ENFORCE_DOCS}}
 
 # Business Related Rules
 

--- a/packages/vest/src/core/produce/produce.js
+++ b/packages/vest/src/core/produce/produce.js
@@ -121,6 +121,7 @@ const produce = isDraft => {
               (properties[name] = {
                 configurable: true,
                 enumerable: true,
+                name,
                 value,
                 writeable: true,
               }),

--- a/packages/vest/src/core/state/state.js
+++ b/packages/vest/src/core/state/state.js
@@ -1,3 +1,4 @@
+import asArray from 'asArray';
 import callEach from 'callEach';
 import context from 'ctx';
 import isFunction from 'isFunction';
@@ -68,7 +69,7 @@ export default (function createState() {
     };
 
     for (const key in handlers) {
-      const [handler, args] = [].concat(handlers[key]);
+      const [handler, args] = asArray(handlers[key]);
       registeredHandlers.push(
         context.bind({ stateRef, reg: { key, args } }, handler)
       );

--- a/packages/vest/src/core/test/test.memo.js
+++ b/packages/vest/src/core/test/test.memo.js
@@ -2,6 +2,7 @@ import addTestToState from 'addTestToState';
 import createCache from 'cache';
 import { isExcluded } from 'exclusive';
 import isFunction from 'isFunction';
+import { isNull } from 'isNull';
 import { setPending } from 'pending';
 import runAsyncTest from 'runAsyncTest';
 import useSuiteId from 'useSuiteId';
@@ -28,7 +29,7 @@ export default function bindTestMemo(test) {
 
     const cached = cache.get(dependencies);
 
-    if (cached === null) {
+    if (isNull(cached)) {
       // Cache miss. Start fresh
       return cache(dependencies, () => test(fieldName, msg, testFn));
     }

--- a/packages/vest/src/hooks/exclusive.js
+++ b/packages/vest/src/hooks/exclusive.js
@@ -1,3 +1,4 @@
+import asArray from 'asArray';
 import context from 'ctx';
 import { ERROR_HOOK_CALLED_OUTSIDE } from 'hookErrors';
 import isStringValue from 'isStringValue';
@@ -34,8 +35,8 @@ const addTo = (exclusionGroup, itemType, item) => {
     return;
   }
 
-  [].concat(item).forEach(itemName => {
-    if (!isStringValue('string')) {
+  asArray(item).forEach(itemName => {
+    if (!isStringValue(itemName)) {
       return null;
     }
 

--- a/packages/vest/src/typings/vest.d.ts
+++ b/packages/vest/src/typings/vest.d.ts
@@ -161,6 +161,9 @@ export interface IEnforceRules<T = {}> {
   lengthNotEquals: RuleNumeral<T>;
   isNegative: RuleNumeral<T>;
   isPositive: RuleNumeral<T>;
+  shape: <T>(shape: {
+    [key: string]: LazyEnforceValue | LazyEnforceValue[];
+  }) => RuleReturn<T>;
 }
 
 interface IEnforce {
@@ -247,6 +250,10 @@ type TEnforceLazy = {
   lengthNotEquals: LazyNumeral;
   isNegative: LazyNumeral;
   isPositive: LazyNumeral;
+  shape: <T>(shape: {
+    [key: string]: LazyEnforceValue | LazyEnforceValue[];
+  }) => LazyEnforceValue;
+  optional: <T>(...rules: LazyEnforceValue[]) => LazyEnforceValue;
 };
 
 declare module 'vest' {

--- a/playground/playground.mjs
+++ b/playground/playground.mjs
@@ -1,13 +1,9 @@
-import vest, { test, enforce } from 'vest';
+import enforce from '../packages/n4s/n4s.umd.development.js';
 
-const v = vest.create('playground', (data = {}) => {
-  test('username', 'Must not be empty', () => {
-    enforce(data.username).isNotEmpty();
-  });
+const o = enforce({
+  username: 45,
+}).shape({
+  username: enforce.isBetween(1, 20),
 });
 
-v({
-  username: 'ealush',
-});
-
-console.log(v.get());
+console.log(o);

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -13,10 +13,10 @@ const updateDocs = require('./release/steps/updateDocs');
 const { TRAVIS_BRANCH, RELEASE_BRANCH } = process.env;
 
 const run = async () => {
+  updateDocs();
+
   logger.info('🔍 Finding diffs');
   const { changedPackages, allMessages, messagesPerPackage } = await getDiff();
-
-  updateDocs();
 
   const packageData = changedPackages.map(packageName => {
     logger.info(`Package: 📦 ${packageName}`);

--- a/scripts/release/github/createRelease.js
+++ b/scripts/release/github/createRelease.js
@@ -1,6 +1,6 @@
 const fetch = require('node-fetch');
 
-const { logger } = require('../../util');
+const { logger } = require('../../../util');
 
 const { TRAVIS_REPO_SLUG, GITHUB_TOKEN } = process.env;
 

--- a/scripts/release/github/getDiff.js
+++ b/scripts/release/github/getDiff.js
@@ -1,7 +1,7 @@
 const { get } = require('lodash');
 const fetch = require('node-fetch');
 
-const { packageNames, filePaths } = require('../../util');
+const { packageNames, filePaths } = require('../../../util');
 
 const {
   TRAVIS_REPO_SLUG,

--- a/scripts/release/steps/updateDocs.js
+++ b/scripts/release/steps/updateDocs.js
@@ -8,17 +8,27 @@ const VEST_DOCS_PATH = packagePath(packageNames.VEST, 'docs');
 function updateDocs() {
   logger.info('📖 Updating documentation.');
   const readme = fs.readFileSync('./README.md', 'utf8');
-  const n4sRules = fs
-    .readFileSync(packagePath(packageNames.N4S, 'docs', 'rules.md'), 'utf8')
-    .replace('\n#', '\n##');
+  const n4sRules = fs.readFileSync(
+    packagePath(packageNames.N4S, 'docs', 'rules.md'),
+    'utf8'
+  );
+  const customRules = fs.readFileSync(
+    packagePath(packageNames.N4S, 'docs', 'custom.md'),
+    'utf8'
+  );
+  const shape = fs.readFileSync(
+    packagePath(packageNames.N4S, 'docs', 'shape.md'),
+    'utf8'
+  );
+
   const enforceDoc = fs.readFileSync(
     path.join(VEST_DOCS_PATH, 'enforce.md.bak'),
     'utf8'
   );
 
   const nextEnforceDoc = enforceDoc.replace(
-    '{{LIST_OF_ENFORCE_RULES}}',
-    n4sRules
+    '{{COPIED_ENFORCE_DOCS}}',
+    [n4sRules, customRules, shape].join('\n\n').replace(/^#|\n#/g, '\n##')
   );
 
   fs.writeFileSync(path.join(VEST_DOCS_PATH, 'enforce.md'), nextEnforceDoc);


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix?         | ✔                                                                        |
| New feature?     | ✔                                                                        |
| Breaking change? | ✖                                                                        |
| Deprecations?    | ✖                                                                        |
| Documentation?   | ✔                                                                        |
| Tests added?     | ✔                                                                        |

<!-- Describe your changes below in detail. -->

# Shape validations

Enforce (only, not ensure) comes with a built-in lean schema validator rule called `shape`. It allows you to use all the existing and custom rules of enforce to validate the shape of an object.

When using enforce rules inside your shape, use the rules that exist as properties on enforce itself (`enforce.isString()`). For rules used like this, rule chaining is not possible.

## Example

```js
enforce({
  firstName: 'Rick',
  lastName: 'Sanchez',
  age: 70
}).shape({
  firstName: enforce.isString(),
  lastName: enforce.isString(),
  age: enforce.isNumber()
});
```

## Testing multiple rules for the same key

To test multiple rules with the same key use an array of rules:

```js
enforce({
  age: 22
}).shape({
  age: [enforce.isNumber(), enforce.isBetween(0, 150)]
});
```

## Deeply nested data objects:

To deeply nest shape calls, just use them as any other rules inside shape:

```js
enforce({
  user: {
    name: {
      first: 'Joseph',
      last: 'Weil',
    }
  }
}).shape({
  user: enforce.shape({
    name: enforce.shape({
      first: enforce.isString(),
      last: enforce.isString()
    })
  })
});
```

## Marking a field as optional

In regular cases, a missing key in the data object would cause an error to be thrown. To prevent that from happening, mark your optional keys with `enforce.optional`.

enforce.optional will pass a key that's either not defined, undefined or null.

`enforce.optional` takes as its arguments all the rules that the value should pass - only if it is present. If it is not present in the data object.

```js
enforce({
  user: {
    name: {
      first: 'Joseph',
      last: 'Weil',
    }
  }
}).shape({
  user: enforce.shape({
    name: enforce.shape({
      first: enforce.isString(),
      last: enforce.isString(),
      middle: enforce.optional(enforce.isString(), enforce.longerThan(3))
    })
  })
});
```