### PR TITLE
docs: clearer server side function name

### DIFF
--- a/website/docs/understanding_state.md
+++ b/website/docs/understanding_state.md
@@ -95,7 +95,7 @@ To do that, all you need to do is wrap your suite initialization with a wrapper 
 ```js
 import { create } from 'vest';
 
-function suite(data) {
+function serversideStatelessCheck(data) {
   return create(() => {
     test('username', 'username is required', () => {
       enforce(data.username).isNotEmpty();
@@ -105,5 +105,5 @@ function suite(data) {
   // so what we return is actually the suite result
 }
 
-const result = suite({ username: 'Mike123' });
+const result = serversideStatelessCheck({ username: 'Mike123' });
 ```


### PR DESCRIPTION
Maybe we could change the function name to make clear what it does and where it should be used.

Alternatively, maybe vest could check internally for NODE_ENV and if it runs server-side, automatically transform to stateless so this security aspect is abstracted away and solved by default, which would be the most favorable approach.

<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Please fill the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✖ |
| New feature?     | ✖ |
| Breaking change? | ✖ |
| Deprecations?    | ✖ |
| Documentation?   | ✔ |
| Tests added?     | ✖ |
| Types added?     | ✖ |
| Related issues   |     |

<!-- Describe your changes below in detail. -->
