### PR TITLE
conf: add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+jsconfig.json linguist-generated


### PR DESCRIPTION
Hide jsconfig from git reviews by default.