### PR TITLE
fix(vest): only.group works in conjunction with only

### DIFF
--- a/packages/n4s/src/exports/compose.ts
+++ b/packages/n4s/src/exports/compose.ts
@@ -1,9 +1,9 @@
 import mapFirst from 'mapFirst';
-import { ctx } from 'n4s';
 import throwError from 'throwError';
 
 import type { TComposeResult, TLazyRuleRunners } from 'genEnforceLazy';
 import { isEmpty } from 'isEmpty';
+import { ctx } from 'n4s';
 import { defaultToPassing, TRuleDetailedResult } from 'ruleReturn';
 import runLazyRule from 'runLazyRule';
 

--- a/packages/n4s/src/exports/compounds.ts
+++ b/packages/n4s/src/exports/compounds.ts
@@ -1,8 +1,8 @@
-import { enforce } from 'n4s';
 import { DropFirst } from 'utilityTypes';
 
 import { allOf } from 'allOf';
 import { anyOf } from 'anyOf';
+import { enforce } from 'n4s';
 import { noneOf } from 'noneOf';
 import { oneOf } from 'oneOf';
 

--- a/packages/n4s/src/exports/schema.ts
+++ b/packages/n4s/src/exports/schema.ts
@@ -1,8 +1,8 @@
-import { enforce } from 'n4s';
 import { DropFirst } from 'utilityTypes';
 
 import { isArrayOf } from 'isArrayOf';
 import { loose } from 'loose';
+import { enforce } from 'n4s';
 import { optional } from 'optional';
 import { shape } from 'shape';
 

--- a/packages/n4s/src/plugins/schema/isArrayOf.ts
+++ b/packages/n4s/src/plugins/schema/isArrayOf.ts
@@ -1,7 +1,7 @@
 import mapFirst from 'mapFirst';
-import { ctx } from 'n4s';
 
 import type { TLazy } from 'genEnforceLazy';
+import { ctx } from 'n4s';
 import type { TRuleDetailedResult } from 'ruleReturn';
 import * as ruleReturn from 'ruleReturn';
 import runLazyRule from 'runLazyRule';

--- a/packages/n4s/src/plugins/schema/loose.ts
+++ b/packages/n4s/src/plugins/schema/loose.ts
@@ -1,6 +1,5 @@
-import { ctx } from 'n4s';
-
 import type { IShapeObject } from 'genEnforceLazy';
+import { ctx } from 'n4s';
 import type { TRuleDetailedResult } from 'ruleReturn';
 import * as ruleReturn from 'ruleReturn';
 import runLazyRule from 'runLazyRule';

--- a/packages/vest/src/core/isolate/isolates/__tests__/group.test.ts
+++ b/packages/vest/src/core/isolate/isolates/__tests__/group.test.ts
@@ -55,16 +55,16 @@ describe('group: exclusion', () => {
         });
       }
     );
