### PR TITLE
Use TLazyRuleRunners for isArrayOf

### DIFF
--- a/packages/n4s/src/plugins/schema/isArrayOf.ts
+++ b/packages/n4s/src/plugins/schema/isArrayOf.ts
@@ -1,6 +1,6 @@
 import mapFirst from 'mapFirst';
 
-import type { TLazy } from 'genEnforceLazy';
+import type { TLazyRuleRunners } from 'genEnforceLazy';
 import { ctx } from 'n4s';
 import type { TRuleDetailedResult } from 'ruleReturn';
 import * as ruleReturn from 'ruleReturn';
@@ -8,7 +8,7 @@ import runLazyRule from 'runLazyRule';
 
 export function isArrayOf(
   inputArray: any[],
-  currentRule: TLazy
+  currentRule: TLazyRuleRunners
 ): TRuleDetailedResult {
   return ruleReturn.defaultToPassing(
     mapFirst(inputArray, (currentValue, breakout, index) => {

--- a/packages/vest/src/exports/enforce@schema.ts
+++ b/packages/vest/src/exports/enforce@schema.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-unresolved
-import 'n4s/schema';
+import 'n4s/schema'; // eslint-disable-line import/no-unresolved


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Please fill the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✔ |
| Related issues   | Closing #773   |

<!-- Describe your changes below in detail. -->

It looks like the type definition for isArrayOf was too broad and it couldn't make sense of the compose return type which was not as broad. I changed it to use the bare minimum required for a validation, and it seems to fix it on my end.

To try it
```
npm i vest@4.0.3-dev-0bdac6
```