### PR TITLE
patch: Avoid crashing when Function.name is not configurable

### DIFF
--- a/packages/__shared/src/setFnName.js
+++ b/packages/__shared/src/setFnName.js
@@ -1,3 +1,5 @@
 export default function setFnName(fn, value) {
-  return Object.defineProperty(fn, 'name', { value });
+  // Pre ES2015 non standard implementation, "Function.name" is non configurable field
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name
+  return Object.getOwnPropertyDescriptor(fn, 'name').configurable ? Object.defineProperty(fn, 'name', { value }) : fn;
 }


### PR DESCRIPTION
| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✔ |
| New feature?     | ✖ |
| Breaking change? | ✖ |
| Deprecations?    | ✖ |
| Documentation?   | ✖ |
| Tests added?     | ✖ |
| Types added?     | ✖ |
| Related issues   |  #666    |

Resolve issue #666
