### PR TITLE
feat(vest): test.each

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -117,6 +117,7 @@
       "pending": ["./packages/vest/src/core/test/lib/pending.js"],
       "VestTest": ["./packages/vest/src/core/test/lib/VestTest.js"],
       "runAsyncTest": ["./packages/vest/src/core/test/runAsyncTest.js"],
+      "test.each": ["./packages/vest/src/core/test/test.each.js"],
       "test": ["./packages/vest/src/core/test/test.js"],
       "test.memo": ["./packages/vest/src/core/test/test.memo.js"],
       "exclusive": ["./packages/vest/src/hooks/exclusive.js"],

--- a/packages/vest/src/core/test/__tests__/each.test.js
+++ b/packages/vest/src/core/test/__tests__/each.test.js
@@ -1,0 +1,132 @@
+import faker from 'faker';
+import enforce from 'n4s';
+
+import test from 'test';
+import vest from 'vest';
+
+let testObjects;
+
+describe("Test Vest's `test.each` function", () => {
+  describe('Sync Tests', () => {
+    describe('Basic Functionality', () => {
+      it('Should return all test objects correctly', () => {
+        vest.create(faker.random.word(), () => {
+          testObjects = test.each([[1, 2, 3], [2, 7, 9]])(faker.random.word(), faker.lorem.sentence(), (a, b, c) => {
+            enforce(a + b).equals(c);
+          });
+        })();
+        expect(testObjects).toHaveLength(2);
+        expect(testObjects[0].failed).toBe(false);
+        expect(testObjects[1].failed).toBe(false);
+      });
+
+      it('Should mark failed tests as such', () => {
+        vest.create(faker.random.word(), () => {
+          testObjects = test.each([[5, 5, 10], [1, 4, 10], [2, 7, 9]])(faker.random.word(), faker.lorem.sentence(), (a, b, c) => {
+            enforce(a + b).equals(c);
+          });
+        })();
+        expect(testObjects).toHaveLength(3);
+        expect(testObjects[0].failed).toBe(false);
+        expect(testObjects[1].failed).toBe(true);
+        expect(testObjects[2].failed).toBe(false);
+      });
+
+      it('Should include function message when fail test uses function statement', () => {
+        vest.create(faker.random.word(), () => {
+          testObjects = test.each([[5, 4, 10]])(faker.random.word(), (a, b, c) => {
+            return `${a} + ${b} != ${c}`;
+          }, (a, b, c) => {
+            enforce(a + b).equals(c);
+          });
+        })();
+        expect(testObjects).toHaveLength(1);
+        expect(testObjects[0].failed).toBe(true);
+        expect(testObjects[0].statement).toBe('5 + 4 != 10');
+      });
+
+      it('Should work correctly with exclusions', () => {
+        const statementFn1 = jest.fn();
+        const testFn1 = jest.fn();
+        const testFn2 = jest.fn();
+
+        const validate = vest.create(faker.random.word(), () => {
+          vest.only('test2');
+          test.each([[5, 4, 10]])('test1', statementFn1, testFn1);
+          test.each([[5, 4, 10]])('test2', faker.lorem.sentence(), testFn2);
+        });
+        validate();
+        expect(testFn1).not.toHaveBeenCalled();
+        expect(statementFn1).toHaveBeenCalled();
+        expect(testFn2).toHaveBeenCalled();
+      })
+
+      it('Should work correctly with 1d-array', () => {
+        vest.create(faker.random.word(), () => {
+          testObjects = test.each([1, 2, 3])(faker.random.word(), faker.lorem.sentence(), (a) => {
+            enforce(a).greaterThanOrEquals(2);
+          });
+        })();
+        expect(testObjects).toHaveLength(3);
+        expect(testObjects[0].failed).toBe(true);
+        expect(testObjects[1].failed).toBe(false);
+        expect(testObjects[2].failed).toBe(false);
+      });
+    });
+  });
+
+  describe('Async Tests', () => {
+    describe('Basic Functionality', () => {
+      it('Should finish with no errors', () => {
+        new Promise(done => {
+          const validate = vest.create(faker.random.word(), () => {
+            test.each([[1, 2, 3], [2, 7, 9]])('f1', faker.lorem.sentence(), (a, b, c) =>
+              new Promise((resolve, reject) => {
+                setTimeout(() => {
+                  try {
+                    enforce(a + b).equals(c);
+                  } catch (_) {
+                    reject();
+                  }
+                  resolve();
+                }, 100);
+              })
+            );
+          });
+          validate().done(res => {
+            expect(res.hasErrors('f1')).toBe(false);
+            done();
+          });
+        });
+      });
+
+      it('Should have errors when finished', () => {
+        new Promise(done => {
+          const validate = vest.create(faker.random.word(), () => {
+            test.each([[1, 2, 3], [2, 1, 9]])('f1', (a, b, c) => {
+              return `${a} + ${b} != ${c}`;
+            }, (a, b, c) =>
+              new Promise((resolve, reject) => {
+                setTimeout(() => {
+                  try {
+                    enforce(a + b).equals(c);
+                  } catch (_) {
+                    reject();
+                  }
+                  resolve();
+                }, 100);
+              })
+            );
+          });
+          validate().done(res => {
+            expect(res.hasErrors('f1')).toBe(true);
+            const errors = res.getErrors('f1');
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toBe('2 + 1 != 9');
+            done();
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/vest/src/core/test/test.each.js
+++ b/packages/vest/src/core/test/test.each.js
@@ -1,4 +1,6 @@
 import asArray from 'asArray';
+import optionalFunctionValue from 'optionalFunctionValue';
+import throwError from 'throwError';
 import { withFirst } from 'withArgs';
 
 /* eslint-disable jest/no-export */
@@ -13,7 +15,7 @@ export default function bindTestEach(test) {
    */
   function each(table) {
     if (!Array.isArray(table)) {
-      throw new Error('[vest/test.each]: Expected table to be an array.');
+      throwError('test.each: Expected table to be an array.');
     }
 
     return withFirst((fieldName, args) => {
@@ -21,8 +23,7 @@ export default function bindTestEach(test) {
 
       return table.map(item => {
         item = asArray(item);
-        const itemStatement = typeof statement === 'function' ? statement(...item) : statement;
-        return test(fieldName, itemStatement, () => testFn(...item));
+        return test(optionalFunctionValue(fieldName, item), optionalFunctionValue(statement, item), () => testFn.apply(null, item));
       });
     })
   }

--- a/packages/vest/src/core/test/test.each.js
+++ b/packages/vest/src/core/test/test.each.js
@@ -1,0 +1,31 @@
+import asArray from 'asArray';
+import { withFirst } from 'withArgs';
+
+/* eslint-disable jest/no-export */
+export default function bindTestEach(test) {
+  /**
+   * Run multiple tests using a parameter table
+   * @param {any[]} table         Array of arrays with params for each run (will accept 1d-array and treat every item as size one array)
+   * @param {String} fieldName    Name of the field to test.
+   * @param {String|function} [statement]  The message returned in case of a failure.  Follows printf syntax.
+   * @param {function} testFn     The actual test callback.
+   * @return {VestTest[]}           An array of VestTest instances.
+   */
+  function each(table) {
+    if (!Array.isArray(table)) {
+      throw new Error('[vest/test.each]: Expected table to be an array.');
+    }
+
+    return withFirst((fieldName, args) => {
+      const [testFn, statement] = args.reverse();
+
+      return table.map(item => {
+        item = asArray(item);
+        const itemStatement = typeof statement === 'function' ? statement(...item) : statement;
+        return test(fieldName, itemStatement, () => testFn(...item));
+      });
+    })
+  }
+
+  test.each = each;
+}

--- a/packages/vest/src/core/test/test.js
+++ b/packages/vest/src/core/test/test.js
@@ -6,6 +6,7 @@ import isFunction from 'isFunction';
 import isPromise from 'isPromise';
 import { setPending } from 'pending';
 import runAsyncTest from 'runAsyncTest';
+import bindTestEach from 'test.each';
 import bindTestMemo from 'test.memo';
 import throwError from 'throwError';
 import { withFirst } from 'withArgs';
@@ -98,6 +99,7 @@ function test(fieldName, args) {
 
 const exportedTest = withFirst(test);
 
+bindTestEach(exportedTest);
 bindTestMemo(exportedTest);
 
 /* eslint-disable jest/no-export */

--- a/packages/vest/src/typings/vest.d.ts
+++ b/packages/vest/src/typings/vest.d.ts
@@ -2,6 +2,8 @@ import { TEnforce } from './enforce';
 import { IVestResult, DraftResult } from './vestResult';
 
 type TestCB = () => void | Promise<void | string> | false;
+type TestArgsCB = (...args: any[]) => void | Promise<void | string> | false;
+type MessageFunc = (...args: any[]) => string;
 type ExclusionArg = string | string[] | void;
 
 export = vest;
@@ -15,6 +17,30 @@ interface VestTest {
   statement: string;
   testFn: TestCB;
   asyncTest?: Promise<void | string>;
+}
+
+interface ITestEach {
+  /**
+   * Run multiple tests using a parameter table 
+   * @param {String} fieldName          Name of the field to test.
+   * @param {String|function} message   The message returned in case of a failure.  Follows printf syntax.
+   * @param {function} testFn           The actual test callback.
+   * 
+   * @example
+   * 
+   * test.each([[1,2,3],[2,1,3]])('test', (a, b, c) => `${a} + ${b} does not equal ${c}`, (a, b, c) => enforce(a + b).equals(c));
+   */
+  (fieldName: string, message: string | MessageFunc, testFn: TestArgsCB): VestTest[];
+  /**
+   * Run multiple tests using a parameter table 
+   * @param {String} fieldName    Name of the field to test.
+   * @param {function} testFn     The actual test callback.
+   * 
+   * @example
+   * 
+   * test.each([[1,2,3],[2,1,3]])('test', (a, b, c) => enforce(a + b).equals(c));
+   */
+  (fieldName: string, testFn: TestArgsCB): VestTest[];
 }
 
 interface ITest {
@@ -71,6 +97,15 @@ interface ITest {
    * test.memo('username', () => doesUserExist(username), [username])
    */
   memo(fieldName: string, testFn: TestCB, dependencies: any[]): VestTest;
+  /**
+   * Create test.each with table of parameters
+   * @param {any[]} table               Array of arrays with params for each run, although it 
+   *                                      will accept 1d-array and treat every item as size one array (e.g. [1,2,3] -> [[1],[2],[3]])
+   * @example
+   * 
+   * test.each([[1,2,3],[2,1,3]])('test', 'failed', (a, b, c) => enforce(a + b).equals(c));
+   */
+  each(table: any[]): ITestEach;
 }
 
 interface ISkip {

--- a/packages/vest/src/typings/vest.d.ts
+++ b/packages/vest/src/typings/vest.d.ts
@@ -30,7 +30,7 @@ interface ITestEach {
    * 
    * test.each([[1,2,3],[2,1,3]])('test', (a, b, c) => `${a} + ${b} does not equal ${c}`, (a, b, c) => enforce(a + b).equals(c));
    */
-  (fieldName: string, message: string | MessageFunc, testFn: TestArgsCB): VestTest[];
+  (fieldName: string | MessageFunc, message: string | MessageFunc, testFn: TestArgsCB): VestTest[];
   /**
    * Run multiple tests using a parameter table 
    * @param {String} fieldName    Name of the field to test.
@@ -40,7 +40,7 @@ interface ITestEach {
    * 
    * test.each([[1,2,3],[2,1,3]])('test', (a, b, c) => enforce(a + b).equals(c));
    */
-  (fieldName: string, testFn: TestArgsCB): VestTest[];
+  (fieldName: string | MessageFunc, testFn: TestArgsCB): VestTest[];
 }
 
 interface ITest {


### PR DESCRIPTION
| Q                | A   |
| ---------------- | --- |
| Bug fix?         |  |
| New feature?     | ✔ |
| Breaking change? |  |
| Deprecations?    |  |
| Documentation?   |  |
| Tests added?     | ✔ |
| Types added?     | ✔ |
| Related issues   |  #393  |

Seems to be working as intended, though your feedback would be appreciated.
One issue I'm not entirely sure of - 
I went ahead with the method @omriLugasi suggested for the statement - it can either be a string or a function.
The way I implemented test.each means if the statement is a function it will be called regardless the test results as it is generated prior to being passed on to test. 
I was wondering if you think this is the expected behavior, and if now should we change test interface to support argument-less function as statement (which would allow me to pass it on to be rendered later).
Let me know your thoughts and any changes you think should be made 😄 
