### PR TITLE
initial

### DIFF
--- a/packages/vest/src/core/suite/produce/__tests__/produce.test.ts
+++ b/packages/vest/src/core/suite/produce/__tests__/produce.test.ts
@@ -111,8 +111,10 @@ describe('suite.get()', () => {
       expect(suite.get()).toMatchInlineSnapshot(`
         Object {
           "errorCount": 0,
+          "getError": [Function],
           "getErrors": [Function],
           "getErrorsByGroup": [Function],
+          "getWarning": [Function],
           "getWarnings": [Function],
           "getWarningsByGroup": [Function],
           "groups": Object {},
@@ -140,8 +142,10 @@ describe('suite()', () => {
         Object {
           "done": [Function],
           "errorCount": 0,
+          "getError": [Function],
           "getErrors": [Function],
           "getErrorsByGroup": [Function],
+          "getWarning": [Function],
           "getWarnings": [Function],
           "getWarningsByGroup": [Function],
           "groups": Object {},

--- a/packages/vest/src/core/suite/produce/summaryGenerators/SuiteSummaryTypes.ts
+++ b/packages/vest/src/core/suite/produce/summaryGenerators/SuiteSummaryTypes.ts
@@ -25,4 +25,8 @@ type SummaryBase = {
 
 export type GetFailuresResponse = FailureMessages | string[];
 
+export type GetFailureResponse = FailureMessage | string;
+
 export type FailureMessages = Record<string, string[]>;
+
+export type FailureMessage = Record<string, string>;

--- a/packages/vest/src/core/suite/produce/summarySelectors/__tests__/getFailures.test.ts
+++ b/packages/vest/src/core/suite/produce/summarySelectors/__tests__/getFailures.test.ts
@@ -1,8 +1,31 @@
+/* eslint-disable no-console */
 import { dummyTest } from '../../../../../../testUtils/testDummy';
 
 import * as vest from 'vest';
 
 describe('->getFailures', () => {
+  describe('getError', () => {
+    describe('When no error', () => {
+      describe('When requesting a fieldName', () => {
+        it('Should return an empty string', () => {
+          const suite = vest.create(() => {});
+          expect(suite().getError('field_1')).toBe('');
+          expect(suite.get().getError('field_1')).toBe('');
+        });
+      });
+    });
+    describe('When got an error', () => {
+      describe('When requesting a fieldName', () => {
+        it('Should return an empty string', () => {
+          const suite = vest.create(() => {
+            dummyTest.failing('field_1', 'msg_1');
+          });
+          expect(suite().getError('field_1')).toBe('msg_1');
+          expect(suite.get().getError('field_1')).toBe('msg_1');
+        });
+      });
+    });
+  });
   describe(`getErrors`, () => {
     describe('When no tests', () => {
       describe('When no parameters passed', () => {
@@ -80,6 +103,64 @@ describe('->getFailures', () => {
     });
   });
 
+  describe('getWarning', () => {
+    describe('When got no warning', () => {
+      describe('When no parameters passed', () => {
+        it('Should return an empty string', () => {
+          const suite = vest.create(() => {
+            dummyTest.passing('x');
+            dummyTest.passing('y');
+          });
+          expect(suite().getWarning()).toBe('');
+          expect(suite.get().getWarning()).toBe('');
+        });
+      });
+      describe('When requesting a fieldName', () => {
+        it('Should return an empty string', () => {
+          const suite = vest.create(() => {
+            dummyTest.passing('field_1');
+            dummyTest.passing();
+          });
+          expect(suite().getWarning('field_1')).toBe('');
+          expect(suite.get().getWarning('field_1')).toBe('');
+        });
+      });
+    });
+    describe('When there is a warning', () => {
+      describe('When no parameters passed', () => {
+        it('Should return an object with a string per field', () => {
+          const suite = vest.create(() => {
+            dummyTest.failingWarning('field_1', 'msg_1');
+            dummyTest.failingWarning('field_2', 'msg_2');
+            dummyTest.failingWarning('field_2', 'msg_3');
+            dummyTest.passingWarning('field_1', 'msg_4');
+            dummyTest.failing('field_1', 'msg_5');
+          });
+          expect(suite().getWarning()).toEqual({
+            field_1: 'msg_1',
+            field_2: 'msg_2',
+          });
+          expect(suite.get().getWarning()).toEqual({
+            field_1: 'msg_1',
+            field_2: 'msg_2',
+          });
+        });
+      });
+      describe('When requesting a fieldName', () => {
+        it('Should return a string message', () => {
+          const suite = vest.create(() => {
+            dummyTest.failingWarning('field_1', 'msg_1');
+            dummyTest.failingWarning('field_2', 'msg_2');
+            dummyTest.failingWarning('field_2', 'msg_3');
+            dummyTest.passingWarning('field_1', 'msg_4');
+            dummyTest.failing('field_1', 'msg_5');
+          });
+          expect(suite().getWarning('field_1')).toBe('msg_1');
+          expect(suite.get().getWarning('field_1')).toBe('msg_1');
+        });
+      });
+    });
+  });
   describe(`getWarnings`, () => {
     describe('When no testObjects', () => {
       describe('When no parameters passed', () => {
@@ -141,7 +222,7 @@ describe('->getFailures', () => {
         });
       });
       describe('When requesting a fieldName', () => {
-        it('Should return an empty array', () => {
+        it('Should return an array containing the field message', () => {
           const suite = vest.create(() => {
             dummyTest.failingWarning('field_1', 'msg_1');
             dummyTest.failingWarning('field_2', 'msg_2');

--- a/packages/vest/src/core/suite/produce/summarySelectors/suiteSelectors.ts
+++ b/packages/vest/src/core/suite/produce/summarySelectors/suiteSelectors.ts
@@ -91,7 +91,6 @@ export function suiteSelectors(summary: SuiteSummary): SuiteSelectors {
 
     const result: GetFailureResponse = {},
       warnings = getWarnings();
-    console.log({ getWarnings: warnings });
     if (!Object.keys(warnings).length) return '';
     Object.keys(warnings).forEach(
       (key: string) => (result[key] = warnings[key][0])

--- a/packages/vest/src/core/suite/produce/summarySelectors/suiteSelectors.ts
+++ b/packages/vest/src/core/suite/produce/summarySelectors/suiteSelectors.ts
@@ -3,7 +3,9 @@ import { isPositive } from 'vest-utils';
 import { Severity, SeverityCount } from 'Severity';
 import {
   FailureMessages,
+  FailureMessage,
   GetFailuresResponse,
+  GetFailureResponse,
   SuiteSummary,
   TestsContainer,
 } from 'SuiteSummaryTypes';
@@ -12,8 +14,10 @@ import { gatherFailures } from 'collectFailures';
 // eslint-disable-next-line max-lines-per-function, max-statements
 export function suiteSelectors(summary: SuiteSummary): SuiteSelectors {
   const selectors = {
+    getError,
     getErrors,
     getErrorsByGroup,
+    getWarning,
     getWarnings,
     getWarningsByGroup,
     hasErrors,
@@ -80,10 +84,30 @@ export function suiteSelectors(summary: SuiteSummary): SuiteSelectors {
 
   // Responses
 
+  function getWarning(): FailureMessage;
+  function getWarning(fieldName: string): string;
+  function getWarning(fieldName?: string): GetFailureResponse {
+    if (fieldName) return getWarnings(fieldName)[0] || '';
+
+    const result: GetFailureResponse = {},
+      warnings = getWarnings();
+    console.log({ getWarnings: warnings });
+    if (!Object.keys(warnings).length) return '';
+    Object.keys(warnings).forEach(
+      (key: string) => (result[key] = warnings[key][0])
+    );
+    return result;
+  }
+
   function getWarnings(): FailureMessages;
   function getWarnings(fieldName: string): string[];
   function getWarnings(fieldName?: string): GetFailuresResponse {
     return getFailures(summary, Severity.WARNINGS, fieldName);
+  }
+
+  function getError(fieldName: string): string;
+  function getError(fieldName: string): string {
+    return getErrors(fieldName)[0] || '';
   }
 
   function getErrors(): FailureMessages;
@@ -111,8 +135,10 @@ export function suiteSelectors(summary: SuiteSummary): SuiteSelectors {
 }
 
 export interface SuiteSelectors {
+  getError(fieldName?: string): string;
   getErrors(fieldName: string): string[];
   getErrors(): FailureMessages;
+  getWarning(fieldName?: string): string;
   getWarnings(): FailureMessages;
   getWarnings(fieldName: string): string[];
   getErrorsByGroup(groupName: string, fieldName: string): string[];

--- a/website/docs/api_reference.md
+++ b/website/docs/api_reference.md
@@ -90,7 +90,9 @@ After running your suite, the results object is returned. It has the following f
 
 - [hasErrors](./writing_your_suite/result_object.md#haserrors-and-haswarnings) - Returns true if the suite or the provided field has errors.
 - [hasWarnings](./writing_your_suite/result_object.md#haserrors-and-haswarnings) - Returns true if the suite or the provided field has warnings.
+- [getError](./writing_your_suite/result_object.md#geterror-and-getwarning) - Returns a string error in the suite, or for a specific field.
 - [getErrors](./writing_your_suite/result_object.md#geterrors-and-getwarnings) - Returns an object with errors in the suite, or an array of objects for a specific field.
+- [getWarning](./writing_your_suite/result_object.md#geterrors-and-getwarnings) - Returns a string with a warning in the suite, or for a specific field.
 - [getWarnings](./writing_your_suite/result_object.md#geterrors-and-getwarnings) - Returns an object with warnings in the suite, or an array of objects for a specific field.
 - [hasErrorsByGroup](./writing_your_suite/result_object.md#haserrorsbygroup-and-haswarningsbygroup) - Returns true if the provided group has errors.
 - [hasWarningByGroup](./writing_your_suite/result_object.md#haserrorsbygroup-and-haswarningsbygroup) - Returns true if the provided group has warnings.

--- a/website/docs/writing_your_suite/result_object.md
+++ b/website/docs/writing_your_suite/result_object.md
@@ -154,9 +154,31 @@ resultObject.hasWarningsByGroup('groupName');
 
 [Read more about groups](../writing_tests/advanced_test_features/grouping_tests.md)
 
+## `getError` and `getWarning`
+
+These functions return a string error for the specified field.
+
+```js
+resultObject.getError('username');
+// 'Username is too short'
+
+resultObject.getWarning('password');
+// 'Password must contain special characters'
+```
+
+If there is no error for the field, the function defaults to an empty string.
+
+```js
+resultObject.getError('username');
+// ""
+
+resultObject.getWarning('username');
+// ""
+```
+
 ## `getErrors` and `getWarnings`
 
-These functions return an array of errors for the specified field. If no field is specified, it returns an object with all fields as keys and their error arrays as values.
+These functions recive a field name and return an array of errors for the specified field. If no field is specified, it returns an object with all fields as keys and their error arrays as values.
 
 ```js
 resultObject.getErrors('username');


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Please fill the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         ✖ 
| New feature?      ✔
| Breaking change? ✖ 
| Deprecations?    ✖ 
| Documentation?   ✔
| Tests added?     |✔
| Types added?     |✔

Add singular form of the following: [https://github.com/ealush/vest/issues/808]

getErrors() -> getError()
getWarnings() -> getWarning()

The idea is to return the first error/warning of a field, instead of an array.
Unlike getErrors/getWarnings that can either take 0 or 1 arguments, getError/getWarning must receive a field name.
