### PR TITLE
docs(vest): add enforce import

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Vest tries to remediate this by separating validation logic from feature logic s
 ## Example code ([Run in sandbox](https://codesandbox.io/s/vest-react-tutorial-finished-ztt8t?file=/src/validate.js))
 
 ```js
-import vest, { test } from 'vest';
+import vest, { test, enforce } from 'vest';
 
 export default vest.create('user_form', (data = {}, currentField) => {
   vest.only(currentField);


### PR DESCRIPTION
resolve `enforce`method from `vest`

<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✔ |
| New feature?     | ✖ |
| Breaking change? | ✖ |
| Deprecations?    | ✖ |
| Documentation?   | ✖ |
| Tests added?     | ✖ |
| Types added?     | ✖ |
| Related issues   |     |

<!-- Describe your changes below in detail. -->
The README was missing the `enforce` in the example. Just added it to the import
