### PR TITLE
add(vest): omitWhen

### DIFF
--- a/packages/vest/src/core/ctx/ctx.ts
+++ b/packages/vest/src/core/ctx/ctx.ts
@@ -43,6 +43,7 @@ type CTXType = {
   currentTest?: VestTest;
   groupName?: string;
   skipped?: boolean;
+  omitted?: boolean;
   bus?: {
     on: (
       event: string,

--- a/packages/vest/src/core/isolate/IsolateTypes.ts
+++ b/packages/vest/src/core/isolate/IsolateTypes.ts
@@ -5,6 +5,7 @@ export enum IsolateTypes {
   SUITE,
   EACH,
   SKIP_WHEN,
+  OMIT_WHEN,
   GROUP,
 }
 

--- a/packages/vest/src/core/isolate/isolates/__tests__/__snapshots__/omitWhen.test.ts.snap
+++ b/packages/vest/src/core/isolate/isolates/__tests__/__snapshots__/omitWhen.test.ts.snap
@@ -1,0 +1,315 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`omitWhen When conditional is falsy boolean conditional Should have auu tests within the omit block referenced in the result 1`] = `
+Object {
+  "field_1": Object {
+    "errorCount": 1,
+    "testCount": 2,
+    "warnCount": 0,
+  },
+  "field_2": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+  "field_3": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+  "field_4": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+}
+`;
+
+exports[`omitWhen When conditional is falsy boolean conditional Should run tests normally 1`] = `
+Object {
+  "field_1": Object {
+    "errorCount": 1,
+    "testCount": 2,
+    "warnCount": 0,
+  },
+  "field_2": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+  "field_3": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+  "field_4": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+}
+`;
+
+exports[`omitWhen When conditional is falsy boolean conditional Should run tests normally 2`] = `
+Object {
+  "field_1": Object {
+    "errorCount": 1,
+    "testCount": 2,
+    "warnCount": 0,
+  },
+  "field_2": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+  "field_3": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+  "field_4": Object {
+    "errorCount": 0,
+    "testCount": 1,
+    "warnCount": 0,
+  },
+}
+`;
+
+exports[`omitWhen When conditional is falsy function conditional Should have auu tests within the omit block referenced in the result 1`] = `
+Object {
+  "field_1": Object {
+    "errorCount": 1,
+    "testCount": 2,
+    "warnCount": 0,
+  },
+  "field_2": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+  "field_3": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+  "field_4": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+}
+`;
+
+exports[`omitWhen When conditional is falsy function conditional Should run tests normally 1`] = `
+Object {
+  "field_1": Object {
+    "errorCount": 1,
+    "testCount": 2,
+    "warnCount": 0,
+  },
+  "field_2": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+  "field_3": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+  "field_4": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+}
+`;
+
+exports[`omitWhen When conditional is falsy function conditional Should run tests normally 2`] = `
+Object {
+  "field_1": Object {
+    "errorCount": 1,
+    "testCount": 2,
+    "warnCount": 0,
+  },
+  "field_2": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+  "field_3": Object {
+    "errorCount": 0,
+    "testCount": 0,
+    "warnCount": 0,
+  },
+  "field_4": Object {
+    "errorCount": 0,
+    "testCount": 1,
+    "warnCount": 0,
+  },
+}
+`;
+
+exports[`omitWhen When conditional is truthy boolean conditional Should avoid running the omitted tests 1`] = `
+Object {
+  "errorCount": 1,
+  "getErrors": [Function],
+  "getErrorsByGroup": [Function],
+  "getWarnings": [Function],
+  "getWarningsByGroup": [Function],
+  "groups": Object {},
+  "hasErrors": [Function],
+  "hasErrorsByGroup": [Function],
+  "hasWarnings": [Function],
+  "hasWarningsByGroup": [Function],
+  "isValid": [Function],
+  "suiteName": undefined,
+  "testCount": 2,
+  "tests": Object {
+    "field_1": Object {
+      "errorCount": 0,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_2": Object {
+      "errorCount": 1,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_3": Object {
+      "errorCount": 0,
+      "testCount": 0,
+      "warnCount": 0,
+    },
+    "field_4": Object {
+      "errorCount": 0,
+      "testCount": 0,
+      "warnCount": 0,
+    },
+  },
+  "warnCount": 0,
+}
+`;
+
+exports[`omitWhen When conditional is truthy boolean conditional Should skip and not run omitted fields when no filter provided 1`] = `
+Object {
+  "errorCount": 1,
+  "getErrors": [Function],
+  "getErrorsByGroup": [Function],
+  "getWarnings": [Function],
+  "getWarningsByGroup": [Function],
+  "groups": Object {},
+  "hasErrors": [Function],
+  "hasErrorsByGroup": [Function],
+  "hasWarnings": [Function],
+  "hasWarningsByGroup": [Function],
+  "isValid": [Function],
+  "suiteName": undefined,
+  "testCount": 2,
+  "tests": Object {
+    "field_1": Object {
+      "errorCount": 0,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_2": Object {
+      "errorCount": 1,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_3": Object {
+      "errorCount": 0,
+      "testCount": 0,
+      "warnCount": 0,
+    },
+    "field_4": Object {
+      "errorCount": 0,
+      "testCount": 0,
+      "warnCount": 0,
+    },
+  },
+  "warnCount": 0,
+}
+`;
+
+exports[`omitWhen When conditional is truthy function conditional Should avoid running the omitted tests 1`] = `
+Object {
+  "errorCount": 1,
+  "getErrors": [Function],
+  "getErrorsByGroup": [Function],
+  "getWarnings": [Function],
+  "getWarningsByGroup": [Function],
+  "groups": Object {},
+  "hasErrors": [Function],
+  "hasErrorsByGroup": [Function],
+  "hasWarnings": [Function],
+  "hasWarningsByGroup": [Function],
+  "isValid": [Function],
+  "suiteName": undefined,
+  "testCount": 2,
+  "tests": Object {
+    "field_1": Object {
+      "errorCount": 0,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_2": Object {
+      "errorCount": 1,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_3": Object {
+      "errorCount": 0,
+      "testCount": 0,
+      "warnCount": 0,
+    },
+    "field_4": Object {
+      "errorCount": 0,
+      "testCount": 0,
+      "warnCount": 0,
+    },
+  },
+  "warnCount": 0,
+}
+`;
+
+exports[`omitWhen When conditional is truthy function conditional Should skip and not run omitted fields when no filter provided 1`] = `
+Object {
+  "errorCount": 1,
+  "getErrors": [Function],
+  "getErrorsByGroup": [Function],
+  "getWarnings": [Function],
+  "getWarningsByGroup": [Function],
+  "groups": Object {},
+  "hasErrors": [Function],
+  "hasErrorsByGroup": [Function],
+  "hasWarnings": [Function],
+  "hasWarningsByGroup": [Function],
+  "isValid": [Function],
+  "suiteName": undefined,
+  "testCount": 2,
+  "tests": Object {
+    "field_1": Object {
+      "errorCount": 0,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_2": Object {
+      "errorCount": 1,
+      "testCount": 1,
+      "warnCount": 0,
+    },
+    "field_3": Object {
+      "errorCount": 0,
+      "testCount": 0,
+      "warnCount": 0,
+    },
+    "field_4": Object {
+      "errorCount": 0,
+      "testCount": 0,
+      "warnCount": 0,
+    },
+  },
+  "warnCount": 0,
+}
+`;

--- a/packages/vest/src/core/isolate/isolates/__tests__/omitWhen.test.ts
+++ b/packages/vest/src/core/isolate/isolates/__tests__/omitWhen.test.ts
@@ -1,0 +1,161 @@
+import * as vest from 'vest';
+import { omitWhen, only } from 'vest';
+
+describe('omitWhen', () => {
+  let suite, cb1, cb2, cb3, cb4, cb5, allFieldsPass;
+
+  beforeEach(() => {
+    cb1 = jest.fn();
+    cb2 = jest.fn(() => (allFieldsPass ? undefined : false));
+    cb3 = jest.fn(() => (allFieldsPass ? undefined : false));
+    cb4 = jest.fn(() => (allFieldsPass ? undefined : false));
+    cb5 = jest.fn();
+
+    suite = vest.create((omitConditional, currentField) => {
+      only(currentField);
+      vest.test('field_1', cb1);
+      vest.test('field_2', cb2);
+
+      omitWhen(omitConditional, () => {
+        vest.test('field_1', cb3);
+        vest.test('field_3', cb4);
+        vest.test('field_4', cb5);
+      });
+    });
+  });
+
+  afterEach(() => {
+    allFieldsPass = undefined;
+  });
+
+  describe('When conditional is falsy', () => {
+    describe.each([
+      ['boolean conditional', false],
+      ['function conditional', () => false],
+    ])('%s', (_, omitConditional) => {
+      it('Should run tests normally', () => {
+        suite(omitConditional, 'field_1');
+        expect(cb1).toHaveBeenCalledTimes(1);
+        expect(cb2).not.toHaveBeenCalled();
+        expect(cb3).toHaveBeenCalledTimes(1);
+        expect(cb4).not.toHaveBeenCalled();
+        expect(cb5).not.toHaveBeenCalled();
+        expect(suite.get().hasErrors('field_1')).toBe(true);
+        expect(suite.get().tests.field_1.testCount).toBe(2);
+        expect(suite.get().tests.field_1.errorCount).toBe(1);
+        expect(suite.get().hasErrors('field_2')).toBe(false);
+        expect(suite.get().hasErrors('field_3')).toBe(false);
+        expect(suite.get().hasErrors('field_4')).toBe(false);
+        expect(suite.get().tests).toMatchSnapshot();
+        suite(omitConditional, 'field_4');
+        expect(cb1).toHaveBeenCalledTimes(1);
+        expect(cb2).not.toHaveBeenCalled();
+        expect(cb3).toHaveBeenCalledTimes(1);
+        expect(cb4).not.toHaveBeenCalled();
+        expect(cb5).toHaveBeenCalledTimes(1);
+        expect(suite.get().hasErrors('field_1')).toBe(true);
+        expect(suite.get().tests.field_1.testCount).toBe(2);
+        expect(suite.get().tests.field_1.errorCount).toBe(1);
+        expect(suite.get().hasErrors('field_2')).toBe(false);
+        expect(suite.get().hasErrors('field_3')).toBe(false);
+        expect(suite.get().hasErrors('field_4')).toBe(false);
+        expect(suite.get().tests.field_4.testCount).toBe(1);
+        expect(suite.get().tests.field_4.errorCount).toBe(0);
+        expect(suite.get().tests).toMatchSnapshot();
+      });
+
+      it('Should have all tests within the omit block referenced in the result', () => {
+        suite(omitConditional, 'field_1');
+        expect(suite.get().tests.field_1).toBeDefined();
+        expect(suite.get().tests.field_3).toBeDefined();
+        expect(suite.get().tests.field_4).toBeDefined();
+        expect(suite.get().tests).toMatchSnapshot();
+      });
+
+      it('Should retain normal `isValid` functionality', () => {
+        expect(suite.get().isValid()).toBe(false);
+        suite(omitConditional, 'field_1');
+        expect(suite.get().isValid()).toBe(false);
+        allFieldsPass = true;
+        suite(omitConditional);
+        expect(suite.get().isValid()).toBe(true);
+      });
+    });
+  });
+
+  describe('When conditional is truthy', () => {
+    describe.each([
+      ['boolean conditional', true],
+      ['function conditional', () => true],
+    ])('%s', (_, omitConditional) => {
+      it('Should avoid running the omitted tests', () => {
+        suite(omitConditional, 'field_1');
+        expect(suite.get().tests.field_1.testCount).toBe(1);
+        suite(omitConditional, 'field_2');
+        expect(suite.get().tests.field_2.testCount).toBe(1);
+        suite(omitConditional, 'field_3');
+        expect(suite.get().tests.field_3.testCount).toBe(0);
+        suite(omitConditional, 'field_4');
+        expect(suite.get().tests.field_4.testCount).toBe(0);
+        expect(cb1).toHaveBeenCalledTimes(1);
+        expect(cb2).toHaveBeenCalledTimes(1);
+        expect(cb3).toHaveBeenCalledTimes(0);
+        expect(cb4).toHaveBeenCalledTimes(0);
+        expect(cb5).toHaveBeenCalledTimes(0);
+        suite(omitConditional);
+        expect(cb1).toHaveBeenCalledTimes(2);
+        expect(cb2).toHaveBeenCalledTimes(2);
+        expect(cb3).toHaveBeenCalledTimes(0);
+        expect(cb4).toHaveBeenCalledTimes(0);
+        expect(cb5).toHaveBeenCalledTimes(0);
+        expect(suite.get()).toMatchSnapshot();
+      });
+
+      it('Should consider the suite as valid even without the omitted tests', () => {
+        expect(suite.get().isValid()).toBe(false);
+        suite(omitConditional, 'field_1');
+        expect(suite.get().isValid()).toBe(false);
+        suite(omitConditional, 'field_2');
+        expect(suite.get().isValid()).toBe(false);
+        allFieldsPass = true;
+        suite(omitConditional, 'field_2');
+        expect(suite.get().tests.field_1.testCount).toBe(1);
+        expect(suite.get().tests.field_2.testCount).toBe(1);
+        expect(suite.get().tests.field_3.testCount).toBe(0);
+        expect(suite.get().tests.field_4.testCount).toBe(0);
+        expect(suite.get().isValid()).toBe(true);
+      });
+
+      it('Should skip and not run omitted fields when no filter provided', () => {
+        suite(omitConditional);
+        expect(suite.get().tests.field_1.testCount).toBe(1);
+        expect(suite.get().tests.field_2.testCount).toBe(1);
+        expect(suite.get().tests.field_3.testCount).toBe(0);
+        expect(suite.get().tests.field_4.testCount).toBe(0);
+        expect(suite.get()).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('When the conditional changes between runs', () => {
+    it('Should omit previously run fields if changes to `true`', () => {
+      suite(false, 'field_1');
+      expect(suite.get().tests.field_1.testCount).toBe(2);
+      expect(cb1).toHaveBeenCalledTimes(1);
+      expect(cb3).toHaveBeenCalledTimes(1);
+      suite(true, 'field_1');
+      expect(suite.get().tests.field_1.testCount).toBe(1);
+      expect(cb1).toHaveBeenCalledTimes(2);
+      expect(cb3).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should run fields that were previously omitted when changing to `false`', () => {
+      suite(true, 'field_3');
+      expect(suite.get().tests.field_3.testCount).toBe(0);
+      expect(cb4).toHaveBeenCalledTimes(0);
+      suite(false, 'field_3');
+      expect(suite.get().tests.field_3.testCount).toBe(1);
+      expect(cb4).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/vest/src/core/isolate/isolates/omitWhen.ts
+++ b/packages/vest/src/core/isolate/isolates/omitWhen.ts
@@ -1,0 +1,27 @@
+import optionalFunctionValue from 'optionalFunctionValue';
+
+import { IsolateTypes } from 'IsolateTypes';
+import ctx from 'ctx';
+import { isolate } from 'isolate';
+import { produceDraft, TDraftResult } from 'produceDraft';
+
+export default function omitWhen(
+  conditional: boolean | ((draft: TDraftResult) => boolean),
+  callback: (...args: any[]) => void
+): void {
+  isolate({ type: IsolateTypes.OMIT_WHEN }, () => {
+    ctx.run(
+      {
+        omitted: optionalFunctionValue(
+          conditional,
+          optionalFunctionValue(produceDraft)
+        ),
+      },
+      () => callback()
+    );
+  });
+}
+
+export function isOmitted(): boolean {
+  return !!ctx.useX().omitted;
+}

--- a/packages/vest/src/core/suite/produce/genTestsSummary.ts
+++ b/packages/vest/src/core/suite/produce/genTestsSummary.ts
@@ -64,7 +64,7 @@ function genTestObject(
 
   const testKey = summaryKey[fieldName];
 
-  if (testObject.isSkipped()) return testKey;
+  if (testObject.isSkipped() || testObject.isOmitted()) return testKey;
 
   summaryKey[fieldName].testCount++;
 

--- a/packages/vest/src/core/test/lib/registerPrevRunTest.ts
+++ b/packages/vest/src/core/test/lib/registerPrevRunTest.ts
@@ -3,22 +3,28 @@ import isPromise from 'isPromise';
 import VestTest from 'VestTest';
 import cancelOverriddenPendingTest from 'cancelOverriddenPendingTest';
 import { isExcluded, isExcludedIndividually } from 'exclusive';
+import { isOmitted } from 'omitWhen';
 import registerTest from 'registerTest';
 import runAsyncTest from 'runAsyncTest';
 import * as testCursor from 'testCursor';
 import { useTestAtCursor, useSetTestAtCursor } from 'useTestAtCursor';
 
+// eslint-disable-next-line max-statements
 export default function registerPrevRunTest(testObject: VestTest): VestTest {
   const prevRunTest = useTestAtCursor(testObject);
+
+  if (isOmitted()) {
+    prevRunTest.omit();
+    testCursor.moveForward();
+    return prevRunTest;
+  }
 
   if (isExcluded(testObject)) {
     // We're forcing skipping the pending test
     // if we're directly within a skipWhen block
     // This mostly means that we're probably giving
     // up on this async test intentionally.
-    if (isExcludedIndividually()) {
-      prevRunTest.omit();
-    }
+    prevRunTest.skip(isExcludedIndividually());
     testCursor.moveForward();
     return prevRunTest;
   }

--- a/packages/vest/src/core/test/lib/registerPrevRunTest.ts
+++ b/packages/vest/src/core/test/lib/registerPrevRunTest.ts
@@ -16,7 +16,9 @@ export default function registerPrevRunTest(testObject: VestTest): VestTest {
     // if we're directly within a skipWhen block
     // This mostly means that we're probably giving
     // up on this async test intentionally.
-    prevRunTest.skip(isExcludedIndividually());
+    if (isExcludedIndividually()) {
+      prevRunTest.omit();
+    }
     testCursor.moveForward();
     return prevRunTest;
   }

--- a/packages/vest/src/vest.ts
+++ b/packages/vest/src/vest.ts
@@ -4,6 +4,7 @@ import create from 'create';
 import each from 'each';
 import { only, skip } from 'exclusive';
 import group from 'group';
+import omitWhen from 'omitWhen';
 import optional from 'optionalTests';
 import skipWhen from 'skipWhen';
 import test from 'test';
@@ -20,6 +21,7 @@ export {
   group,
   optional,
   skipWhen,
+  omitWhen,
   enforce,
   VERSION,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -119,6 +119,7 @@
       "isolate": ["./packages/vest/src/core/isolate/isolate.ts"],
       "each": ["./packages/vest/src/core/isolate/isolates/each.ts"],
       "group": ["./packages/vest/src/core/isolate/isolates/group.ts"],
+      "omitWhen": ["./packages/vest/src/core/isolate/isolates/omitWhen.ts"],
       "skipWhen": ["./packages/vest/src/core/isolate/isolates/skipWhen.ts"],
       "IsolateTypes": ["./packages/vest/src/core/isolate/IsolateTypes.ts"],
       "createStateRef": ["./packages/vest/src/core/state/createStateRef.ts"],


### PR DESCRIPTION

# omitWhen - Conditionally omit tests from a suite

In some cases, we need to wish to omit certain portions of our suite in a way that these tests won't run, and will not count agains `isValid`. For example, when we have some tests that are only allowed to run when a certain checkbox is checked by the user.

Generally, when we skip fields, they are counted against `isValid`, meaning, unless specifically marked as `optional`, the suite will not be regarded as valid. Using `omitWhen` fixes it by both preventing the omitted tests from running, _and_ allowing the suite to be valid even without them.

## Differences from `skipWhen`

When using `skipWhen` the tests within the block will be skipped, but will still be counted against `isValid`. When using `omitWhen`, the tests within the block will be omitted, and will not be counted against `isValid`.

## Params

| Name        | Type                   | Description                                                                                           |
| :---------- | :--------------------- | :---------------------------------------------------------------------------------------------------- |
| Conditional | `boolean`/`function`\* | The conditional expression to be evaluated. When Truthy, the tests within `omitWhen` will be omitted. |
| Body        | `function`             | A callback function containing the tests to either omit or run.                                       |

\* When using the function conditional, the function will be passed the current validation result as an argument, so it can be used to skip tests based on the current validation result.

## Usage Example

```js
import { create, test, enforce, omitWhen, only } from "vest";

create((data = {}, currentField) => {
  only(currentField);

  test("username", "username is required", () => {
    enforce(data.username).isNotBlank();
  });

  omitWhen(data.useNewAddress, () => {
    test("address_line_1", "Address Line 1 is required", () => {
      enforce(data.address_line_1).isNotBlank();
    });

    test("city", "City is required", () => {
      enforce(data.city).isNotBlank();
    });

    test("postal_code", "Postal code is required", () => {
      enforce(data.postal_code).isNotBlank();
    });
  });
});
```

```js
omitWhen(
  (res) => res.hasErrors("username"),
  () => {
    test("username", "Username already exists", () => {
      // this is an example for a server call
      return doesUserExist(data.username);
    });
  }
);
```
