### PR TITLE
Fix a docs typo

### DIFF
--- a/website/docs/writing_tests/advanced_test_features/grouping_tests.md
+++ b/website/docs/writing_tests/advanced_test_features/grouping_tests.md
@@ -54,7 +54,7 @@ You may have in your application a multi-screen form in which you want to valida
 import { create, test, group, enforce, only } from 'vest';
 
 const suite = create((data, currentTab) => {
-  only.group(currentScreen);
+  only.group(currentTab);
 
   group('overview_tab', () => {
     test('productTitle', 'Must be at least 5 chars.', () => {


### PR DESCRIPTION

<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Please fill the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✖ |
| New feature?     | ✖ |
| Breaking change? | ✖ |
| Deprecations?    | ✖ |
| Documentation?   | ✔ |
| Tests added?     | ✖ |
| Types added?     | ✖ |
| Related issues   |     |

<!-- Describe your changes below in detail. -->
I believe there is a typo in the "Multi-stage form" example. This PR fixes the typo.
