### PR TITLE
fix(package): deprecated folder mapping "./" in the "exports" field m…

### DIFF
--- a/packages/vest/package.json
+++ b/packages/vest/package.json
@@ -228,7 +228,7 @@
       "default": "./dist/cjs/vest.production.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "unpkg": "./dist/umd/vest.production.js",
   "jsdelivr": "./dist/umd/vest.production.js"


### PR DESCRIPTION
…odule resolution

NodeJS v14.20.0

(node:77968) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at D:\0\node_modules\vest\package.json.
Update this package.json to use a subpath pattern like "./*".
(Use `node --trace-deprecation ...` to show where the warning was created)

<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Please fill the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✔ |
| Deprecations?    | ✔ |

I'm using vest with nuxt3, and when I create a production build, I have a warning about vest package.json.
I saw a similar issue on postcss project : https://github.com/postcss/postcss/pull/1456

It seems that exports "./" is deprecated for node 13+ and should use pattern. I do not find any other information about this deprecation, but when I manually fix the package json, my production build ended without warn or error.