-  let res, validate;
+  let res, suite;
 
   beforeEach(() => {
     groupName = faker.random.word();
-    validate = validation();
+    suite = validation();
   });
 
   describe('When skipped', () => {
     beforeEach(() => {
-      res = validate({ skipGroup: groupName });
+      res = suite({ skipGroup: groupName });
     });
 
     it('produce result object with the group', () => {
@@ -123,25 +123,25 @@ describe('group: exclusion', () => {
 
   describe('When `only`ed', () => {
     beforeEach(() => {
-      res = validate({ onlyGroup: groupName });
+      res = suite({ onlyGroup: groupName });
     });
     it('produce result object with group', () => {
       expect(res.groups).toHaveProperty(groupName);
     });
 
     it('produce correct result object', () => {
-      expect(res.testCount).toBe(11);
-      expect(res.errorCount).toBe(5);
-      expect(res.warnCount).toBe(2);
-      expect(res.tests['field_1'].errorCount).toBe(3);
+      expect(res.testCount).toBe(5);
+      expect(res.errorCount).toBe(2);
+      expect(res.warnCount).toBe(1);
+      expect(res.tests['field_1'].errorCount).toBe(1);
       expect(res.tests['field_1'].warnCount).toBe(0);
       expect(res.tests['field_2'].errorCount).toBe(0);
       expect(res.tests['field_2'].warnCount).toBe(0);
       expect(res.tests['field_3'].errorCount).toBe(0);
-      expect(res.tests['field_3'].warnCount).toBe(2);
+      expect(res.tests['field_3'].warnCount).toBe(1);
       expect(res.tests['field_4'].errorCount).toBe(0);
       expect(res.tests['field_4'].warnCount).toBe(0);
-      expect(res.tests['field_5'].errorCount).toBe(1);
+      expect(res.tests['field_5'].errorCount).toBe(0);
       expect(res.tests['field_5'].warnCount).toBe(0);
       expect(res.tests['field_6'].errorCount).toBe(1);
       expect(res.tests['field_6'].warnCount).toBe(0);
@@ -156,25 +156,11 @@ describe('group: exclusion', () => {
         }
       });
     });
-
-    it('Should only run tests outside of the group that are not in another group', () => {
-      Object.values(topLevelTestObjects).forEach(testObject => {
-        expect(testObject.testFn).toHaveBeenCalled();
-      });
-      let count = 0;
-      Object.values(groupTestObjects).forEach(testObject => {
-        if (testObject.groupName !== groupName) {
-          count++;
-          expect(testObject.testFn).not.toHaveBeenCalled();
-        }
-      });
-      expect(count).toBe(3);
-    });
   });
 
   describe('When skipped field inside `only`ed group', () => {
     beforeEach(() => {
-      res = validate({ skip: 'field_1', onlyGroup: groupName });
+      res = suite({ skip: 'field_1', onlyGroup: groupName });
     });
     it('produce result object with group', () => {
       expect(res.groups).toHaveProperty(groupName);
@@ -196,13 +182,9 @@ describe('group: exclusion', () => {
           expect(testObject.testFn).not.toHaveBeenCalled();
         });
     });
-    it('Should skip all matching tests outside group', () => {
+    it('Should skip all tests outside of the group', () => {
       Object.values(topLevelTestObjects).forEach(testObject => {
-        if (testObject.fieldName === 'field_1') {
-          expect(testObject.testFn).not.toHaveBeenCalled();
-        } else {
-          expect(testObject.testFn).toHaveBeenCalled();
-        }
+        expect(testObject.testFn).not.toHaveBeenCalled();
       });
     });
   });
@@ -232,8 +214,8 @@ describe('group: base case', () => {
   let res;
   beforeEach(() => {
     groupName = faker.random.word();
-    const validate = validation();
-    res = validate();
+    const suite = validation();
+    res = suite();
   });
 
   it('Should contain all tests in tests object', () => {

--- a/packages/vest/src/hooks/__tests__/exclusive.test.ts
+++ b/packages/vest/src/hooks/__tests__/exclusive.test.ts
@@ -366,9 +366,9 @@ describe('isExcluded', () => {
       );
     });
 
-    it('returns false for tests outside of any group', () => {
-      expect(runIsExcluded(exclusion, genTest('field_1'))).toBe(false);
-      expect(runIsExcluded(exclusion, genTest('field_2'))).toBe(false);
+    it('returns true for tests outside of any group', () => {
+      expect(runIsExcluded(exclusion, genTest('field_1'))).toBe(true);
+      expect(runIsExcluded(exclusion, genTest('field_2'))).toBe(true);
     });
   });
 
@@ -383,9 +383,9 @@ describe('isExcluded', () => {
       };
     });
 
-    it('returns false for included tests', () => {
-      expect(runIsExcluded(exclusion, genTest('field_1'))).toBe(false);
-      expect(runIsExcluded(exclusion, genTest('field_2'))).toBe(false);
+    it('returns true for included tests outside of the group', () => {
+      expect(runIsExcluded(exclusion, genTest('field_1'))).toBe(true);
+      expect(runIsExcluded(exclusion, genTest('field_2'))).toBe(true);
     });
 
     it('returns false for included tests in included groups', () => {
@@ -432,7 +432,7 @@ describe('isExcluded', () => {
       };
     });
 
-    it('returns true for tests in excluded groups', () => {
+    it('returns true for included tests in excluded groups', () => {
       expect(runIsExcluded(exclusion, genTest('field_1', 'group_1'))).toBe(
         true
       );
@@ -453,7 +453,7 @@ describe('isExcluded', () => {
       );
     });
 
-    it('returns false for tests in included tests in non excluded groups', () => {
+    it('returns false for included tests in non excluded groups', () => {
       expect(runIsExcluded(exclusion, genTest('field_1', 'group_3'))).toBe(
         false
       );
@@ -473,7 +473,7 @@ describe('isExcluded', () => {
       expect(runIsExcluded(exclusion, genTest('field_4'))).toBe(true);
     });
 
-    it('returns false for included tests', () => {
+    it('returns false for included tests outside of the group', () => {
       expect(runIsExcluded(exclusion, genTest('field_1'))).toBe(false);
       expect(runIsExcluded(exclusion, genTest('field_2'))).toBe(false);
     });
@@ -493,10 +493,6 @@ describe('isExcluded', () => {
     it('returns true for excluded tests', () => {
       expect(runIsExcluded(exclusion, genTest('field_1'))).toBe(true);
       expect(runIsExcluded(exclusion, genTest('field_2'))).toBe(true);
-    });
-    it('returns false for non excluded tests', () => {
-      expect(runIsExcluded(exclusion, genTest('field_3'))).toBe(false);
-      expect(runIsExcluded(exclusion, genTest('field_4'))).toBe(false);
     });
     it('returns true for excluded test in included group', () => {
       expect(runIsExcluded(exclusion, genTest('field_1', 'group_1'))).toBe(

--- a/packages/vest/src/hooks/exclusive.ts
+++ b/packages/vest/src/hooks/exclusive.ts
@@ -68,12 +68,51 @@ export function isExcluded(testObject: VestTest): boolean {
     }
   }
 
+  if (isMissingFromIncludedGroup(groupName)) {
+    return true;
+  }
+
   // if field is only'ed
   if (isTestIncluded) return false;
 
   // If there is _ANY_ `only`ed test (and we already know this one isn't) return true
   // Otherwise return false
   return hasIncludedTests(keyTests);
+}
+
+// eslint-disable-next-line max-statements
+function isMissingFromIncludedGroup(groupName?: string): boolean {
+  const context = ctx.useX();
+  const exclusion = context.exclusion;
+
+  if (!hasIncludedGroups()) {
+    return false;
+  }
+
+  if (!groupName) {
+    return true;
+  }
+
+  if (groupName in exclusion.groups) {
+    if (exclusion.groups[groupName]) {
+      return false;
+    }
+    return true;
+  }
+
+  return true;
+}
+
+function hasIncludedGroups(): boolean {
+  const context = ctx.useX();
+  const exclusion = context.exclusion;
+
+  for (const group in exclusion.groups) {
+    if (exclusion.groups[group]) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✔ |
| New feature?     | ✖ |
| Breaking change? | ✔ |
| Deprecations?    | ✖ |
| Documentation?   | ✔ |
| Tests added?     | ✔ |
| Types added?     | ✔ |


<!-- Describe your changes below in detail. -->

The implementation of `only.group` in previous versions of Vest was buggy and did not work as expected when combined with `only`. The new implementation is simpler to understand and reason about.

## only.group

When using `only.group`, only tests within the targeted group will be run, all other tests will be skipped - even if they are specifically selected using `only`.

It works like this:
When applied to a suite, `only.group` filters out all possible tests to the tests that are within a certain group. When used in conjunction with `only`, these two filters have and `AND` relationship, meaning that the "onlied" fields will only be selected from within the targeted group.