### PR TITLE
patch: Fix crashing of setFnName in IE11

### DIFF
--- a/packages/__shared/src/setFnName.js
+++ b/packages/__shared/src/setFnName.js
@@ -1,5 +1,7 @@
 export default function setFnName(fn, value) {
   // Pre ES2015 non standard implementation, "Function.name" is non configurable field
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name
-  return Object.getOwnPropertyDescriptor(fn, 'name').configurable ? Object.defineProperty(fn, 'name', { value }) : fn;
+  return Object.getOwnPropertyDescriptor(fn, 'name')?.configurable
+    ? Object.defineProperty(fn, 'name', { value })
+    : fn;
 }


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✔ |
| New feature?     | ✖ |
| Breaking change? | ✖ |
| Deprecations?    | ✖ |
| Documentation?   | ✖ |
| Tests added?     | ✖ |
| Types added?     | ✖ |
| Related issues   |  #666, #667   |

<!-- Describe your changes below in detail. -->

Hi @ealush, would you consider merging this PR? Although #667 fixed some use cases, IE11 throws an error for me.

![image](https://user-images.githubusercontent.com/9109884/127655266-8c81886e-691a-4040-bff0-4c96f3004da1.png)

Adding the optional chaining in node_modules manually fixes the issue for me locally.