### PR TITLE
patch(vest): add tsconfig.json to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 packages/*/src
+packages/*/tsconfig.json


### PR DESCRIPTION

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✔ |
| Related issues   |  /node_modules/vest/tsconfig.json  |

I have added tsconfig.json to .npmignore so it won't publish, as it seems to be the cause of this problem.

```
[{
    "resource": "/node_modules/vest/tsconfig.json",
    "owner": "typescript",
    "severity": 8,
    "message": "Option 'declarationDir' cannot be specified without specifying option 'declaration' or option 'composite'.",
    "source": "ts",
    "startLineNumber": 6,
    "startColumn": 5,
    "endLineNumber": 6,
    "endColumn": 21
},{
    "resource": "/node_modules/vest/tsconfig.json",
    "owner": "typescript",
    "severity": 8,
    "message": "Option 'declarationDir' cannot be specified without specifying option 'declaration' or option 'composite'.",
    "source": "ts",
    "startLineNumber": 7,
    "startColumn": 5,
    "endLineNumber": 7,
    "endColumn": 21
}]
```
