### PR TITLE
types: remove `void` from `Maybe<T>` and update `SuiteSelectors`

### DIFF
--- a/packages/vest-utils/src/utilityTypes.ts
+++ b/packages/vest-utils/src/utilityTypes.ts
@@ -12,7 +12,7 @@ export type Nullish<T = void> = Nullable<T> | Maybe<T>;
 
 export type Nullable<T> = T | null;
 
-export type Maybe<T> = T | undefined | void;
+export type Maybe<T> = T | undefined;
 
 export type OneOrMoreOf<T> = T | T[];
 

--- a/packages/vest/src/core/test/TestTypes.ts
+++ b/packages/vest/src/core/test/TestTypes.ts
@@ -6,7 +6,7 @@ type TestFnPayload = { signal: AbortSignal };
 
 export type TestFn = (payload: TestFnPayload) => TestResult;
 export type AsyncTest = Promise<void>;
-export type TestResult = Maybe<AsyncTest | boolean>;
+export type TestResult = Maybe<AsyncTest | boolean> | void;
 
 export type WithFieldName<F extends TFieldName = TFieldName> = {
   fieldName: F;

--- a/packages/vest/src/suiteResult/SummaryFailure.ts
+++ b/packages/vest/src/suiteResult/SummaryFailure.ts
@@ -1,5 +1,3 @@
-import { Maybe } from 'vest-utils';
-
 import { TIsolateTest } from 'IsolateTest';
 import { TFieldName, TGroupName } from 'SuiteResultTypes';
 import { WithFieldName } from 'TestTypes';
@@ -10,8 +8,8 @@ export class SummaryFailure<F extends TFieldName, G extends TGroupName>
 {
   constructor(
     public fieldName: F,
-    public message: Maybe<string>,
-    public groupName: Maybe<G>
+    public message: string | undefined,
+    public groupName: G | undefined
   ) {}
 
   static fromTestObject<F extends TFieldName, G extends TGroupName>(

--- a/packages/vest/src/suiteResult/selectors/suiteSelectors.ts
+++ b/packages/vest/src/suiteResult/selectors/suiteSelectors.ts
@@ -149,7 +149,7 @@ export function suiteSelectors<F extends TFieldName, G extends TGroupName>(
 
   function getWarning(): Maybe<SummaryFailure<F, G>>;
   function getWarning(fieldName: F): Maybe<string>;
-  function getWarning(fieldName?: F): GetSingularResponse<F, G> {
+  function getWarning(fieldName?: F): Maybe<SummaryFailure<F, G> | string> {
     return getFailure<F, G>(Severity.WARNINGS, summary, fieldName as F);
   }
 
@@ -161,7 +161,7 @@ export function suiteSelectors<F extends TFieldName, G extends TGroupName>(
 
   function getError(): Maybe<SummaryFailure<F, G>>;
   function getError(fieldName: F): Maybe<string>;
-  function getError(fieldName?: F): GetSingularResponse<F, G> {
+  function getError(fieldName?: F): Maybe<SummaryFailure<F, G> | string> {
     return getFailure<F, G>(Severity.ERRORS, summary, fieldName as F);
   }
 
@@ -188,12 +188,12 @@ export function suiteSelectors<F extends TFieldName, G extends TGroupName>(
 }
 
 export interface SuiteSelectors<F extends TFieldName, G extends TGroupName> {
-  getWarning(): Maybe<SummaryFailure<F, G>>;
-  getWarning(fieldName: F): Maybe<string>;
-  getWarning(fieldName?: F): GetSingularResponse<F, G>;
-  getError(): Maybe<SummaryFailure<F, G>>;
-  getError(fieldName: F): Maybe<string>;
-  getError(fieldName?: F): GetSingularResponse<F, G>;
+  getWarning(): SummaryFailure<F, G> | undefined;
+  getWarning(fieldName: F): string | undefined;
+  getWarning(fieldName?: F): SummaryFailure<F, G> | string | undefined;
+  getError(): SummaryFailure<F, G> | undefined;
+  getError(fieldName: F): string | undefined;
+  getError(fieldName?: F): SummaryFailure<F, G> | string | undefined;
   getErrors(): FailureMessages;
   getErrors(fieldName: F): string[];
   getErrors(fieldName?: F): string[] | FailureMessages;
@@ -319,7 +319,3 @@ function getFailure<F extends TFieldName, G extends TGroupName>(
       matchingFieldName(summaryFailure, fieldName)
   )?.message;
 }
-
-type GetSingularResponse<F extends TFieldName, G extends TGroupName> = Maybe<
-  string | SummaryFailure<F, G>
->;


### PR DESCRIPTION
| Q                | A   |
| ---------------- | --- |
| Types added?     | ✔/✖ |

In #1070 I've referenced `Maybe` in exported type. Did not know that `Maybe` is an internal helper type. Because of this I've met errors of such sort:
```
The inferred type of 'getError' cannot be named without a reference to '.pnpm/vest-utils@1.0.2/node_modules/vest-utils'. This is likely not portable. A type annotation is necessary.
```

So this PR removes `Maybe` usage from `SuiteSelectors`. 

But while doing it I've encountered resistance from typescript because `Maybe<T>` is currently defined as `T | undefined | void`. I think it is mistake to include `void` because it is a special thing - something like `unknown` but one that you should not touch at all, only discard. So I've changed `Maybe` to simple `T | undefined`.