### PR TITLE
feat(vest): use key prop to retain test state after reorder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,10 @@ module.exports = {
         'plugin:@typescript-eslint/recommended',
         'plugin:import/typescript',
       ],
-      files: ['*.ts'],
+      files: ['packages/**/*.ts'],
+      parserOptions: {
+        project: ['./tsconfig.json'], // Specify it only for TypeScript files
+      },
       rules: {
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
@@ -91,6 +94,7 @@ module.exports = {
     'no-multi-spaces': 1,
     'no-prototype-builtins': 0,
     'no-trailing-spaces': [2, { ignoreComments: false }],
+    'no-undef': 2,
     'no-unneeded-ternary': 2,
     'no-unused-expressions': 2,
     'no-useless-catch': 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,37 +7,44 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## vest: [3.2.8] - 2021-11-02
 
 ### Fixed and improved
-- 9555d1b  types: Add types for skipWhen (ealush)
+
+- 9555d1b types: Add types for skipWhen (ealush)
 
 ## vest: [3.2.7] - 2021-10-16
 
 ### Fixed and improved
-- c2964e0  patch: add skipWhen for forward compatibility (ealush)
+
+- c2964e0 patch: add skipWhen for forward compatibility (ealush)
 
 ## n4s: [3.1.0] - 2021-10-09
 
 ### Added
-- 5adc337  feat: add isBlank rule (Luca Pizzini)
+
+- 5adc337 feat: add isBlank rule (Luca Pizzini)
 
 ## vest: [3.2.6] - 2021-10-09
 
 ### Fixed and improved
-- e538e5b  patch: remove incorrect messaging from group initialization error (ealush)
+
+- e538e5b patch: remove incorrect messaging from group initialization error (ealush)
 
 ## vest: [3.2.5] - 2021-07-31
 
 ### Fixed and improved
-- 3bb7f76  patch: Fix crashing of setFnName in IE11 (#671) (Václav Jančařík)
+
+- 3bb7f76 patch: Fix crashing of setFnName in IE11 (#671) (Václav Jančařík)
 
 ## vest: [3.2.4] - 2021-07-19
 
 ### Fixed and improved
-- ba6c296  patch: remove unused optional references from the state (ealush)
+
+- ba6c296 patch: remove unused optional references from the state (ealush)
 
 ## vest: [3.2.3] - 2021-05-27
 
 ### Fixed and improved
-- c02f22f  patch: use context only as dev dep (ealush)
+
+- c02f22f patch: use context only as dev dep (ealush)
 
 ## vest: [3.2.2] - 2021-05-17
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 If you want to try it out, you can already install it with the `next` tag.
 
-```npm install vest@next```
+`npm install vest@next`
 
 This version brings many enhancements to Vest. This version is well tested, and can be used safely. If you do, however encounter any issues or have any thoughts on the next version, please report them on the issues page.
 

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -4,6 +4,7 @@ Simple utility for context propagation within Javascript applications and librar
 It allows you to keep reference for shared variables, and access them down in your function call even if not declared in the same scope.
 
 ## How Context Works?
+
 The way context works is quite simple. Creating a context initializes a closure with a context storage object. When you run your context call, it takes your values, and places them in the context storage object. When your function finishes running, the context is cleared.
 
 ![image](https://user-images.githubusercontent.com/11255103/137119151-6912d3f1-ab48-4c91-a426-76af8abc8c55.png)
@@ -125,13 +126,15 @@ Working with context inside within async code may lead to unexpected results whe
 This is known and expected behavior. Context is a synchronous context propagation tool that completely relies on the synchronous nature of function calls in JS - this is exactly what allows context to run.
 
 #### But my function is still running. Why did the context clear?
+
 The async parts of your function are actually not executed along with your sync code, and even though you "await" it, the browser carries on and allows other code to run in between instead of blocking execution until your async code is complete.
 
 #### Ok, so what do I do?
+
 There are multiple strategies of handling async functions with context.
 
 1. Pulling your values from context right before your async call
-This is the most obvious and easiest to achieve, though not always what you need. The basic idea is that you take whatever you need from the context when it is still available to you.
+   This is the most obvious and easiest to achieve, though not always what you need. The basic idea is that you take whatever you need from the context when it is still available to you.
 
 2. context.bind or context.run your async function to the context you extracted
-This is the next logical step - you have a function that you know should run later with your context. You can bind your context to it for delayed execution. When your function runs later down the line within your asynchronous code, internally it will still have access to whatever you bound to it.
+   This is the next logical step - you have a function that you know should run later with your context. You can bind your context to it for delayed execution. When your function runs later down the line within your asynchronous code, internally it will still have access to whatever you bound to it.

--- a/packages/n4s/src/plugins/schema/optional.ts
+++ b/packages/n4s/src/plugins/schema/optional.ts
@@ -1,12 +1,12 @@
+import isNullish from 'isNullish';
+
 import type { TLazy } from 'genEnforceLazy';
-import { isNull } from 'isNull';
-import { isUndefined } from 'isUndefined';
 import type { TRuleDetailedResult } from 'ruleReturn';
 import * as ruleReturn from 'ruleReturn';
 import runLazyRule from 'runLazyRule';
 
 export function optional(value: any, ruleChain: TLazy): TRuleDetailedResult {
-  if (isUndefined(value) || isNull(value)) {
+  if (isNullish(value)) {
     return ruleReturn.passing();
   }
   return runLazyRule(ruleChain, value);

--- a/packages/n4s/src/runtime/enforceEager.ts
+++ b/packages/n4s/src/runtime/enforceEager.ts
@@ -25,14 +25,14 @@ export default function enforceEager(value: TRuleValue): IRules {
     return target;
   }
 
-  const proxy = new Proxy(target, {
+  const proxy: TEnforceEager = new Proxy(target, {
     get: (_, ruleName: string) => {
       const rule = getRule(ruleName);
       if (rule) {
         return genRuleCall(proxy, rule, ruleName);
       }
     },
-  }) as IRules;
+  });
 
   return proxy;
 

--- a/packages/shared/src/isNullish.ts
+++ b/packages/shared/src/isNullish.ts
@@ -1,0 +1,6 @@
+import { isNull } from 'isNull';
+import { isUndefined } from 'isUndefined';
+
+export default function isNullish(value: any): value is null | undefined {
+  return isNull(value) || isUndefined(value);
+}

--- a/packages/vest/README.md
+++ b/packages/vest/README.md
@@ -4,7 +4,7 @@
 
 If you want to try it out, you can already install it with the `next` tag.
 
-```npm install vest@next```
+`npm install vest@next`
 
 This version brings many enhancements to Vest. This version is well tested, and can be used safely. If you do, however encounter any issues or have any thoughts on the next version, please report them on the issues page.
 

--- a/packages/vest/src/__tests__/isolate.test.ts
+++ b/packages/vest/src/__tests__/isolate.test.ts
@@ -1,20 +1,17 @@
+import mockThrowError from '../../testUtils/mockThrowError';
+
 import { IsolateTypes } from 'IsolateTypes';
 
 describe('isolate', () => {
   let firstRun = true;
   let vest, isolate, skipWhen, dummyTest;
-  let throwError, throwErrorDeferred;
+  let throwErrorDeferred;
 
   beforeEach(() => {
     firstRun = true;
-    jest.resetModules();
-    throwError = jest.fn();
-    throwErrorDeferred = jest.fn();
-    jest.mock('throwError', () => ({
-      throwErrorDeferred,
-      default: throwError,
-    }));
-    vest = require('vest');
+    const mock = mockThrowError();
+    throwErrorDeferred = mock.throwErrorDeferred;
+    vest = mock.vest;
     skipWhen = vest.skipWhen;
     isolate = require('isolate').isolate;
     dummyTest = require('../../testUtils/testDummy').dummyTest;

--- a/packages/vest/src/core/ctx/ctx.ts
+++ b/packages/vest/src/core/ctx/ctx.ts
@@ -2,7 +2,7 @@ import assign from 'assign';
 import { createContext } from 'context';
 import { createCursor } from 'cursor';
 
-import { IsolateTypes } from 'IsolateTypes';
+import { IsolateKeys, IsolateTypes } from 'IsolateTypes';
 import VestTest from 'VestTest';
 import type { TStateRef } from 'createStateRef';
 
@@ -12,19 +12,28 @@ export default createContext<CTXType>((ctxRef, parentContext) =>
     : assign(
         {},
         {
-          isolate: { type: IsolateTypes.DEFAULT },
-          testCursor: createCursor(),
           exclusion: {
             tests: {},
             groups: {},
           },
+          isolate: {
+            type: IsolateTypes.DEFAULT,
+            keys: {
+              current: {},
+              prev: {},
+            },
+          },
+          testCursor: createCursor(),
         },
         ctxRef
       )
 );
 
 type CTXType = {
-  isolate: { type: IsolateTypes };
+  isolate: {
+    type: IsolateTypes;
+    keys: IsolateKeys;
+  };
   testCursor: ReturnType<typeof createCursor>;
   stateRef?: TStateRef;
   exclusion: {

--- a/packages/vest/src/core/isolate/IsolateTypes.ts
+++ b/packages/vest/src/core/isolate/IsolateTypes.ts
@@ -1,3 +1,5 @@
+import VestTest from 'VestTest';
+
 export enum IsolateTypes {
   DEFAULT,
   SUITE,
@@ -5,3 +7,8 @@ export enum IsolateTypes {
   SKIP_WHEN,
   GROUP,
 }
+
+export type IsolateKeys = {
+  current: Record<string, VestTest>;
+  prev: Record<string, VestTest>;
+};

--- a/packages/vest/src/core/isolate/isolate.ts
+++ b/packages/vest/src/core/isolate/isolate.ts
@@ -1,9 +1,10 @@
 import isFunction from 'isFunction';
 import * as nestedArray from 'nestedArray';
 
-import { IsolateTypes } from 'IsolateTypes';
+import { IsolateKeys, IsolateTypes } from 'IsolateTypes';
 import VestTest from 'VestTest';
 import ctx from 'ctx';
+import { usePrevKeys } from 'key';
 import { useSetTests } from 'stateHooks';
 import * as testCursor from 'testCursor';
 
@@ -14,10 +15,16 @@ export function isolate(
   if (!isFunction(callback)) {
     return;
   }
+  const keys: IsolateKeys = {
+    current: {},
+    prev: {},
+  };
 
   const path = testCursor.usePath();
-  return ctx.run({ isolate: { type } }, () => {
+  return ctx.run({ isolate: { type, keys } }, () => {
     testCursor.addLevel();
+
+    keys.prev = usePrevKeys();
 
     useSetTests(tests => nestedArray.setValueAtPath(tests, path, []));
 

--- a/packages/vest/src/core/state/createStateRef.ts
+++ b/packages/vest/src/core/state/createStateRef.ts
@@ -26,7 +26,7 @@ export default function createStateRef(
       current: NestedArray<VestTest>;
     }>(prev => {
       return {
-        prev: (prev ? prev.current : []) as NestedArray<VestTest>,
+        prev: prev ? prev.current : [],
         current: [] as NestedArray<VestTest>,
       };
     }),

--- a/packages/vest/src/core/test/VestTest.ts
+++ b/packages/vest/src/core/test/VestTest.ts
@@ -14,6 +14,7 @@ export default class VestTest {
   asyncTest?: TAsyncTest;
   groupName?: string;
   message?: string;
+  key?: null | string = null;
 
   id = genId();
   severity = TestSeverity.Error;
@@ -22,7 +23,11 @@ export default class VestTest {
   constructor(
     fieldName: string,
     testFn: TTestFn,
-    { message, groupName }: { message?: string; groupName?: string } = {}
+    {
+      message,
+      groupName,
+      key,
+    }: { message?: string; groupName?: string; key?: string } = {}
   ) {
     this.fieldName = fieldName;
     this.testFn = testFn;
@@ -33,6 +38,10 @@ export default class VestTest {
 
     if (message) {
       this.message = message;
+    }
+
+    if (key) {
+      this.key = key;
     }
   }
 

--- a/packages/vest/src/core/test/__tests__/__snapshots__/VestTest.test.ts.snap
+++ b/packages/vest/src/core/test/__tests__/__snapshots__/VestTest.test.ts.snap
@@ -4,6 +4,7 @@ exports[`VestTest TestObject constructor 1`] = `
 VestTest {
   "fieldName": "unicycle",
   "id": "0",
+  "key": null,
   "message": "I am Root.",
   "severity": "error",
   "status": "UNTESTED",
@@ -15,6 +16,7 @@ exports[`VestTest testObject.warn Should mark the test as warning 1`] = `
 VestTest {
   "fieldName": "unicycle",
   "id": "102",
+  "key": null,
   "message": "I am Root.",
   "severity": "warning",
   "status": "UNTESTED",

--- a/packages/vest/src/core/test/__tests__/__snapshots__/test.test.ts.snap
+++ b/packages/vest/src/core/test/__tests__/__snapshots__/test.test.ts.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test Vest's \`test\` function test params creates a test with a message and with a key 1`] = `
+VestTest {
+  "fieldName": "field_name",
+  "id": "21",
+  "key": "keyboardcat",
+  "message": "failure message",
+  "severity": "error",
+  "status": "PASSING",
+  "testFn": [Function],
+}
+`;
+
+exports[`Test Vest's \`test\` function test params creates a test without a key 1`] = `
+VestTest {
+  "fieldName": "field_name",
+  "id": "17",
+  "key": null,
+  "message": "failure message",
+  "severity": "error",
+  "status": "PASSING",
+  "testFn": [Function],
+}
+`;
+
+exports[`Test Vest's \`test\` function test params creates a test without a message and with a key 1`] = `
+VestTest {
+  "fieldName": "field_name",
+  "id": "19",
+  "key": "keyboardcat",
+  "severity": "error",
+  "status": "PASSING",
+  "testFn": [Function],
+}
+`;
+
+exports[`Test Vest's \`test\` function test params creates a test without a message and without a key 1`] = `
+VestTest {
+  "fieldName": "field_name",
+  "id": "15",
+  "key": null,
+  "severity": "error",
+  "status": "PASSING",
+  "testFn": [Function],
+}
+`;

--- a/packages/vest/src/core/test/__tests__/key.test.ts
+++ b/packages/vest/src/core/test/__tests__/key.test.ts
@@ -1,0 +1,175 @@
+import mockThrowError from '../../../../testUtils/mockThrowError';
+
+import * as vest from 'vest';
+import { create, test, skipWhen } from 'vest';
+
+describe('key', () => {
+  describe('When key is provided', () => {
+    describe('When tests change their order between runs', () => {
+      it('Should retain test results', () => {
+        let count = 0;
+        const suite = create(() => {
+          /**
+           * This test is pretty confusing, but its the most effective way to test this behavior.
+           *
+           * It basically checks that when provided, key is used to override default test order behavior.
+           * We don't mind the order of tests, because the key tells us which test really needs to get which state.
+           *
+           * The reason we have both skipWhen and and if block is this:
+           * if/else: to simulate reordering between runs
+           * skipWhen: to prevent running the tests so they have to get the previous state
+           */
+
+          skipWhen(count === 1, () => {
+            if (count === 0) {
+              test('field_1', () => false, 'field_1_key_1');
+              test('field_1', () => undefined, 'field_1_key_2');
+              test('field_2', () => false, 'field_2_key_1');
+              test('field_2', () => undefined, 'field_2_key_2');
+            } else {
+              test('field_2', () => undefined, 'field_2_key_2');
+              test('field_2', () => false, 'field_2_key_1');
+              test('field_1', () => undefined, 'field_1_key_2');
+              test('field_1', () => false, 'field_1_key_1');
+            }
+          });
+          count++;
+        });
+
+        const res1 = suite();
+        const res2 = suite();
+
+        expect(res1.tests).toEqual(res2.tests);
+      });
+    });
+
+    describe('When two tests in two different isolates have the same key', () => {
+      it('Should regarad each key as unique and retain each tests individual result', () => {
+        const calls = [];
+        const suite = create(() => {
+          const currentCall = [];
+
+          skipWhen(calls.length === 1, () => {
+            vest.group('group_1', () => {
+              currentCall.push(test('field1', () => false, 'key_1'));
+            });
+
+            vest.group('group_2', () => {
+              currentCall.push(test('field2', () => false, 'key_1'));
+            });
+          });
+
+          calls.push(currentCall);
+        });
+
+        const res1 = suite();
+        const res2 = suite();
+
+        expect(calls[0][0]).toBe(calls[1][0]);
+        expect(calls[0][1]).toBe(calls[1][1]);
+        expect(calls[0][0]).not.toBe(calls[0][1]);
+        expect(calls[1][0]).not.toBe(calls[1][1]);
+        expect(res1.tests).toEqual(res2.tests);
+      });
+    });
+
+    describe('When tests without a key reorder get added above a test with a key', () => {
+      let vest;
+      beforeEach(() => {
+        vest = mockThrowError().vest;
+      });
+      afterEach(() => {
+        jest.resetModules();
+        jest.resetAllMocks();
+      });
+      it('Should retain keyd tests', () => {
+        const calls = [];
+        const suite = vest.create(() => {
+          const currentCall = [];
+          vest.skipWhen(calls.length === 1, () => {
+            if (calls.length === 1) {
+              vest.test('reordered', () => false);
+            }
+
+            currentCall.push(vest.test('field1', () => false, 'key_1'));
+            currentCall.push(vest.test('field2', () => false, 'key_2'));
+            currentCall.push(vest.test('field3', () => false, 'key_3'));
+
+            if (calls.length === 0) {
+              vest.test('reordered', () => false);
+            }
+          });
+          calls.push(currentCall);
+        });
+
+        const res1 = suite();
+        const res2 = suite();
+
+        expect(calls[0][0]).toBe(calls[1][0]);
+        expect(calls[0][1]).toBe(calls[1][1]);
+        expect(calls[0][2]).toBe(calls[1][2]);
+        expect(res1.tests.reordered).toEqual({
+          errorCount: 1,
+          testCount: 1,
+          warnCount: 0,
+        });
+        expect(res2.tests.reordered).toEqual({
+          errorCount: 0,
+          testCount: 0,
+          warnCount: 0,
+        });
+        expect(res1.tests).not.toEqual(res2.tests);
+        expect(res2.tests).toMatchInlineSnapshot(`
+          Object {
+            "field1": Object {
+              "errorCount": 1,
+              "testCount": 1,
+              "warnCount": 0,
+            },
+            "field2": Object {
+              "errorCount": 1,
+              "testCount": 1,
+              "warnCount": 0,
+            },
+            "field3": Object {
+              "errorCount": 1,
+              "testCount": 1,
+              "warnCount": 0,
+            },
+            "reordered": Object {
+              "errorCount": 0,
+              "testCount": 0,
+              "warnCount": 0,
+            },
+          }
+        `);
+      });
+    });
+
+    describe('When the same key is encountered twice', () => {
+      let throwErrorDeferred, vest;
+      beforeEach(() => {
+        const mock = mockThrowError();
+
+        throwErrorDeferred = mock.throwErrorDeferred;
+        vest = mock.vest;
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+        jest.resetModules();
+      });
+
+      it('Should throw a deferred error', () => {
+        const suite = vest.create(() => {
+          vest.test('field1', () => false, 'key_1');
+          vest.test('field2', () => false, 'key_1');
+        });
+        suite();
+        expect(throwErrorDeferred).toHaveBeenCalledWith(
+          `Encountered the same test key "key_1" twice. This may lead to tests overriding each other's results, or to tests being unexpectedly omitted.`
+        );
+      });
+    });
+  });
+});

--- a/packages/vest/src/core/test/__tests__/merging_of_previous_test_runs.test.ts
+++ b/packages/vest/src/core/test/__tests__/merging_of_previous_test_runs.test.ts
@@ -1,3 +1,4 @@
+import mockThrowError from '../../../../testUtils/mockThrowError';
 import { dummyTest } from '../../../../testUtils/testDummy';
 
 import { create, skipWhen } from 'vest';
@@ -73,13 +74,9 @@ describe('Merging of previous test runs', () => {
   describe('When tests are passed in a different order between runs', () => {
     let throwErrorDeferred, vest;
     beforeEach(() => {
-      throwErrorDeferred = jest.fn();
-      jest.resetModules();
-      jest.mock('throwError', () => ({
-        throwErrorDeferred,
-        default: jest.fn(),
-      }));
-      vest = require('vest');
+      const mock = mockThrowError();
+      throwErrorDeferred = mock.throwErrorDeferred;
+      vest = mock.vest;
     });
 
     afterAll(() => {

--- a/packages/vest/src/core/test/__tests__/test.test.ts
+++ b/packages/vest/src/core/test/__tests__/test.test.ts
@@ -114,6 +114,96 @@ describe("Test Vest's `test` function", () => {
         }));
     });
   });
+
+  describe('test params', () => {
+    let testObject;
+    it('creates a test without a message and without a key', () => {
+      create(() => {
+        testObject = test('field_name', () => undefined);
+      })();
+      expect(testObject.fieldName).toBe('field_name');
+      expect(testObject.key).toBeNull();
+      expect(testObject.message).toBeUndefined();
+      expect(testObject).toMatchSnapshot();
+    });
+
+    it('creates a test without a key', () => {
+      create(() => {
+        testObject = test('field_name', 'failure message', () => undefined);
+      })();
+      expect(testObject.fieldName).toBe('field_name');
+      expect(testObject.key).toBeNull();
+      expect(testObject.message).toBe('failure message');
+      expect(testObject).toMatchSnapshot();
+    });
+
+    it('creates a test without a message and with a key', () => {
+      create(() => {
+        testObject = test('field_name', () => undefined, 'keyboardcat');
+      })();
+      expect(testObject.fieldName).toBe('field_name');
+      expect(testObject.key).toBe('keyboardcat');
+      expect(testObject.message).toBeUndefined();
+      expect(testObject).toMatchSnapshot();
+    });
+
+    it('creates a test with a message and with a key', () => {
+      create(() => {
+        testObject = test(
+          'field_name',
+          'failure message',
+          () => undefined,
+          'keyboardcat'
+        );
+      })();
+      expect(testObject.fieldName).toBe('field_name');
+      expect(testObject.key).toBe('keyboardcat');
+      expect(testObject.message).toBe('failure message');
+      expect(testObject).toMatchSnapshot();
+    });
+
+    it('throws when field name is not a string', () => {
+      const control = jest.fn();
+      create(() => {
+        // @ts-ignore
+        expect(() => test(undefined, () => undefined)).toThrow(
+          'Incompatible params passed to test function. fieldName must be a string'
+        );
+        // @ts-expect-error
+        expect(() => test(null, 'error message', () => undefined)).toThrow(
+          'Incompatible params passed to test function. fieldName must be a string'
+        );
+        expect(() =>
+          // @ts-expect-error
+          test(null, 'error message', () => undefined, 'key')
+        ).toThrow(
+          'Incompatible params passed to test function. fieldName must be a string'
+        );
+        control();
+      })();
+      expect(control).toHaveBeenCalled();
+    });
+
+    it('throws when callback is not a function', () => {
+      const control = jest.fn();
+      create(() => {
+        // @ts-expect-error
+        expect(() => test('x')).toThrow(
+          'Incompatible params passed to test function. Test callback must be a function'
+        );
+        // @ts-expect-error
+        expect(() => test('x', 'msg', undefined)).toThrow(
+          'Incompatible params passed to test function. Test callback must be a function'
+        );
+        // @ts-expect-error
+        expect(() => test('x', 'msg', undefined, 'key')).toThrow(
+          'Incompatible params passed to test function. Test callback must be a function'
+        );
+        control();
+      })();
+      expect(control).toHaveBeenCalled();
+    });
+  });
 });
 
 function failWithString(msg?: string) {

--- a/packages/vest/src/core/test/key.ts
+++ b/packages/vest/src/core/test/key.ts
@@ -1,0 +1,47 @@
+import asArray from 'asArray';
+import isNullish from 'isNullish';
+import * as nestedArray from 'nestedArray';
+import { throwErrorDeferred } from 'throwError';
+
+import VestTest from 'VestTest';
+import ctx from 'ctx';
+import { useTestObjects } from 'stateHooks';
+import * as testCursor from 'testCursor';
+
+export function usePrevKeys(): Record<string, VestTest> {
+  const [{ prev }] = useTestObjects();
+
+  return asArray(nestedArray.getCurrent(prev, testCursor.usePath())).reduce(
+    (prevKeys, testObject) => {
+      if (!(testObject instanceof VestTest)) {
+        return prevKeys;
+      }
+
+      if (isNullish(testObject.key)) {
+        return prevKeys;
+      }
+
+      prevKeys[testObject.key] = testObject;
+      return prevKeys;
+    },
+    {} as Record<string, VestTest>
+  );
+}
+
+export function usePrevTestByKey(key: string): VestTest | undefined {
+  const prev = ctx.useX().isolate.keys.prev;
+  return prev[key];
+}
+
+export function useRetainTestKey(key: string, testObject: VestTest) {
+  const context = ctx.useX();
+
+  const current = context.isolate.keys.current;
+  if (isNullish(current[key])) {
+    current[key] = testObject;
+  } else {
+    throwErrorDeferred(
+      `Encountered the same test key "${key}" twice. This may lead to tests overriding each other's results, or to tests being unexpectedly omitted.`
+    );
+  }
+}

--- a/packages/vest/src/core/test/test.ts
+++ b/packages/vest/src/core/test/test.ts
@@ -1,4 +1,7 @@
 import assign from 'assign';
+import isFunction from 'isFunction';
+import { isNotString } from 'isString';
+import throwError from 'throwError';
 
 import VestTest, { TTestFn } from 'VestTest';
 import ctx from 'ctx';
@@ -6,20 +9,40 @@ import registerPrevRunTest from 'registerPrevRunTest';
 import bindTestEach from 'test.each';
 import bindTestMemo from 'test.memo';
 
+function testBase(fieldName: string, message: string, cb: TTestFn): VestTest;
+function testBase(fieldName: string, cb: TTestFn): VestTest;
 function testBase(
   fieldName: string,
-  ...args: [message: string, cb: TTestFn]
+  message: string,
+  cb: TTestFn,
+  key: string
 ): VestTest;
-function testBase(fieldName: string, ...args: [cb: TTestFn]): VestTest;
+function testBase(fieldName: string, cb: TTestFn, key: string): VestTest;
 function testBase(
   fieldName: string,
-  ...args: [message: string, cb: TTestFn] | [cb: TTestFn]
+  ...args:
+    | [message: string, cb: TTestFn]
+    | [cb: TTestFn]
+    | [message: string, cb: TTestFn, key: string]
+    | [cb: TTestFn, key: string]
 ): VestTest {
-  const [testFn, message] = args.reverse() as [TTestFn, string | undefined];
+  const [message, testFn, key] = (
+    isFunction(args[1]) ? args : [undefined, ...args]
+  ) as [string | undefined, TTestFn, string | undefined];
+
+  if (isNotString(fieldName)) {
+    throwIncompatibleParamsError('fieldName', 'string');
+  }
+
+  if (!isFunction(testFn)) {
+    throwIncompatibleParamsError('Test callback', 'function');
+  }
+
   const context = ctx.useX();
   const testObject = new VestTest(fieldName, testFn, {
     message,
     groupName: context.groupName,
+    key,
   });
 
   return registerPrevRunTest(testObject);
@@ -31,3 +54,9 @@ export default assign(testBase, {
 });
 
 export type TTestBase = typeof testBase;
+
+function throwIncompatibleParamsError(name: string, expected: string) {
+  throwError(
+    `Incompatible params passed to test function. ${name} must be a ${expected}`
+  );
+}

--- a/packages/vest/src/hooks/__tests__/__snapshots__/each.test.ts.snap
+++ b/packages/vest/src/hooks/__tests__/__snapshots__/each.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`each When callback is not a function should throw 1`] = `"callback must be a function"`;

--- a/packages/vest/src/hooks/__tests__/each.test.ts
+++ b/packages/vest/src/hooks/__tests__/each.test.ts
@@ -1,0 +1,35 @@
+import * as vest from 'vest';
+
+describe('each', () => {
+  describe('When callback is not a function', () => {
+    it('should throw', () => {
+      const control = jest.fn();
+      const suite = vest.create(() => {
+        expect(() => {
+          // @ts-expect-error
+          vest.each([null], null);
+        }).toThrowErrorMatchingSnapshot();
+        control();
+      });
+
+      suite();
+      expect(control).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('Should pass to callback the current list item and index', () => {
+    const cb = jest.fn();
+    const suite = vest.create(() => {
+      vest.each([1, 2, 3, 'str'], cb);
+    });
+
+    suite();
+
+    expect(cb).toHaveBeenCalledTimes(4);
+
+    expect(cb).toHaveBeenNthCalledWith(1, 1, 0);
+    expect(cb).toHaveBeenNthCalledWith(2, 2, 1);
+    expect(cb).toHaveBeenNthCalledWith(3, 3, 2);
+    expect(cb).toHaveBeenNthCalledWith(4, 'str', 3);
+  });
+});

--- a/packages/vest/src/hooks/__tests__/exclusive.test.ts
+++ b/packages/vest/src/hooks/__tests__/exclusive.test.ts
@@ -167,7 +167,7 @@ describe('exclusive hooks', () => {
       test('isExcluded returns false for non excluded field', () => {
         vest.create(() => {
           vest.skip(test1.fieldName);
-          res = isExcluded(vest.test(test2, jest.fn()));
+          res = isExcluded(vest.test(test2.fieldName, jest.fn()));
         })();
         expect(res).toBe(false);
       });

--- a/packages/vest/src/hooks/each.ts
+++ b/packages/vest/src/hooks/each.ts
@@ -1,0 +1,20 @@
+import isFunction from 'isFunction';
+import throwError from 'throwError';
+
+import { IsolateTypes } from 'IsolateTypes';
+import { isolate } from 'isolate';
+
+export default function each<T>(
+  list: T[],
+  callback: (arg: T, index: number) => void
+): void {
+  if (!isFunction(callback)) {
+    throwError('callback must be a function');
+  }
+
+  isolate({ type: IsolateTypes.EACH }, () => {
+    list.forEach((arg, index) => {
+      callback(arg, index);
+    });
+  });
+}

--- a/packages/vest/src/hooks/optionalTests.ts
+++ b/packages/vest/src/hooks/optionalTests.ts
@@ -9,7 +9,7 @@ export default function optional(optionals: TOptionalsInput): void {
 
   setOptionalFields(state => {
     if (!isArray(optionals) && !isStringValue(optionals)) {
-      const optionalFunctions = optionals as TOptionalsObject;
+      const optionalFunctions = optionals;
       for (const field in optionalFunctions) {
         const predicate = optionalFunctions[field];
         state[field] = predicate;

--- a/packages/vest/src/vest.ts
+++ b/packages/vest/src/vest.ts
@@ -1,6 +1,7 @@
 import { enforce } from 'n4s';
 
 import create from 'create';
+import each from 'each';
 import { only, skip } from 'exclusive';
 import group from 'group';
 import optional from 'optionalTests';
@@ -12,6 +13,7 @@ const VERSION = __LIB_VERSION__;
 export {
   test,
   create,
+  each,
   only,
   skip,
   warn,

--- a/packages/vest/testUtils/mockThrowError.ts
+++ b/packages/vest/testUtils/mockThrowError.ts
@@ -1,0 +1,16 @@
+export default function mockThrowError() {
+  const throwErrorDeferred = jest.fn();
+  const throwError = jest.fn();
+  jest.resetModules();
+  jest.mock('throwError', () => ({
+    throwErrorDeferred,
+    default: throwError,
+  }));
+  const vest = require('vest');
+
+  return {
+    throwErrorDeferred,
+    throwError,
+    vest,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -101,6 +101,7 @@
       "hasOwnProperty": ["./packages/shared/src/hasOwnProperty.ts"],
       "isBooleanValue": ["./packages/shared/src/isBooleanValue.ts"],
       "isFunction": ["./packages/shared/src/isFunction.ts"],
+      "isNullish": ["./packages/shared/src/isNullish.ts"],
       "isPromise": ["./packages/shared/src/isPromise.ts"],
       "isStringValue": ["./packages/shared/src/isStringValue.ts"],
       "last": ["./packages/shared/src/last.ts"],
@@ -123,6 +124,7 @@
       "hasRemainingTests": [
         "./packages/vest/src/core/suite/hasRemainingTests.ts"
       ],
+      "key": ["./packages/vest/src/core/test/key.ts"],
       "cancelOverriddenPendingTest": [
         "./packages/vest/src/core/test/lib/cancelOverriddenPendingTest.ts"
       ],
@@ -158,6 +160,7 @@
       "enforce@schema": ["./packages/vest/src/exports/enforce@schema.ts"],
       "parser": ["./packages/vest/src/exports/parser.ts"],
       "promisify": ["./packages/vest/src/exports/promisify.ts"],
+      "each": ["./packages/vest/src/hooks/each.ts"],
       "exclusive": ["./packages/vest/src/hooks/exclusive.ts"],
       "group": ["./packages/vest/src/hooks/group.ts"],
       "hookErrors": ["./packages/vest/src/hooks/hookErrors.ts"],


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✔ |
| New feature?     | ✔ |
| Breaking change? | ✖ |
| Deprecations?    | ✖ |
| Documentation?   | ✖ |
| Tests added?     | ✔ |
| Types added?     | ✔ |

<!-- Describe your changes below in detail. -->

Introducing a more reliant way of handling dynamic validations.
Previously, Vest 3 used the test.each interface to iterate over tests. The one problem that this function did not take into account is the dynamic nature of these tests. Dynamic tests created via an iteration may reorder between runs - and then vest has no way of knowing which state belongs to which test.

This PR introduces the "key" argument, which is an optional last argument passed to the test function. Its intention is similar to [React's key prop in JSX](https://reactjs.org/docs/lists-and-keys.html#keys), and it is to provide absolute specificity when in doubt on re-run.

# Registering tests dynamically with each

A common use case in forms is to have fields that are added dynamically via the user interface. These fields may have multiple validations of their own, and their amount and order may change via the lifetime of the suite.

To handle these dynamic tests, you may use the `each` function provided by Vest. It accepts an array of values, and a callback. It then iterates over each of the array items, and runs the provided callback, similarly to a `forEach` call.

Within your `each` callback you can add your tests. It is recommended that you add each tests a unique "key" prop as the last argument. This will guarantee correct behavior when tests are removed, or their order changes.

```js
import { create, test, each, enforce } from 'vest';

const suite = create((data = {}) => {
  each(data.fields, (field) => {
    test(field.name, 'field value must not be empty', () => {
      enforce(field.value).isNotEmpty();
    }, field.id);
  });
});
```

:::tip The Key Prop
When using the key argument, make sure you use a consistent key to the test itself, and avoid values that may change between runs - such as the item's index.
If you have multiple tests in for the same item, each has to have its own unique key!
:::