### PR TITLE
Feature: new enforce rule - isURL

### DIFF
--- a/packages/n4s/.npmignore
+++ b/packages/n4s/.npmignore
@@ -5,7 +5,7 @@ src
 !dist/
 tsconfig.json
 !schema/
-!isUrl/
+!isURL/
 !email/
 !date/
 !compounds/

--- a/packages/n4s/.npmignore
+++ b/packages/n4s/.npmignore
@@ -5,6 +5,7 @@ src
 !dist/
 tsconfig.json
 !schema/
+!isUrl/
 !email/
 !date/
 !compounds/

--- a/packages/n4s/package.json
+++ b/packages/n4s/package.json
@@ -59,6 +59,36 @@
       "module": "./dist/es/schema.production.js",
       "default": "./dist/cjs/schema.production.js"
     },
+    "./isUrl": {
+      "production": {
+        "types": "./types/isUrl.d.ts",
+        "browser": "./dist/es/isUrl.production.js",
+        "umd": "./dist/umd/isUrl.production.js",
+        "import": "./dist/es/isUrl.production.js",
+        "require": "./dist/cjs/isUrl.production.js",
+        "node": "./dist/cjs/isUrl.production.js",
+        "module": "./dist/es/isUrl.production.js",
+        "default": "./dist/cjs/isUrl.production.js"
+      },
+      "development": {
+        "types": "./types/isUrl.d.ts",
+        "browser": "./dist/es/isUrl.development.js",
+        "umd": "./dist/umd/isUrl.development.js",
+        "import": "./dist/es/isUrl.development.js",
+        "require": "./dist/cjs/isUrl.development.js",
+        "node": "./dist/cjs/isUrl.development.js",
+        "module": "./dist/es/isUrl.development.js",
+        "default": "./dist/cjs/isUrl.development.js"
+      },
+      "types": "./types/isUrl.d.ts",
+      "browser": "./dist/es/isUrl.production.js",
+      "umd": "./dist/umd/isUrl.production.js",
+      "import": "./dist/es/isUrl.production.js",
+      "require": "./dist/cjs/isUrl.production.js",
+      "node": "./dist/cjs/isUrl.production.js",
+      "module": "./dist/es/isUrl.production.js",
+      "default": "./dist/cjs/isUrl.production.js"
+    },
     "./email": {
       "production": {
         "types": "./types/email.d.ts",

--- a/packages/n4s/package.json
+++ b/packages/n4s/package.json
@@ -59,35 +59,35 @@
       "module": "./dist/es/schema.production.js",
       "default": "./dist/cjs/schema.production.js"
     },
-    "./isUrl": {
+    "./isURL": {
       "production": {
-        "types": "./types/isUrl.d.ts",
-        "browser": "./dist/es/isUrl.production.js",
-        "umd": "./dist/umd/isUrl.production.js",
-        "import": "./dist/es/isUrl.production.js",
-        "require": "./dist/cjs/isUrl.production.js",
-        "node": "./dist/cjs/isUrl.production.js",
-        "module": "./dist/es/isUrl.production.js",
-        "default": "./dist/cjs/isUrl.production.js"
+        "types": "./types/isURL.d.ts",
+        "browser": "./dist/es/isURL.production.js",
+        "umd": "./dist/umd/isURL.production.js",
+        "import": "./dist/es/isURL.production.js",
+        "require": "./dist/cjs/isURL.production.js",
+        "node": "./dist/cjs/isURL.production.js",
+        "module": "./dist/es/isURL.production.js",
+        "default": "./dist/cjs/isURL.production.js"
       },
       "development": {
-        "types": "./types/isUrl.d.ts",
-        "browser": "./dist/es/isUrl.development.js",
-        "umd": "./dist/umd/isUrl.development.js",
-        "import": "./dist/es/isUrl.development.js",
-        "require": "./dist/cjs/isUrl.development.js",
-        "node": "./dist/cjs/isUrl.development.js",
-        "module": "./dist/es/isUrl.development.js",
-        "default": "./dist/cjs/isUrl.development.js"
+        "types": "./types/isURL.d.ts",
+        "browser": "./dist/es/isURL.development.js",
+        "umd": "./dist/umd/isURL.development.js",
+        "import": "./dist/es/isURL.development.js",
+        "require": "./dist/cjs/isURL.development.js",
+        "node": "./dist/cjs/isURL.development.js",
+        "module": "./dist/es/isURL.development.js",
+        "default": "./dist/cjs/isURL.development.js"
       },
-      "types": "./types/isUrl.d.ts",
-      "browser": "./dist/es/isUrl.production.js",
-      "umd": "./dist/umd/isUrl.production.js",
-      "import": "./dist/es/isUrl.production.js",
-      "require": "./dist/cjs/isUrl.production.js",
-      "node": "./dist/cjs/isUrl.production.js",
-      "module": "./dist/es/isUrl.production.js",
-      "default": "./dist/cjs/isUrl.production.js"
+      "types": "./types/isURL.d.ts",
+      "browser": "./dist/es/isURL.production.js",
+      "umd": "./dist/umd/isURL.production.js",
+      "import": "./dist/es/isURL.production.js",
+      "require": "./dist/cjs/isURL.production.js",
+      "node": "./dist/cjs/isURL.production.js",
+      "module": "./dist/es/isURL.production.js",
+      "default": "./dist/cjs/isURL.production.js"
     },
     "./email": {
       "production": {

--- a/packages/n4s/src/exports/__tests__/isUrl.test.ts
+++ b/packages/n4s/src/exports/__tests__/isUrl.test.ts
@@ -1,0 +1,51 @@
+import { enforce } from 'n4s';
+import 'isUrl';
+
+describe('isUrl', () => {
+  it('Should pass for valid urls', () => {
+    expect(() => enforce('http://www.google.com').isUrl()).not.toThrow();
+    expect(() => enforce('https://google.com').isUrl()).not.toThrow();
+    expect(() => enforce('google.com').isUrl()).not.toThrow();
+    expect(() => enforce('https://www.wikipedia.org/wiki/Main_Page').isUrl()).not.toThrow();
+    expect(() => enforce('ftp://myserver.net').isUrl()).not.toThrow();
+    expect(() => enforce('https://www.example.com/query?search=AI').isUrl()).not.toThrow();
+    expect(() => enforce('https://username:password@hostname.com:8080').isUrl()).not.toThrow();
+    expect(() => enforce('http://233.233.233.233').isUrl()).not.toThrow();
+    expect(() => enforce('https://www.example.com/foo/?bar=baz&inga=42&quux').isUrl()).not.toThrow();
+    expect(() => enforce('http://www.example.com/index.html#section1').isUrl()).not.toThrow();
+  });
+
+  it('Should fail for invalid urls', () => {
+    expect(() => enforce('').isUrl()).toThrow();
+    expect(() => enforce('google').isUrl()).toThrow();
+    expect(() => enforce('http://').isUrl()).toThrow();
+    expect(() => enforce('https://').isUrl()).toThrow();
+    expect(() => enforce('www.google.').isUrl()).toThrow();
+    expect(() => enforce('http://google').isUrl()).toThrow();
+    expect(() => enforce('https://google').isUrl()).toThrow();
+    expect(() => enforce('http:///www.google.com').isUrl()).toThrow();
+    expect(() => enforce('https:///www.google.com').isUrl()).toThrow();
+    expect(() => enforce('http://www.goo gle.com').isUrl()).toThrow();
+    expect(() => enforce('://www.google.com').isUrl()).toThrow();
+    expect(() => enforce('http://localhost').isUrl()).toThrow();
+    expect(() => enforce('www.com').isUrl({ require_host: false })).not.toThrow();
+  })
+
+  describe('With options', () => {
+    it('should pass for valid urls', () => {
+        expect(() => enforce('myprotocol://customdomain.com').isUrl({ protocols: ['myprotocol'] })).not.toThrow();
+        expect(() => enforce('http://localhost:8080').isUrl({ require_tld: false })).not.toThrow();
+        expect(() => enforce('invalid://www.google.com').isUrl({ require_valid_protocol: false })).not.toThrow();
+        expect(() => enforce('http://my_server.com').isUrl({ allow_underscores: true })).not.toThrow();
+    });
+
+    it('should fail for invalid urls', () => {
+        expect(() => enforce('myprotocol://customdomain.com').isUrl({ protocols: ['http'] })).toThrow();
+        expect(() => enforce('http://localhost:8080').isUrl({ require_tld: true })).toThrow();
+        expect(() => enforce('invalid://www.google.com').isUrl({ require_valid_protocol: true })).toThrow();
+        expect(() => enforce('http://my_server.com').isUrl({ allow_underscores: false })).toThrow();
+        expect(() => enforce('http://www.example.com/index.html#section1').isUrl({ allow_fragments: false })).toThrow();
+    });
+  });
+
+});

--- a/packages/n4s/src/exports/__tests__/isUrl.test.ts
+++ b/packages/n4s/src/exports/__tests__/isUrl.test.ts
@@ -1,50 +1,50 @@
 import { enforce } from 'n4s';
-import 'isUrl';
+import 'isURL';
 
-describe('isUrl', () => {
-  it('Should pass for valid urls', () => {
-    expect(() => enforce('http://www.google.com').isUrl()).not.toThrow();
-    expect(() => enforce('https://google.com').isUrl()).not.toThrow();
-    expect(() => enforce('google.com').isUrl()).not.toThrow();
-    expect(() => enforce('https://www.wikipedia.org/wiki/Main_Page').isUrl()).not.toThrow();
-    expect(() => enforce('ftp://myserver.net').isUrl()).not.toThrow();
-    expect(() => enforce('https://www.example.com/query?search=AI').isUrl()).not.toThrow();
-    expect(() => enforce('https://username:password@hostname.com:8080').isUrl()).not.toThrow();
-    expect(() => enforce('http://233.233.233.233').isUrl()).not.toThrow();
-    expect(() => enforce('https://www.example.com/foo/?bar=baz&inga=42&quux').isUrl()).not.toThrow();
-    expect(() => enforce('http://www.example.com/index.html#section1').isUrl()).not.toThrow();
+describe('isURL', () => {
+  it('Should pass for valid URLs', () => {
+    expect(() => enforce('http://www.google.com').isURL()).not.toThrow();
+    expect(() => enforce('https://google.com').isURL()).not.toThrow();
+    expect(() => enforce('google.com').isURL()).not.toThrow();
+    expect(() => enforce('https://www.wikipedia.org/wiki/Main_Page').isURL()).not.toThrow();
+    expect(() => enforce('ftp://myserver.net').isURL()).not.toThrow();
+    expect(() => enforce('https://www.example.com/query?search=AI').isURL()).not.toThrow();
+    expect(() => enforce('https://username:password@hostname.com:8080').isURL()).not.toThrow();
+    expect(() => enforce('http://233.233.233.233').isURL()).not.toThrow();
+    expect(() => enforce('https://www.example.com/foo/?bar=baz&inga=42&quux').isURL()).not.toThrow();
+    expect(() => enforce('http://www.example.com/index.html#section1').isURL()).not.toThrow();
   });
 
-  it('Should fail for invalid urls', () => {
-    expect(() => enforce('').isUrl()).toThrow();
-    expect(() => enforce('google').isUrl()).toThrow();
-    expect(() => enforce('http://').isUrl()).toThrow();
-    expect(() => enforce('https://').isUrl()).toThrow();
-    expect(() => enforce('www.google.').isUrl()).toThrow();
-    expect(() => enforce('http://google').isUrl()).toThrow();
-    expect(() => enforce('https://google').isUrl()).toThrow();
-    expect(() => enforce('http:///www.google.com').isUrl()).toThrow();
-    expect(() => enforce('https:///www.google.com').isUrl()).toThrow();
-    expect(() => enforce('http://www.goo gle.com').isUrl()).toThrow();
-    expect(() => enforce('://www.google.com').isUrl()).toThrow();
-    expect(() => enforce('http://localhost').isUrl()).toThrow();
-    expect(() => enforce('www.com').isUrl({ require_host: false })).not.toThrow();
+  it('Should fail for invalid URLs', () => {
+    expect(() => enforce('').isURL()).toThrow();
+    expect(() => enforce('google').isURL()).toThrow();
+    expect(() => enforce('http://').isURL()).toThrow();
+    expect(() => enforce('https://').isURL()).toThrow();
+    expect(() => enforce('www.google.').isURL()).toThrow();
+    expect(() => enforce('http://google').isURL()).toThrow();
+    expect(() => enforce('https://google').isURL()).toThrow();
+    expect(() => enforce('http:///www.google.com').isURL()).toThrow();
+    expect(() => enforce('https:///www.google.com').isURL()).toThrow();
+    expect(() => enforce('http://www.goo gle.com').isURL()).toThrow();
+    expect(() => enforce('://www.google.com').isURL()).toThrow();
+    expect(() => enforce('http://localhost').isURL()).toThrow();
+    expect(() => enforce('www.com').isURL({ require_host: false })).not.toThrow();
   })
 
   describe('With options', () => {
-    it('should pass for valid urls', () => {
-        expect(() => enforce('myprotocol://customdomain.com').isUrl({ protocols: ['myprotocol'] })).not.toThrow();
-        expect(() => enforce('http://localhost:8080').isUrl({ require_tld: false })).not.toThrow();
-        expect(() => enforce('invalid://www.google.com').isUrl({ require_valid_protocol: false })).not.toThrow();
-        expect(() => enforce('http://my_server.com').isUrl({ allow_underscores: true })).not.toThrow();
+    it('should pass for valid URLs', () => {
+        expect(() => enforce('myprotocol://customdomain.com').isURL({ protocols: ['myprotocol'] })).not.toThrow();
+        expect(() => enforce('http://localhost:8080').isURL({ require_tld: false })).not.toThrow();
+        expect(() => enforce('invalid://www.google.com').isURL({ require_valid_protocol: false })).not.toThrow();
+        expect(() => enforce('http://my_server.com').isURL({ allow_underscores: true })).not.toThrow();
     });
 
-    it('should fail for invalid urls', () => {
-        expect(() => enforce('myprotocol://customdomain.com').isUrl({ protocols: ['http'] })).toThrow();
-        expect(() => enforce('http://localhost:8080').isUrl({ require_tld: true })).toThrow();
-        expect(() => enforce('invalid://www.google.com').isUrl({ require_valid_protocol: true })).toThrow();
-        expect(() => enforce('http://my_server.com').isUrl({ allow_underscores: false })).toThrow();
-        expect(() => enforce('http://www.example.com/index.html#section1').isUrl({ allow_fragments: false })).toThrow();
+    it('should fail for invalid URLs', () => {
+        expect(() => enforce('myprotocol://customdomain.com').isURL({ protocols: ['http'] })).toThrow();
+        expect(() => enforce('http://localhost:8080').isURL({ require_tld: true })).toThrow();
+        expect(() => enforce('invalid://www.google.com').isURL({ require_valid_protocol: true })).toThrow();
+        expect(() => enforce('http://my_server.com').isURL({ allow_underscores: false })).toThrow();
+        expect(() => enforce('http://www.example.com/index.html#section1').isURL({ allow_fragments: false })).toThrow();
     });
   });
 

--- a/packages/n4s/src/exports/isUrl.ts
+++ b/packages/n4s/src/exports/isUrl.ts
@@ -1,0 +1,15 @@
+import { enforce } from 'n4s';
+import isUrl from 'validator/es/lib/isUrl';
+
+import { EnforceCustomMatcher } from 'enforceUtilityTypes';
+
+enforce.extend({ isUrl });
+
+/* eslint-disable @typescript-eslint/no-namespace */
+declare global {
+  namespace n4s {
+    interface EnforceCustomMatchers<R> {
+      isUrl: EnforceCustomMatcher<typeof isUrl, R>;
+    }
+  }
+}

--- a/packages/n4s/src/exports/isUrl.ts
+++ b/packages/n4s/src/exports/isUrl.ts
@@ -1,15 +1,15 @@
 import { enforce } from 'n4s';
-import isUrl from 'validator/es/lib/isUrl';
+import isURL from 'validator/es/lib/isURL';
 
 import { EnforceCustomMatcher } from 'enforceUtilityTypes';
 
-enforce.extend({ isUrl });
+enforce.extend({ isURL });
 
 /* eslint-disable @typescript-eslint/no-namespace */
 declare global {
   namespace n4s {
     interface EnforceCustomMatchers<R> {
-      isUrl: EnforceCustomMatcher<typeof isUrl, R>;
+      isURL: EnforceCustomMatcher<typeof isURL, R>;
     }
   }
 }

--- a/packages/n4s/tsconfig.json
+++ b/packages/n4s/tsconfig.json
@@ -53,7 +53,7 @@
       "ruleReturn": ["./src/lib/ruleReturn.ts"],
       "enforceUtilityTypes": ["./src/lib/enforceUtilityTypes.ts"],
       "schema": ["./src/exports/schema.ts"],
-      "isUrl": ["./src/exports/isUrl.ts"],
+      "isURL": ["./src/exports/isURL.ts"],
       "email": ["./src/exports/email.ts"],
       "date": ["./src/exports/date.ts"],
       "compounds": ["./src/exports/compounds.ts"],

--- a/packages/n4s/tsconfig.json
+++ b/packages/n4s/tsconfig.json
@@ -53,6 +53,7 @@
       "ruleReturn": ["./src/lib/ruleReturn.ts"],
       "enforceUtilityTypes": ["./src/lib/enforceUtilityTypes.ts"],
       "schema": ["./src/exports/schema.ts"],
+      "isUrl": ["./src/exports/isUrl.ts"],
       "email": ["./src/exports/email.ts"],
       "date": ["./src/exports/date.ts"],
       "compounds": ["./src/exports/compounds.ts"],

--- a/website/docs/enforce/builtin-enforce-plugins/isUrl.md
+++ b/website/docs/enforce/builtin-enforce-plugins/isUrl.md
@@ -1,0 +1,60 @@
+---
+sidebar_position: 4
+title: isUrl enforce Rule
+description: isUrl enforce rule for validating url addresses.
+keywords: [Vest, enforce, plugin, isUrl, n4s, url]
+---
+
+# isUrl Enforce Rule
+
+## Description
+
+The isUrl enforce rule provides functionality to validate URL values. This documentation covers the `isUrl` rule, along with its options and configurations.
+
+These rule exposes the [`validator.js`](https://www.npmjs.com/package/validator) isUrl rule, and accepts the same options.
+
+## isUrl Rule
+
+The `isUrl` rule checks whether a given value is a valid URL. It accepts various options to customize the validation behavior.
+
+```javascript
+enforce(value).isUrl(options);
+```
+
+### Options
+
+The isUrl rule accepts an optional options object to customize the validation behavior. The available options are as follows:
+
+The `isUrl` rule accepts an optional `options` object to customize the validation behavior. The available options are as follows:
+
+| Option                        | Default Value | Description                                                                                                           |
+| ----------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `require_protocol`            | `false`       | Requires the URL to include a protocol (e.g., `http://` or `https://`).                                                |
+| `require_host`                | `true`        | Requires the URL to include a host (e.g., `www.example.com`).                                                         |
+| `require_valid_protocol`      | `true`        | Requires the URL's protocol to be in the list of valid protocols (`http`, `https`, `ftp`).                            |
+| `allow_underscores`           | `false`       | Allows underscores in the host name.                                                                                  |
+| `allow_trailing_dot`          | `false`       | Allows a trailing dot in the host name.                                                                               |
+| `allow_protocol_relative_urls`| `false`       | Allows protocol-relative URLs (e.g., `//www.example.com`).                                                            |
+| `allow_fragments`             | `true`        | Allows URL fragments (e.g., `#section`).                                                                              |
+| `allow_query_components`      | `true`        | Allows query components in the URL (e.g., `?query=value`).                                                            |
+| `validate_length`             | `true`        | Validates that the URL length does not exceed the maximum allowed length (2083 characters).                           |
+
+### Usage Example
+
+```javascript
+// Usage with options
+enforce(url).isUrl({
+  protocols: ['http', 'https', 'ftp'],
+  require_tld: true,
+  require_protocol: false,
+  require_host: true,
+  require_port: false,
+  require_valid_protocol: true,
+  allow_underscores: false,
+  allow_trailing_dot: false,
+  allow_protocol_relative_urls: false,
+  allow_fragments: true,
+  allow_query_components: true,
+  validate_length: true
+});
+```

--- a/website/docs/enforce/builtin-enforce-plugins/isUrl.md
+++ b/website/docs/enforce/builtin-enforce-plugins/isUrl.md
@@ -1,29 +1,29 @@
 ---
 sidebar_position: 4
-title: isUrl enforce Rule
-description: isUrl enforce rule for validating url addresses.
-keywords: [Vest, enforce, plugin, isUrl, n4s, url]
+title: isURL enforce Rule
+description: isURL enforce rule for validating url addresses.
+keywords: [Vest, enforce, plugin, isURL, n4s, url]
 ---
 
-# isUrl Enforce Rule
+# isURL Enforce Rule
 
 ## Description
 
-The isUrl enforce rule provides functionality to validate URL values. This documentation covers the `isUrl` rule, along with its options and configurations.
+The isURL enforce rule provides functionality to validate URL values. This documentation covers the `isUrl` rule, along with its options and configurations.
 
-These rule exposes the [`validator.js`](https://www.npmjs.com/package/validator) isUrl rule, and accepts the same options.
+These rule exposes the [`validator.js`](https://www.npmjs.com/package/validator) isURL rule, and accepts the same options.
 
-## isUrl Rule
+## isURL Rule
 
-The `isUrl` rule checks whether a given value is a valid URL. It accepts various options to customize the validation behavior.
+The `isURL` rule checks whether a given value is a valid URL. It accepts various options to customize the validation behavior.
 
 ```javascript
-enforce(value).isUrl(options);
+enforce(value).isURL(options);
 ```
 
 ### Options
 
-The isUrl rule accepts an optional options object to customize the validation behavior. The available options are as follows:
+The isURL rule accepts an optional options object to customize the validation behavior. The available options are as follows:
 
 The `isUrl` rule accepts an optional `options` object to customize the validation behavior. The available options are as follows:
 
@@ -43,7 +43,7 @@ The `isUrl` rule accepts an optional `options` object to customize the validatio
 
 ```javascript
 // Usage with options
-enforce(url).isUrl({
+enforce(url).isURL({
   protocols: ['http', 'https', 'ftp'],
   require_tld: true,
   require_protocol: false,


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Please fill out the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✖ |
| New feature?     | ✔ |
| Breaking change? | ✖ |
| Deprecations?    | ✖ |
| Documentation?   | ✔ |
| Tests added?     | ✔ |
| Types added?     | ✖ |
| Related issues   |     |

<!-- Describe your changes below in detail. -->

This PR includes a new feature for the n4s package, the New isURL enforce rule provides functionality to validate URL values.

This rule exposes the [`validator.js`](https://www.npmjs.com/package/validator) isURL rule and accepts the same options.

The file name is not `url.ts` like the other rules files convention (ex: `email.ts`) because jest is not able to find the file, and instead, it searches for the url module on node_modules, I currently wasn't able to fix it.
