### PR TITLE
2024-03-30-debouce

### DIFF
--- a/packages/vest/.npmignore
+++ b/packages/vest/.npmignore
@@ -12,6 +12,7 @@ tsconfig.json
 !enforce@date/
 !enforce@compounds/
 !enforce@compose/
+!debounce/
 !classnames/
 !SuiteSerializer/
 

--- a/packages/vest/package.json
+++ b/packages/vest/package.json
@@ -283,6 +283,36 @@
       "module": "./dist/es/enforce/compose.production.js",
       "default": "./dist/cjs/enforce/compose.production.js"
     },
+    "./debounce": {
+      "production": {
+        "types": "./types/debounce.d.ts",
+        "browser": "./dist/es/debounce.production.js",
+        "umd": "./dist/umd/debounce.production.js",
+        "import": "./dist/es/debounce.production.js",
+        "require": "./dist/cjs/debounce.production.js",
+        "node": "./dist/cjs/debounce.production.js",
+        "module": "./dist/es/debounce.production.js",
+        "default": "./dist/cjs/debounce.production.js"
+      },
+      "development": {
+        "types": "./types/debounce.d.ts",
+        "browser": "./dist/es/debounce.development.js",
+        "umd": "./dist/umd/debounce.development.js",
+        "import": "./dist/es/debounce.development.js",
+        "require": "./dist/cjs/debounce.development.js",
+        "node": "./dist/cjs/debounce.development.js",
+        "module": "./dist/es/debounce.development.js",
+        "default": "./dist/cjs/debounce.development.js"
+      },
+      "types": "./types/debounce.d.ts",
+      "browser": "./dist/es/debounce.production.js",
+      "umd": "./dist/umd/debounce.production.js",
+      "import": "./dist/es/debounce.production.js",
+      "require": "./dist/cjs/debounce.production.js",
+      "node": "./dist/cjs/debounce.production.js",
+      "module": "./dist/es/debounce.production.js",
+      "default": "./dist/cjs/debounce.production.js"
+    },
     "./classnames": {
       "production": {
         "types": "./types/classnames.d.ts",

--- a/packages/vest/src/core/isolate/IsolateTest/IsolateTestReconciler.ts
+++ b/packages/vest/src/core/isolate/IsolateTest/IsolateTestReconciler.ts
@@ -3,7 +3,6 @@ import { IsolateInspector, Reconciler } from 'vestjs-runtime';
 import type { TIsolate } from 'vestjs-runtime';
 
 import { ErrorStrings } from 'ErrorStrings';
-import { IsolateReconciler } from 'IsolateReconciler';
 import type { TIsolateTest } from 'IsolateTest';
 import { VestTest } from 'VestTest';
 import cancelOverriddenPendingTest from 'cancelOverriddenPendingTest';
@@ -11,7 +10,7 @@ import { isSameProfileTest } from 'isSameProfileTest';
 import { useIsExcluded } from 'useIsExcluded';
 import { useVerifyTestRun } from 'verifyTestRun';
 
-export class IsolateTestReconciler extends IsolateReconciler {
+export class IsolateTestReconciler {
   static match(currentNode: TIsolate, historyNode: TIsolate): boolean {
     return VestTest.is(currentNode) && VestTest.is(historyNode);
   }

--- a/packages/vest/src/core/isolate/VestReconciler.ts
+++ b/packages/vest/src/core/isolate/VestReconciler.ts
@@ -3,13 +3,28 @@ import { TIsolate } from 'vestjs-runtime';
 
 import { IsolateTestReconciler } from 'IsolateTestReconciler';
 
+const reconcilers: IsolateReconciler[] = [IsolateTestReconciler];
+
+export function registerIsolateReconciler(reconciler: IsolateReconciler) {
+  if (reconcilers.includes(reconciler)) {
+    return;
+  }
+
+  reconcilers.push(reconciler);
+}
+
 export function VestReconciler(
   currentNode: TIsolate,
-  historyNode: TIsolate
+  historyNode: TIsolate,
 ): Nullable<TIsolate> {
   return (
-    [IsolateTestReconciler]
+    reconcilers
       .find(reconciler => reconciler.match(currentNode, historyNode))
       ?.reconcile(currentNode as any, historyNode as any) ?? null
   );
 }
+
+export type IsolateReconciler = {
+  match(currentNode: TIsolate, historyNode: TIsolate): boolean;
+  reconcile(elecurrentNode: TIsolate, historyNode: TIsolate): TIsolate;
+};

--- a/packages/vest/src/core/isolate/VestReconciler.ts
+++ b/packages/vest/src/core/isolate/VestReconciler.ts
@@ -5,7 +5,7 @@ import { IsolateTestReconciler } from 'IsolateTestReconciler';
 
 const reconcilers: IsolateReconciler[] = [IsolateTestReconciler];
 
-export function registerIsolateReconciler(reconciler: IsolateReconciler) {
+export function registerReconciler(reconciler: IsolateReconciler) {
   if (reconcilers.includes(reconciler)) {
     return;
   }

--- a/packages/vest/src/core/test/TestTypes.ts
+++ b/packages/vest/src/core/test/TestTypes.ts
@@ -2,7 +2,7 @@ import { Maybe } from 'vest-utils';
 
 import { TFieldName } from 'SuiteResultTypes';
 
-type TestFnPayload = { signal: AbortSignal };
+export type TestFnPayload = { signal: AbortSignal };
 
 export type TestFn = (payload: TestFnPayload) => TestResult;
 export type AsyncTest = Promise<void>;

--- a/packages/vest/src/exports/__tests__/debounce.test.ts
+++ b/packages/vest/src/exports/__tests__/debounce.test.ts
@@ -1,0 +1,233 @@
+import wait from 'wait';
+
+import { TestFnPayload } from 'TestTypes';
+import * as vest from 'vest';
+import debounce from 'vest/debounce';
+
+describe('debounce', () => {
+  describe('Sync test', () => {
+    describe('Returning false', () => {
+      it('Should debounce test function calls when used', () => {
+        const test = jest.fn(() => {
+          return false;
+        });
+
+        return new Promise<void>(done => {
+          const suite = vest.create('suite', () => {
+            vest.test('test', 'message', debounce(test, 1500));
+          });
+
+          suite();
+          suite();
+          suite();
+          suite();
+          suite();
+          suite();
+          suite().done(() => {
+            expect(test).toHaveBeenCalledTimes(1);
+            expect(suite.isValid()).toBe(false);
+            done();
+          });
+        });
+      });
+    });
+
+    describe('Throwing an error', () => {
+      it('Should debounce test function calls when used', () => {
+        const test = jest.fn(() => {
+          throw new Error();
+        });
+
+        return new Promise<void>(done => {
+          const suite = vest.create('suite', () => {
+            vest.test('test', 'message', debounce(test, 1500));
+          });
+
+          suite();
+          suite();
+          suite();
+          suite();
+          suite();
+          suite();
+          suite().done(() => {
+            expect(test).toHaveBeenCalledTimes(1);
+            expect(suite.isValid()).toBe(false);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  describe('Async test', () => {
+    it('Should complete the async test after the delay', async () => {
+      const t = jest.fn(async () => {
+        await wait(1000);
+        vest.enforce(1).equals(2);
+      });
+
+      const suite = vest.create('suite', () => {
+        vest.test('test', 'message', debounce(t, 1500));
+      });
+
+      suite();
+      expect(t).toHaveBeenCalledTimes(0);
+      expect(suite.isPending()).toBe(true);
+      await wait(2000);
+      expect(t).toHaveBeenCalledTimes(1);
+      expect(suite.get().hasErrors('test')).toBe(false);
+      expect(suite.isPending()).toBe(true);
+      await wait(1000);
+      expect(suite.isPending()).toBe(false);
+      expect(suite.get().hasErrors('test')).toBe(true);
+    });
+  });
+
+  describe('When delay met multiple times', () => {
+    it('Should call once per completed delay', async () => {
+      const test = jest.fn(() => {
+        return false;
+      });
+
+      const suite = vest.create('suite', () => {
+        vest.test('test', 'message', debounce(test, 1000));
+      });
+
+      suite();
+      await wait(1000);
+      expect(suite.get().hasErrors('test')).toBe(true);
+      expect(test).toHaveBeenCalledTimes(1);
+
+      suite();
+      suite();
+      suite();
+      expect(test).toHaveBeenCalledTimes(1);
+      await wait(1000);
+      expect(suite.get().hasErrors('test')).toBe(true);
+      expect(test).toHaveBeenCalledTimes(2);
+
+      suite();
+      suite();
+      suite();
+      expect(test).toHaveBeenCalledTimes(2);
+      await wait(1000);
+    });
+  });
+
+  describe('Debounced tests with non-debounced tests', () => {
+    it('Should complete non-debounced tests immediately', () => {
+      const test = jest.fn(() => {
+        return false;
+      });
+
+      const suite = vest.create('suite', () => {
+        vest.test('test', 'message', debounce(test, 1000));
+        vest.test('test2', 'message', test);
+      });
+
+      return new Promise<void>(done => {
+        suite().done(() => {
+          expect(test).toHaveBeenCalledTimes(2);
+          expect(suite.get().hasErrors('test')).toBe(true);
+          expect(suite.get().hasErrors('test2')).toBe(true);
+          done();
+        });
+        expect(test).toHaveBeenCalledTimes(1);
+        expect(suite.get().hasErrors('test')).toBe(false);
+        expect(suite.get().hasErrors('test2')).toBe(true);
+      });
+    });
+  });
+
+  describe('Multiple debounced fields', () => {
+    it('Should conclude them on their own time', () => {
+      const t = jest.fn(() => {
+        return false;
+      });
+
+      const suite = vest.create('suite', () => {
+        vest.test('test', 'message', debounce(t, 1000));
+        vest.test('test2', 'message', debounce(t, 1500));
+        vest.test('test3', 'message', debounce(t, 2000));
+      });
+
+      const control = jest.fn();
+
+      return new Promise<void>(done => {
+        suite();
+        suite();
+        suite()
+          .done('test', () => {
+            expect(control).toHaveBeenCalledTimes(0);
+            expect(t).toHaveBeenCalledTimes(1);
+            expect(suite.get().hasErrors('test')).toBe(true);
+            expect(suite.get().hasErrors('test2')).toBe(false);
+            expect(suite.get().hasErrors('test3')).toBe(false);
+            control();
+          })
+          .done('test2', () => {
+            expect(control).toHaveBeenCalledTimes(1);
+            expect(t).toHaveBeenCalledTimes(2);
+            expect(suite.get().hasErrors('test')).toBe(true);
+            expect(suite.get().hasErrors('test2')).toBe(true);
+            expect(suite.get().hasErrors('test3')).toBe(false);
+            control();
+          })
+          .done('test3', () => {
+            expect(control).toHaveBeenCalledTimes(2);
+            expect(t).toHaveBeenCalledTimes(3);
+            expect(suite.get().hasErrors('test')).toBe(true);
+            expect(suite.get().hasErrors('test2')).toBe(true);
+            expect(suite.get().hasErrors('test3')).toBe(true);
+            control();
+          })
+          .done(() => {
+            expect(control).toHaveBeenCalledTimes(3);
+            expect(t).toHaveBeenCalledTimes(3);
+            expect(suite.get().hasErrors('test')).toBe(true);
+            expect(suite.get().hasErrors('test2')).toBe(true);
+            expect(suite.get().hasErrors('test3')).toBe(true);
+            done();
+          });
+      });
+    });
+  });
+
+  describe('Test payload', () => {
+    describe('AbortSignal', () => {
+      it('Should abort the test when signal is aborted', async () => {
+        const control = jest.fn();
+
+        let run = 0;
+        const test = jest.fn(async (payload: TestFnPayload) => {
+          expect(payload.signal.aborted).toBe(false);
+          await wait(50);
+          // We should only abort on the first run because
+          // the second run is canceling the firt, but nothing
+          // cancels the second.
+          expect(payload.signal.aborted).toBe(run === 0);
+          control();
+          return true;
+        });
+
+        const suite = vest.create('suite', () => {
+          vest.test('test', 'message', debounce(test, 200));
+          run++;
+        });
+
+        // eslint-disable-next-line no-async-promise-executor
+        return new Promise<void>(async done => {
+          suite();
+          await wait(200);
+          // This cancels the first run
+          suite().done(() => {
+            expect(suite.hasErrors('test')).toBe(false);
+            expect(test).toHaveBeenCalledTimes(2);
+            expect(control).toHaveBeenCalledTimes(1);
+            done();
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/vest/src/exports/debounce.ts
+++ b/packages/vest/src/exports/debounce.ts
@@ -1,0 +1,65 @@
+import { registerIsolateReconciler } from 'vest';
+import { CB, isPromise, Nullable } from 'vest-utils';
+import { Isolate, TIsolate, IsolateSelectors } from 'vestjs-runtime';
+
+import { TestFn, TestFnPayload } from 'TestTypes';
+
+const isolateType = 'Debounce';
+
+export default function debounce<Callback extends CB = CB>(
+  callback: Callback,
+  delay: number = 0,
+): TestFn {
+  let timeout: Nullable<NodeJS.Timeout> = null;
+
+  const f = () => (payload: TestFnPayload) =>
+    new Promise((resolve, reject) => {
+      timeout = setTimeout(() => {
+        let res = false;
+        try {
+          res = callback(payload);
+        } catch (e) {
+          return reject(e);
+        }
+
+        if (res === false) {
+          return reject();
+        }
+
+        return isPromise(res) ? res.then(resolve, reject) : resolve(res);
+      }, delay);
+    });
+
+  const i = Isolate.create(isolateType, f, {
+    clearTimeout: () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    },
+  });
+
+  return i.output;
+}
+
+export class IsolateDebounceReconciler {
+  static match(currentNode: TIsolate, historyNode: TIsolate): boolean {
+    return (
+      IsolateSelectors.isIsolateType(currentNode, isolateType) &&
+      IsolateSelectors.isIsolateType(historyNode, isolateType)
+    );
+  }
+
+  static reconcile(current: TIsolateDebounce, history: TIsolateDebounce) {
+    history?.data?.clearTimeout?.();
+
+    return current;
+  }
+}
+
+export type TIsolateDebounce = TIsolate<IsolateDebouncePayload>;
+
+export type IsolateDebouncePayload = {
+  clearTimeout: () => void;
+};
+
+registerIsolateReconciler(IsolateDebounceReconciler);

--- a/packages/vest/src/exports/debounce.ts
+++ b/packages/vest/src/exports/debounce.ts
@@ -1,4 +1,4 @@
-import { registerIsolateReconciler } from 'vest';
+import { registerReconciler } from 'vest';
 import { CB, isPromise, Nullable } from 'vest-utils';
 import { Isolate, TIsolate, IsolateSelectors } from 'vestjs-runtime';
 
@@ -62,4 +62,4 @@ export type IsolateDebouncePayload = {
   clearTimeout: () => void;
 };
 
-registerIsolateReconciler(IsolateDebounceReconciler);
+registerReconciler(IsolateDebounceReconciler);

--- a/packages/vest/src/vest.ts
+++ b/packages/vest/src/vest.ts
@@ -8,6 +8,7 @@ import type {
   SuiteSummary,
 } from 'SuiteResultTypes';
 import type { Suite } from 'SuiteTypes';
+import { registerIsolateReconciler } from 'VestReconciler';
 import { createSuite, staticSuite, StaticSuite } from 'createSuite';
 import { each } from 'each';
 import { skip, only } from 'focused';
@@ -37,6 +38,7 @@ export {
   mode,
   staticSuite,
   Modes,
+  registerIsolateReconciler,
 };
 
 export type { SuiteResult, SuiteRunResult, SuiteSummary, Suite, StaticSuite };

--- a/packages/vest/src/vest.ts
+++ b/packages/vest/src/vest.ts
@@ -8,7 +8,7 @@ import type {
   SuiteSummary,
 } from 'SuiteResultTypes';
 import type { Suite } from 'SuiteTypes';
-import { registerIsolateReconciler } from 'VestReconciler';
+import { registerReconciler } from 'VestReconciler';
 import { createSuite, staticSuite, StaticSuite } from 'createSuite';
 import { each } from 'each';
 import { skip, only } from 'focused';
@@ -38,7 +38,7 @@ export {
   mode,
   staticSuite,
   Modes,
-  registerIsolateReconciler,
+  registerReconciler,
 };
 
 export type { SuiteResult, SuiteRunResult, SuiteSummary, Suite, StaticSuite };

--- a/packages/vest/tsconfig.json
+++ b/packages/vest/tsconfig.json
@@ -66,6 +66,7 @@
       "enforce@date": ["./src/exports/enforce@date.ts"],
       "enforce@compounds": ["./src/exports/enforce@compounds.ts"],
       "enforce@compose": ["./src/exports/enforce@compose.ts"],
+      "debounce": ["./src/exports/debounce.ts"],
       "classnames": ["./src/exports/classnames.ts"],
       "SuiteSerializer": ["./src/exports/SuiteSerializer.ts"],
       "ErrorStrings": ["./src/errors/ErrorStrings.ts"],

--- a/website/docs/writing_tests/advanced_test_features/debounce.md
+++ b/website/docs/writing_tests/advanced_test_features/debounce.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 4
+title: Debouncing Tests
+description: Debouncing tests to improve async test performance and flow control
+keywords: [Vest, debounce, async, test]
+---
+
+## `debounce()`
+
+The `debounce()` function in Vest helps you optimize function execution by introducing a delay. This is useful in scenarios where a function is called repeatedly due to user interaction, and you only want to execute the latest version after a period of inactivity.
+
+### Usage
+
+**1. Import Debounce**
+
+```js
+import debounce from 'vest/debounce';
+```
+
+**2. Wrap your Test Callback:**
+
+```js
+test(
+  'username',
+  'User already taken',
+  debounce(async () => {
+    await doesUserExist();
+  }, 2000),
+);
+```
+
+In the above example, Vest will wait for two seconds before executing the test, and it will be run only once, no matter how many times the suite was invoked during this time period.
+
+:::caution IMPORTANT
+When using `debounce`, all debounced tests are treated as async, even if the test callback is synchronous. This is because the test will be executed after the debounce period, which is an async operation.
+:::


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Please fill the following form (leave what's relevant)
-->

| Related issues   |  #1057 1057   |

<!-- Describe your changes below in detail. -->

## `debounce()`

The `debounce()` function in Vest helps you optimize function execution by introducing a delay. This is useful in scenarios where a function is called repeatedly due to user interaction, and you only want to execute the latest version after a period of inactivity.

### Usage

**1. Import Debounce**

```js
import debounce from 'vest/debounce';
```

**2. Wrap your Test Callback:**

```js
test(
  'username',
  'User already taken',
  debounce(async () => {
    await doesUserExist();
  }, 2000),
);
```

In the above example, Vest will wait for two seconds before executing the test, and it will be run only once, no matter how many times the suite was invoked during this time period.
