### PR TITLE
types(vest): fix `AsyncTest`, async test does not expect any returns

### DIFF
--- a/packages/vest/src/core/test/TestTypes.ts
+++ b/packages/vest/src/core/test/TestTypes.ts
@@ -3,7 +3,7 @@ import { Maybe } from 'vest-utils';
 import { TFieldName } from 'SuiteResultTypes';
 
 export type TestFn = () => TestResult;
-export type AsyncTest = Promise<Maybe<string | false>>;
+export type AsyncTest = Promise<void>;
 export type TestResult = Maybe<AsyncTest | boolean>;
 
 export type WithFieldName<F extends TFieldName = TFieldName> = {


### PR DESCRIPTION
| Q                | A   |
| ---------------- | --- |
| Types added?     | ✔/✖ |

Current type of `AsyncTest` implies that resolving async test with a string or false means something (I assume fail), but it is not. Async test is not supposed to return anything, any return is disregarded.

For record, it is trivial to add support for booleans as return type, just by adding `if (result === false) VestTestMutator.fail(testObject);` in promise [done callback](https://github.com/ealush/vest/blob/eeb8bceb6dc25a6ef702043b862c7379968d8597/packages/vest/src/core/test/testLevelFlowControl/runTest.ts#L104). I think it makes sense and I can change the PR to do so, but for now this is simply about reflecting current state.