### PR TITLE
minor(vest): support schema skip and only

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -41,6 +41,7 @@
       "ruleMessage": ["./packages/n4s/src/meta/ruleMessage.js"],
       "ruleMeta": ["./packages/n4s/src/meta/ruleMeta.js"],
       "ruleWarn": ["./packages/n4s/src/meta/ruleWarn.js"],
+      "ruleWhen": ["./packages/n4s/src/meta/ruleWhen.js"],
       "rules": ["./packages/n4s/src/rules.js"],
       "endsWith": ["./packages/n4s/src/rules/endsWith.js"],
       "equals": ["./packages/n4s/src/rules/equals.js"],

--- a/packages/n4s/src/compounds/isArrayOf.js
+++ b/packages/n4s/src/compounds/isArrayOf.js
@@ -23,11 +23,15 @@ function isArrayOf(value, ruleChains) {
   }
 
   for (let i = 0; i < plainValue.length; i++) {
-    // Set result per each item in the array|
+    // Set result per each item in the array
     result.setChild(
       i,
       runCompoundChain(
-        EnforceContext.wrap(plainValue[i]).setFailFast(value.failFast),
+        new EnforceContext({
+          value: plainValue[i],
+          obj: plainValue,
+          key: i,
+        }).setFailFast(value.failFast),
         ruleChains,
         { mode: MODE_ANY }
       )

--- a/packages/n4s/src/meta/__tests__/__snapshots__/ruleMeta.test.js.snap
+++ b/packages/n4s/src/meta/__tests__/__snapshots__/ruleMeta.test.js.snap
@@ -1,5 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Rule with "when" Should skip all excluded array items 1`] = `
+RuleResult {
+  "children": Object {
+    "items": RuleResult {
+      "children": Object {
+        "0": RuleResult {
+          "children": Object {
+            "checked": RuleResult {
+              "failed": false,
+              "hasErrors": false,
+              "hasWarnings": false,
+              "warn": false,
+            },
+          },
+          "failed": false,
+          "hasErrors": false,
+          "hasWarnings": false,
+          "when": false,
+        },
+        "3": RuleResult {
+          "children": Object {
+            "checked": RuleResult {
+              "failed": false,
+              "hasErrors": false,
+              "hasWarnings": false,
+              "warn": false,
+            },
+          },
+          "failed": false,
+          "hasErrors": false,
+          "hasWarnings": false,
+          "when": false,
+        },
+      },
+      "failed": false,
+      "hasErrors": false,
+      "hasWarnings": false,
+      "isArray": true,
+    },
+  },
+  "failed": false,
+  "hasErrors": false,
+  "hasWarnings": false,
+}
+`;
+
+exports[`Rule with "when" Should skip excluded object items 1`] = `
+RuleResult {
+  "children": Object {
+    "example1": RuleResult {
+      "failed": false,
+      "hasErrors": false,
+      "hasWarnings": false,
+      "warn": false,
+    },
+  },
+  "failed": false,
+  "hasErrors": false,
+  "hasWarnings": false,
+}
+`;
+
 exports[`Rule with a message Should add message to result 1`] = `
 RuleResult {
   "children": Object {

--- a/packages/n4s/src/meta/__tests__/ruleMeta.test.js
+++ b/packages/n4s/src/meta/__tests__/ruleMeta.test.js
@@ -1,3 +1,4 @@
+import RuleResult from 'RuleResult';
 import enforce from 'enforce';
 
 describe('Rule with a message', () => {
@@ -60,5 +61,93 @@ describe('Rule with a warning', () => {
     expect(res.children.user.children.name.children.first.warn).toBe(true);
     expect(res.children.user.children.name.children.middle.warn).toBe(true);
     expect(res).toMatchSnapshot();
+  });
+});
+
+describe('Rule with "when"', () => {
+  it('Should skip all excluded array items', () => {
+    const Schema = enforce.shape({
+      items: enforce.isArrayOf(
+        enforce.shape({ checked: enforce.isBoolean() }).when(value => {
+          return value.checked;
+        })
+      ),
+    });
+
+    const res = Schema.run({
+      items: [
+        { checked: true },
+        { checked: false },
+        { checked: false },
+        { checked: true },
+      ],
+    });
+
+    expect(res.children.items.children[0]).toBeInstanceOf(RuleResult);
+    expect(res.children.items.children[1]).toBeUndefined();
+    expect(res.children.items.children[2]).toBeUndefined();
+    expect(res.children.items.children[3]).toBeInstanceOf(RuleResult);
+
+    expect(res).toMatchSnapshot();
+  });
+
+  it('Should skip excluded object items', () => {
+    const Schema = enforce.shape({
+      example: enforce.isString().when(() => false),
+      example1: enforce.isString(),
+    });
+
+    const res = Schema.run({
+      example: 'something',
+      example1: 'something',
+    });
+
+    expect(res.children.example).toBeUndefined();
+    expect(res.children.example1).toBeInstanceOf(RuleResult);
+
+    expect(res).toMatchSnapshot();
+  });
+  it('Should pass each item the value, key and parent', () => {
+    const whenItems = jest.fn();
+    const whenName = jest.fn();
+    const Schema = enforce.shape({
+      name: enforce
+        .shape({
+          first: enforce.isString(),
+        })
+        .when(whenName),
+      items: enforce.isArrayOf(
+        enforce.shape({ checked: enforce.isBoolean() }).when(whenItems)
+      ),
+    });
+
+    const data = {
+      name: {
+        first: 'example',
+      },
+      items: [
+        { checked: true },
+        { checked: false },
+        { checked: false },
+        { checked: true },
+      ],
+    };
+
+    Schema.run(data);
+
+    expect(whenName).toHaveBeenCalledWith(data.name, 'name', data);
+
+    expect(whenItems.mock.calls[0][0]).toBe(data.items[0]);
+    expect(whenItems.mock.calls[1][0]).toBe(data.items[1]);
+    expect(whenItems.mock.calls[2][0]).toBe(data.items[2]);
+    expect(whenItems.mock.calls[3][0]).toBe(data.items[3]);
+    expect(whenItems.mock.calls[0][1]).toBe(0); // key
+    expect(whenItems.mock.calls[1][1]).toBe(1); // key
+    expect(whenItems.mock.calls[2][1]).toBe(2); // key
+    expect(whenItems.mock.calls[3][1]).toBe(3); // key
+    expect(whenItems.mock.calls[0][2]).toBe(data.items); // parent
+    expect(whenItems.mock.calls[1][2]).toBe(data.items); // parent
+    expect(whenItems.mock.calls[2][2]).toBe(data.items); // parent
+    expect(whenItems.mock.calls[3][2]).toBe(data.items); // parent
   });
 });

--- a/packages/n4s/src/meta/ruleMeta.js
+++ b/packages/n4s/src/meta/ruleMeta.js
@@ -1,4 +1,6 @@
+
 import message from 'ruleMessage';
 import warn from 'ruleWarn';
+import when from 'ruleWhen';
 
-export default { warn, message };
+export default { warn, message, when };

--- a/packages/n4s/src/meta/ruleWhen.js
+++ b/packages/n4s/src/meta/ruleWhen.js
@@ -1,0 +1,13 @@
+import EnforceContext from 'EnforceContext';
+import optionalFunctionValue from 'optionalFunctionValue';
+
+export default function when(value, condition, bail) {
+  const shouldBail = !optionalFunctionValue(
+    condition,
+    [EnforceContext.unwrap(value)].concat(
+      EnforceContext.is(value) ? [value.key, value.obj] : []
+    )
+  );
+
+  return bail(shouldBail);
+}

--- a/packages/n4s/src/runtime/RuleResult.js
+++ b/packages/n4s/src/runtime/RuleResult.js
@@ -2,6 +2,7 @@ import hasOwnProperty from 'hasOwnProperty';
 
 import { isBoolean } from 'isBoolean';
 import { isEmpty } from 'isEmpty';
+import { isNull } from 'isNull';
 import { isUndefined } from 'isUndefined';
 import { HAS_WARNINGS, HAS_ERRORS } from 'sharedKeys';
 
@@ -65,6 +66,10 @@ RuleResult.prototype.setFailed = function (failed) {
  * @param {RuleResult} child
  */
 RuleResult.prototype.setChild = function (key, child) {
+  if (isNull(child)) {
+    return null;
+  }
+
   const isWarning =
     this[HAS_WARNINGS] || child[HAS_WARNINGS] || child.warn || this.warn;
   this.setAttribute(HAS_WARNINGS, (isWarning && child.failed) || false);
@@ -96,6 +101,10 @@ RuleResult.prototype.getChild = function (key) {
  * @param {Boolean|RuleResult} newRes
  */
 RuleResult.prototype.extend = function (newRes) {
+  if (isNull(newRes)) {
+    return this;
+  }
+
   const res = RuleResult.is(newRes)
     ? newRes
     : new RuleResult().setAttribute('warn', !!this.warn).setFailed(!newRes);

--- a/packages/n4s/src/runtime/bindLazyRule.js
+++ b/packages/n4s/src/runtime/bindLazyRule.js
@@ -30,8 +30,8 @@ export default function bindLazyRule(ruleName) {
 
       // Add a meta function
       if (ruleMeta[rule.name] === rule) {
-        meta.push((value, ruleResult) => {
-          ruleResult.setAttribute(rule.name, rule(value, args[0]));
+        meta.push((value, ruleResult, bail) => {
+          ruleResult.setAttribute(rule.name, rule(value, args[0], bail));
         });
       } else {
         // Register a rule
@@ -57,10 +57,16 @@ export default function bindLazyRule(ruleName) {
       returnvalue[RUN_RULE] = value => {
         const result = new RuleResult(true);
 
+        let bailed = false;
+
         // Run meta chains
         meta.forEach(fn => {
-          fn(value, result);
+          fn(value, result, shouldBail => (bailed = shouldBail));
         });
+
+        if (bailed) {
+          return null;
+        }
 
         // Iterate over all the registered rules
         // This runs the function that's inside `addFn`

--- a/packages/n4s/src/runtime/runCompoundChain.js
+++ b/packages/n4s/src/runtime/runCompoundChain.js
@@ -1,6 +1,7 @@
 import RuleResult from 'RuleResult';
 import { MODE_ALL, MODE_ONE, MODE_ANY } from 'enforceKeywords';
 import { isEmpty } from 'isEmpty';
+import { isNull } from 'isNull';
 import { runLazyRule } from 'runLazyRules';
 
 /**
@@ -23,6 +24,10 @@ export default function runCompoundChain(value, rules, options) {
   for (const chain of rules) {
     // Inner result for each iteration
     const currentResult = runLazyRule(chain, value);
+
+    if (isNull(currentResult)) {
+      return null;
+    }
 
     const pass = currentResult.pass;
 

--- a/packages/vest/src/__tests__/test_types/fixtures/rules.ts
+++ b/packages/vest/src/__tests__/test_types/fixtures/rules.ts
@@ -121,3 +121,5 @@ enforce(0).warn;
 enforce.warn;
 enforce(0).message;
 enforce.message;
+enforce(0).when;
+enforce.when;

--- a/packages/vest/src/typings/schema.d.ts
+++ b/packages/vest/src/typings/schema.d.ts
@@ -1,23 +1,26 @@
 declare function getFn(fieldName: string): string[];
 declare function getFn(): { [fieldName: string]: string[] };
 
-declare function schema(
-  enforceSchema: any
-): (
-  data: any
-) => {
-  hasErrors: (fieldName?: string) => boolean;
-  hasWarnings: (fieldName?: string) => boolean;
-  getErrors: typeof getFn;
-  getWarnings: typeof getFn;
-  tests: {
-    [key: string]: {
-      hasErrors: boolean;
-      hasWarnings: boolean;
-      warnings: string[];
-      errors: string[];
+interface schema {
+  (enforceSchema: any, body?: (...args: any[]) => void): (
+    data: any
+  ) => {
+    hasErrors: (fieldName?: string) => boolean;
+    hasWarnings: (fieldName?: string) => boolean;
+    getErrors: typeof getFn;
+    getWarnings: typeof getFn;
+    tests: {
+      [key: string]: {
+        hasErrors: boolean;
+        hasWarnings: boolean;
+        warnings: string[];
+        errors: string[];
+      };
     };
   };
-};
+
+  skip: (namespace: string) => void;
+  only: (namespace: string) => void;
+}
 
 export default schema;

--- a/packages/vest/src/utilities/__tests__/__snapshots__/schema.test.js.snap
+++ b/packages/vest/src/utilities/__tests__/__snapshots__/schema.test.js.snap
@@ -126,3 +126,209 @@ Object {
   },
 }
 `;
+
+exports[`schema function body schema.only Should only validate included fields 1`] = `
+Object {
+  "a": Object {
+    "errors": Array [
+      "\\"a\\" must be a number",
+    ],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+}
+`;
+
+exports[`schema function body schema.only Should only validate included fields 2`] = `
+Object {
+  "a": Array [
+    "\\"a\\" must be a number",
+  ],
+}
+`;
+
+exports[`schema function body schema.skip Should validate all but skipped fields 1`] = `
+Object {
+  "b": Object {
+    "errors": Array [
+      "\\"b\\" must be a numeric string",
+    ],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c": Object {
+    "errors": Array [
+      "id must be a string",
+    ],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c[0]": Object {
+    "errors": Array [
+      "id must be a string",
+    ],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c[0].id": Object {
+    "errors": Array [],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c[1]": Object {
+    "errors": Array [
+      "id must be a string",
+    ],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c[1].id": Object {
+    "errors": Array [],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c[2]": Object {
+    "errors": Array [],
+    "hasErrors": false,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c[2].id": Object {
+    "errors": Array [],
+    "hasErrors": false,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+}
+`;
+
+exports[`schema function body schema.skip Should validate all but skipped fields 2`] = `
+Object {
+  "b": Array [
+    "\\"b\\" must be a numeric string",
+  ],
+  "c": Array [
+    "id must be a string",
+  ],
+  "c[0]": Array [
+    "id must be a string",
+  ],
+  "c[0].id": Array [],
+  "c[1]": Array [
+    "id must be a string",
+  ],
+  "c[1].id": Array [],
+  "c[2]": Array [],
+  "c[2].id": Array [],
+}
+`;
+
+exports[`schema function body schema.skip Should validate all but skipped fields 3`] = `
+Object {
+  "a": Object {
+    "errors": Array [
+      "\\"a\\" must be a number",
+    ],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "b": Object {
+    "errors": Array [
+      "\\"b\\" must be a numeric string",
+    ],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+}
+`;
+
+exports[`schema function body schema.skip Should validate all but skipped fields 4`] = `
+Object {
+  "a": Array [
+    "\\"a\\" must be a number",
+  ],
+  "b": Array [
+    "\\"b\\" must be a numeric string",
+  ],
+}
+`;
+
+exports[`schema function body schema.skip Should validate all but skipped fields 5`] = `
+Object {
+  "c": Object {
+    "errors": Array [
+      "id must be a string",
+    ],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c[0]": Object {
+    "errors": Array [
+      "id must be a string",
+    ],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c[0].id": Object {
+    "errors": Array [],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c[1]": Object {
+    "errors": Array [
+      "id must be a string",
+    ],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c[1].id": Object {
+    "errors": Array [],
+    "hasErrors": true,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c[2]": Object {
+    "errors": Array [],
+    "hasErrors": false,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+  "c[2].id": Object {
+    "errors": Array [],
+    "hasErrors": false,
+    "hasWarnings": false,
+    "warnings": Array [],
+  },
+}
+`;
+
+exports[`schema function body schema.skip Should validate all but skipped fields 6`] = `
+Object {
+  "c": Array [
+    "id must be a string",
+  ],
+  "c[0]": Array [
+    "id must be a string",
+  ],
+  "c[0].id": Array [],
+  "c[1]": Array [
+    "id must be a string",
+  ],
+  "c[1].id": Array [],
+  "c[2]": Array [],
+  "c[2].id": Array [],
+}
+`;


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✖ |
| New feature?     | ✔ |
| Breaking change? | ✖ |
| Deprecations?    | ✖ |
| Documentation?   | ✖ |
| Tests added?     | ✔ |
| Types added?     | ✔ |

<!-- Describe your changes below in detail. -->

Add a function body support to `vest/schema`. This allows using schema.skip/schema.only.

```js
import schema from 'vest/schema';
import {enforce} from 'vest'

const Name = enforce.shape({
  first: enforce.isString().isNotEmpty(),
  last: enforce.isString().isNotEmpty(),
  middle: enforc.optional(enforce.isString().isNotEmpty()),
});

const Schema = schema(Name, (data, ...someOtherArgs) => {
   schema.skip('middle'); // alternatively, you could use the passed args determine which field to skip
})

Schema({
  first: 'Jon',
  last: 'Bovi'
});
```