### PR TITLE
patch(vest): Set history root when exiting the root node

### DIFF
--- a/packages/vest/src/core/Runtime.ts
+++ b/packages/vest/src/core/Runtime.ts
@@ -118,6 +118,6 @@ export function useResetSuite() {
 }
 
 export function useLoadSuite(rootNode: TIsolateSuite): void {
-  VestRuntime.useLoadRootNode(rootNode);
+  VestRuntime.useSetHistoryRoot(rootNode);
   useExpireSuiteResultCache();
 }

--- a/packages/vest/src/core/test/test.memo.ts
+++ b/packages/vest/src/core/test/test.memo.ts
@@ -66,7 +66,11 @@ function useGetTestFromCache(
     return cache(dependencies, cacheAction);
   }
 
-  VestRuntime.addNodeToHistory(cachedValue);
+  // FIXME(@ealush 2024-08-12): This is some kind of a hack. Instead organically letting Vest set the next
+  // child of the isolate, we're forcing it from the outside.
+  // Instead, an ideal solution would probably be to have test.memo be its own isolate
+  // that just injects a historic output from a previous test run.
+  VestRuntime.useSetNextIsolateChild(cachedValue);
 
   return cachedValue;
 }

--- a/packages/vest/src/hooks/__tests__/mode.test.ts
+++ b/packages/vest/src/hooks/__tests__/mode.test.ts
@@ -184,12 +184,12 @@ describe('mode', () => {
       it('Should follow the same behavior as if it was not nested', () => {
         const suite = create(() => {
           group('group_1', () => {
-            dummyTest.failing('field_1', 'first-of-field_1');
-            dummyTest.failing('field_1', 'second-of-field_1');
-            dummyTest.failing('field_2', 'first-of-field_2');
-            dummyTest.failing('field_2', 'second-of-field_2');
-            dummyTest.failing('field_3', 'first-of-field_3');
-            dummyTest.failing('field_3', 'second-of-field_3');
+            Vest.test('field_1', 'first-of-field_1', () => false);
+            Vest.test('field_1', 'second-of-field_1', () => false);
+            Vest.test('field_2', 'first-of-field_2', () => false);
+            Vest.test('field_2', 'second-of-field_2', () => false);
+            Vest.test('field_3', 'first-of-field_3', () => false);
+            Vest.test('field_3', 'second-of-field_3', () => false);
           });
         });
         expect(suite.get().testCount).toBe(0); // sanity

--- a/packages/vestjs-runtime/src/VestRuntime.ts
+++ b/packages/vestjs-runtime/src/VestRuntime.ts
@@ -59,14 +59,14 @@ export const Run = PersistedContext.run;
 
 export const RuntimeApi = {
   Run,
-  addNodeToHistory,
   createRef,
   persist,
   reset,
   useAvailableRoot,
   useCurrentCursor,
   useHistoryRoot,
-  useLoadRootNode,
+  useSetHistoryRoot,
+  useSetNextIsolateChild,
   useXAppData,
 };
 
@@ -131,18 +131,7 @@ export function useHistoryIsolateAtCurrentPosition() {
   return historyNode;
 }
 
-export function addNodeToHistory(node: TIsolate): void {
-  const parent = useIsolate();
-  if (parent) {
-    useSetNextIsolateChild(node);
-  } else {
-    useSetHistory(node);
-  }
-
-  IsolateMutator.setParent(node, parent);
-}
-
-export function useSetHistory(history: TIsolate) {
+export function useSetHistoryRoot(history: TIsolate) {
   const [, setHistoryRoot] = useHistoryRoot();
   setHistoryRoot(history);
 }
@@ -172,6 +161,7 @@ export function useSetNextIsolateChild(child: TIsolate): void {
   invariant(currentIsolate, ErrorStrings.NO_ACTIVE_ISOLATE);
 
   IsolateMutator.addChild(currentIsolate, child);
+  IsolateMutator.setParent(child, currentIsolate);
 }
 export function useSetIsolateKey(key: Nullable<string>, node: TIsolate): void {
   if (!key) {
@@ -206,8 +196,4 @@ export function reset() {
   const [, , resetHistoryRoot] = useHistoryRoot();
 
   resetHistoryRoot();
-}
-
-export function useLoadRootNode(root: TIsolate): void {
-  useSetHistory(root);
 }


### PR DESCRIPTION
In the previous version of this code, Vest would set the history root node right when entering the topmost root, making the concept of "history" root node meaningless. This correctly sets the history root node only when exiting the topmost node.