### PR TITLE
minor(vest): staticSuite returns a promise

### DIFF
--- a/packages/vest-utils/src/freezeAssign.ts
+++ b/packages/vest-utils/src/freezeAssign.ts
@@ -1,0 +1,5 @@
+import assign from 'assign';
+
+export function freezeAssign<T extends object>(...args: Partial<T>[]): T {
+  return Object.freeze(assign(...(args as [Partial<T>])));
+}

--- a/packages/vest-utils/src/vest-utils.ts
+++ b/packages/vest-utils/src/vest-utils.ts
@@ -41,6 +41,7 @@ export * as tinyState from 'tinyState';
 export { StringObject } from 'StringObject';
 export { noop } from 'noop';
 export * as Predicates from 'Predicates';
+export { freezeAssign } from 'freezeAssign';
 
 export type {
   DropFirst,

--- a/packages/vest-utils/tsconfig.json
+++ b/packages/vest-utils/tsconfig.json
@@ -35,6 +35,7 @@
       "hasOwnProperty": ["./src/hasOwnProperty.ts"],
       "greaterThan": ["./src/greaterThan.ts"],
       "globals.d": ["./src/globals.d.ts"],
+      "freezeAssign": ["./src/freezeAssign.ts"],
       "either": ["./src/either.ts"],
       "deferThrow": ["./src/deferThrow.ts"],
       "defaultTo": ["./src/defaultTo.ts"],

--- a/packages/vest/src/exports/debounce.ts
+++ b/packages/vest/src/exports/debounce.ts
@@ -1,8 +1,8 @@
-import { registerReconciler } from 'vest';
 import { CB, isPromise, Nullable } from 'vest-utils';
 import { Isolate, TIsolate, IsolateSelectors } from 'vestjs-runtime';
 
 import { TestFn, TestFnPayload } from 'TestTypes';
+import { registerReconciler } from 'vest';
 
 const isolateType = 'Debounce';
 

--- a/packages/vest/src/exports/parser.ts
+++ b/packages/vest/src/exports/parser.ts
@@ -1,15 +1,15 @@
-import { suiteSelectors } from 'vest';
 import { hasOwnProperty, invariant, isNullish, isPositive } from 'vest-utils';
 
 import { ErrorStrings } from 'ErrorStrings';
 import { SuiteSummary, TFieldName, TGroupName } from 'SuiteResultTypes';
+import { suiteSelectors } from 'vest';
 
 export function parse<F extends TFieldName, G extends TGroupName>(
-  summary: SuiteSummary<F, G>
+  summary: SuiteSummary<F, G>,
 ): ParsedVestObject<F> {
   invariant(
     summary && hasOwnProperty(summary, 'valid'),
-    ErrorStrings.PARSER_EXPECT_RESULT_OBJECT
+    ErrorStrings.PARSER_EXPECT_RESULT_OBJECT,
   );
 
   const sel = suiteSelectors(summary);

--- a/packages/vest/src/hooks/focused/__tests__/__snapshots__/focused.test.ts.snap
+++ b/packages/vest/src/hooks/focused/__tests__/__snapshots__/focused.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Top Level Focus Top Level Skip When passing false Should run all fields 1`] = `
-{
+Promise {
   "done": [Function],
   "dump": [Function],
   "errorCount": 3,
@@ -39,7 +39,6 @@ exports[`Top Level Focus Top Level Skip When passing false Should run all fields
   "isValid": [Function],
   "isValidByGroup": [Function],
   "pendingCount": 0,
-  "resolve": [Function],
   "suiteName": undefined,
   "testCount": 3,
   "tests": {
@@ -84,7 +83,7 @@ exports[`Top Level Focus Top Level Skip When passing false Should run all fields
 `;
 
 exports[`Top Level Focus Top Level Skip When passing undefined Should run all fields 1`] = `
-{
+Promise {
   "done": [Function],
   "dump": [Function],
   "errorCount": 3,
@@ -122,7 +121,6 @@ exports[`Top Level Focus Top Level Skip When passing undefined Should run all fi
   "isValid": [Function],
   "isValidByGroup": [Function],
   "pendingCount": 0,
-  "resolve": [Function],
   "suiteName": undefined,
   "testCount": 3,
   "tests": {

--- a/packages/vest/src/hooks/focused/__tests__/__snapshots__/focused.test.ts.snap
+++ b/packages/vest/src/hooks/focused/__tests__/__snapshots__/focused.test.ts.snap
@@ -39,6 +39,7 @@ exports[`Top Level Focus Top Level Skip When passing false Should run all fields
   "isValid": [Function],
   "isValidByGroup": [Function],
   "pendingCount": 0,
+  "resolve": [Function],
   "suiteName": undefined,
   "testCount": 3,
   "tests": {
@@ -121,6 +122,7 @@ exports[`Top Level Focus Top Level Skip When passing undefined Should run all fi
   "isValid": [Function],
   "isValidByGroup": [Function],
   "pendingCount": 0,
+  "resolve": [Function],
   "suiteName": undefined,
   "testCount": 3,
   "tests": {

--- a/packages/vest/src/suite/__tests__/staticSuite.test.ts
+++ b/packages/vest/src/suite/__tests__/staticSuite.test.ts
@@ -142,7 +142,7 @@ describe('runStatic', () => {
     expect(suite2.hasErrors('t4')).toBe(false);
   });
 
-  describe('runStatic.resolve', () => {
+  describe('runStatic (promise)', () => {
     it("Should resolve with the suite's result", async () => {
       const suite = vest.create(() => {
         vest.test('t1', async () => {
@@ -153,8 +153,7 @@ describe('runStatic', () => {
 
       const res = suite.runStatic();
       expect(res.errorCount).toBe(0);
-      expect(res).toHaveProperty('resolve');
-      const result = await res.resolve();
+      const result = await res;
       expect(result.errorCount).toBe(1);
     });
 
@@ -167,7 +166,7 @@ describe('runStatic', () => {
       });
 
       const res = suite.runStatic();
-      const result = await res.resolve();
+      const result = await res;
       expect(result).toHaveProperty('dump');
       expect(result.dump()).toHaveProperty('$type', VestIsolateType.Suite);
     });

--- a/packages/vest/src/suite/__tests__/staticSuite.test.ts
+++ b/packages/vest/src/suite/__tests__/staticSuite.test.ts
@@ -1,3 +1,5 @@
+import wait from 'wait';
+
 import { SuiteSerializer } from 'SuiteSerializer';
 import { VestIsolateType } from 'VestIsolateType';
 import * as vest from 'vest';
@@ -138,5 +140,36 @@ describe('runStatic', () => {
     expect(suite2.hasErrors('t2')).toBe(true);
     expect(suite2.hasErrors('t3')).toBe(false);
     expect(suite2.hasErrors('t4')).toBe(false);
+  });
+
+  describe('runStatic.resolve', () => {
+    it("Should resolve with the suite's result", async () => {
+      const suite = vest.create(() => {
+        vest.test('t1', async () => {
+          await wait(100);
+          throw new Error();
+        });
+      });
+
+      const res = suite.runStatic();
+      expect(res.errorCount).toBe(0);
+      expect(res).toHaveProperty('resolve');
+      const result = await res.resolve();
+      expect(result.errorCount).toBe(1);
+    });
+
+    it("Should have a dump method on the resolved suite's result", async () => {
+      const suite = vest.create(() => {
+        vest.test('t1', async () => {
+          await wait(100);
+          throw new Error();
+        });
+      });
+
+      const res = suite.runStatic();
+      const result = await res.resolve();
+      expect(result).toHaveProperty('dump');
+      expect(result.dump()).toHaveProperty('$type', VestIsolateType.Suite);
+    });
   });
 });

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -155,17 +155,13 @@ function staticSuite<
 
       const result = suite(...args);
 
-      const resolve = new Promise<SuiteWithDump<F, G>>(resolve => {
-        result.done(res => {
-          resolve(withDump(res) as SuiteWithDump<F, G>);
-        });
-      });
-
-      return freezeAssign<StaticSuiteRunResult<F, G>>(
-        withDump({
-          resolve: () => resolve,
+      return assign(
+        new Promise<SuiteWithDump<F, G>>(resolve => {
+          result.done(res => {
+            resolve(withDump(res) as SuiteWithDump<F, G>);
+          });
         }),
-        result,
+        withDump(result),
       );
 
       function withDump(o: any) {
@@ -187,11 +183,8 @@ export type StaticSuite<
 export type StaticSuiteRunResult<
   F extends TFieldName = string,
   G extends TGroupName = string,
-> = WithDump<
-  SuiteRunResult<F, G> & {
-    resolve: () => Promise<SuiteWithDump<F, G>>;
-  } & TTypedMethods<F, G>
->;
+> = Promise<SuiteWithDump<F, G>> &
+  WithDump<SuiteRunResult<F, G> & TTypedMethods<F, G>>;
 
 type WithDump<T> = T & { dump: CB<TIsolateSuite> };
 type SuiteWithDump<F extends TFieldName, G extends TGroupName> = WithDump<

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -1,4 +1,4 @@
-import { assign, CB } from 'vest-utils';
+import { assign, CB, freezeAssign } from 'vest-utils';
 import { Bus, VestRuntime } from 'vestjs-runtime';
 
 import { TTypedMethods, getTypedMethods } from './getTypedMethods';
@@ -9,6 +9,7 @@ import { useCreateVestState, useLoadSuite } from 'Runtime';
 import { SuiteContext } from 'SuiteContext';
 import {
   SuiteName,
+  SuiteResult,
   SuiteRunResult,
   TFieldName,
   TGroupName,
@@ -154,14 +155,22 @@ function staticSuite<
 
       const result = suite(...args);
 
-      return Object.freeze(
-        assign(
-          {
-            dump: suite.dump,
-          },
-          result,
-        ),
-      ) as StaticSuiteRunResult<F, G>;
+      const resolve = new Promise<SuiteWithDump<F, G>>(resolve => {
+        result.done(res => {
+          resolve(withDump(res) as SuiteWithDump<F, G>);
+        });
+      });
+
+      return freezeAssign<StaticSuiteRunResult<F, G>>(
+        withDump({
+          resolve: () => resolve,
+        }),
+        result,
+      );
+
+      function withDump(o: any) {
+        return assign({ dump: suite.dump }, o);
+      }
     },
     {
       ...getTypedMethods<F, G>(),
@@ -178,8 +187,15 @@ export type StaticSuite<
 export type StaticSuiteRunResult<
   F extends TFieldName = string,
   G extends TGroupName = string,
-> = SuiteRunResult<F, G> & {
-  dump: CB<TIsolateSuite>;
-} & TTypedMethods<F, G>;
+> = WithDump<
+  SuiteRunResult<F, G> & {
+    resolve: () => Promise<SuiteWithDump<F, G>>;
+  } & TTypedMethods<F, G>
+>;
+
+type WithDump<T> = T & { dump: CB<TIsolateSuite> };
+type SuiteWithDump<F extends TFieldName, G extends TGroupName> = WithDump<
+  SuiteResult<F, G>
+>;
 
 export { createSuite, staticSuite };

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -1,4 +1,4 @@
-import { assign, CB, freezeAssign } from 'vest-utils';
+import { assign, CB } from 'vest-utils';
 import { Bus, VestRuntime } from 'vestjs-runtime';
 
 import { TTypedMethods, getTypedMethods } from './getTypedMethods';

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -1,4 +1,4 @@
-import { assign } from 'vest-utils';
+import { freezeAssign } from 'vest-utils';
 
 import { useSuiteName, useSuiteResultCache } from 'Runtime';
 import { SuiteResult, TFieldName, TGroupName } from 'SuiteResultTypes';
@@ -7,7 +7,7 @@ import { useProduceSuiteSummary } from 'useProduceSuiteSummary';
 
 export function useCreateSuiteResult<
   F extends TFieldName,
-  G extends TGroupName
+  G extends TGroupName,
 >(): SuiteResult<F, G> {
   return useSuiteResultCache<F, G>(() => {
     // @vx-allow use-use
@@ -15,10 +15,12 @@ export function useCreateSuiteResult<
 
     // @vx-allow use-use
     const suiteName = useSuiteName();
-    return Object.freeze(
-      assign(summary, suiteSelectors<F, G>(summary), {
+    return freezeAssign<SuiteResult<F, G>>(
+      summary,
+      suiteSelectors<F, G>(summary),
+      {
         suiteName,
-      })
+      },
     ) as SuiteResult<F, G>;
   });
 }

--- a/packages/vest/src/suiteResult/suiteRunResult.ts
+++ b/packages/vest/src/suiteResult/suiteRunResult.ts
@@ -1,4 +1,4 @@
-import { assign } from 'vest-utils';
+import { freezeAssign } from 'vest-utils';
 import { VestRuntime } from 'vestjs-runtime';
 
 import {
@@ -14,15 +14,13 @@ import { useCreateSuiteResult } from 'suiteResult';
 
 export function useSuiteRunResult<
   F extends TFieldName,
-  G extends TGroupName
+  G extends TGroupName,
 >(): SuiteRunResult<F, G> {
-  return Object.freeze(
-    assign(
-      {
-        done: VestRuntime.persist(done),
-      },
-      useCreateSuiteResult<F, G>()
-    )
+  return freezeAssign<SuiteRunResult<F, G>>(
+    {
+      done: VestRuntime.persist(done) as Done<F, G>,
+    },
+    useCreateSuiteResult<F, G>(),
   );
 }
 
@@ -36,7 +34,7 @@ function done<F extends TFieldName, G extends TGroupName>(
 ): SuiteRunResult<F, G> {
   const [callback, fieldName] = args.reverse() as [
     (res: SuiteResult<F, G>) => void,
-    F
+    F,
   ];
   const output = useSuiteRunResult<F, G>();
   if (shouldSkipDoneRegistration<F, G>(callback, fieldName, output)) {


### PR DESCRIPTION
This change makes it so that when we use staticSuite, it actually returns a promise, so that we can directly await its response, without needing to use .done.

```
      await suite.runStatic();
```