### PR TITLE
minor(vest): Add subscribe to specific events

### DIFF
--- a/packages/vest/src/core/VestBus/BusEvents.ts
+++ b/packages/vest/src/core/VestBus/BusEvents.ts
@@ -1,11 +1,10 @@
-export enum Events {
-  TEST_RUN_STARTED = 'test_run_started',
-  TEST_COMPLETED = 'test_completed',
-  ALL_RUNNING_TESTS_FINISHED = 'all_running_tests_finished',
-  REMOVE_FIELD = 'remove_field',
-  RESET_FIELD = 'reset_field',
-  RESET_SUITE = 'reset_suite',
-  SUITE_RUN_STARTED = 'suite_run_started',
-  SUITE_CALLBACK_RUN_FINISHED = 'SUITE_CALLBACK_RUN_FINISHED',
-  DONE_TEST_OMISSION_PASS = 'DONE_TEST_OMISSION_PASS',
-}
+export type Events =
+  | 'TEST_RUN_STARTED'
+  | 'TEST_COMPLETED'
+  | 'ALL_RUNNING_TESTS_FINISHED'
+  | 'REMOVE_FIELD'
+  | 'RESET_FIELD'
+  | 'RESET_SUITE'
+  | 'SUITE_RUN_STARTED'
+  | 'SUITE_CALLBACK_RUN_FINISHED'
+  | 'DONE_TEST_OMISSION_PASS';

--- a/packages/vest/src/core/test/test.ts
+++ b/packages/vest/src/core/test/test.ts
@@ -1,7 +1,6 @@
 import { assign, invariant, isFunction, isStringValue, text } from 'vest-utils';
 import { Bus, IsolateKey } from 'vestjs-runtime';
 
-import { Events } from 'BusEvents';
 import { ErrorStrings } from 'ErrorStrings';
 import { IsolateTest, TIsolateTest } from 'IsolateTest';
 import { useGroupName } from 'SuiteContext';
@@ -47,7 +46,7 @@ function vestTest<F extends TFieldName>(
   const testObjectInput = { fieldName, groupName, message, testFn };
 
   // This invalidates the suite cache.
-  Bus.useEmit(Events.TEST_RUN_STARTED);
+  Bus.useEmit('TEST_RUN_STARTED');
 
   return IsolateTest(useAttemptRunTest, testObjectInput, key);
 }

--- a/packages/vest/src/hooks/optional/omitOptionalFields.ts
+++ b/packages/vest/src/hooks/optional/omitOptionalFields.ts
@@ -1,7 +1,6 @@
 import { isEmpty, optionalFunctionValue } from 'vest-utils';
 import { Bus, VestRuntime } from 'vestjs-runtime';
 
-import { Events } from 'BusEvents';
 import { SuiteOptionalFields, TIsolateSuite } from 'IsolateSuite';
 import { TIsolateTest } from 'IsolateTest';
 import { TestWalker } from 'TestWalker';
@@ -44,7 +43,7 @@ export function useOmitOptionalFields(): void {
     }
   });
 
-  Bus.useEmit(Events.DONE_TEST_OMISSION_PASS);
+  Bus.useEmit('DONE_TEST_OMISSION_PASS');
 
   function verifyAndOmit(testObject: TIsolateTest) {
     const { fieldName } = VestTest.getData(testObject);

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -7,6 +7,7 @@ import {
   TFieldName,
   TGroupName,
 } from 'SuiteResultTypes';
+import { Subscribe } from 'VestBus';
 import { StaticSuiteRunResult } from 'createSuite';
 import { TTypedMethods } from 'getTypedMethods';
 import { SuiteSelectors } from 'suiteSelectors';
@@ -29,6 +30,6 @@ export type SuiteMethods<
   remove: CB<void, [fieldName: F]>;
   resetField: CB<void, [fieldName: F]>;
   runStatic: CB<StaticSuiteRunResult<F, G>, Parameters<T>>;
-  subscribe: (cb: CB) => CB<void>;
+  subscribe: Subscribe;
 } & TTypedMethods<F, G> &
   SuiteSelectors<F, G>;

--- a/packages/vest/src/suite/__tests__/subscribe.test.ts
+++ b/packages/vest/src/suite/__tests__/subscribe.test.ts
@@ -1,8 +1,8 @@
-import { SuiteSerializer } from 'SuiteSerializer';
 import { enforce } from 'n4s';
 import { describe, it, expect, vi } from 'vitest';
 import wait from 'wait';
 
+import { SuiteSerializer } from 'SuiteSerializer';
 import * as vest from 'vest';
 
 describe('suite.subscribe', () => {
@@ -50,6 +50,32 @@ describe('suite.subscribe', () => {
 
     // now also after resolving the async test
     expect(cb.mock.calls.length).toBeGreaterThan(callCount);
+  });
+
+  describe('Subscribe with event name', () => {
+    it('Should only call the callback on the specified event', () => {
+      const cbAllDone = vi.fn();
+      const testDone = vi.fn();
+      const testStarted = vi.fn();
+      const suiteStart = vi.fn();
+
+      const suite = vest.create('suite', () => {
+        vest.test('field1', () => false);
+        vest.test('field2', () => true);
+        vest.test('field3', () => false);
+      });
+
+      suite.subscribe('ALL_RUNNING_TESTS_FINISHED', cbAllDone);
+      suite.subscribe('TEST_COMPLETED', testDone);
+      suite.subscribe('TEST_RUN_STARTED', testStarted);
+      suite.subscribe('SUITE_RUN_STARTED', suiteStart);
+
+      suite();
+      expect(cbAllDone).toHaveBeenCalledTimes(1);
+      expect(testDone).toHaveBeenCalledTimes(3);
+      expect(testStarted).toHaveBeenCalledTimes(3);
+      expect(suiteStart).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('unsubscribe', () => {

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -3,7 +3,6 @@ import { Bus, VestRuntime } from 'vestjs-runtime';
 
 import { TTypedMethods, getTypedMethods } from './getTypedMethods';
 
-import { Events } from 'BusEvents';
 import { IsolateSuite, TIsolateSuite } from 'IsolateSuite';
 import { useCreateVestState, useLoadSuite } from 'Runtime';
 import { SuiteContext } from 'SuiteContext';
@@ -55,7 +54,7 @@ function createSuite<
         suiteParams: args,
       },
       () => {
-        Bus.useEmit(Events.SUITE_RUN_STARTED);
+        Bus.useEmit('SUITE_RUN_STARTED');
 
         return IsolateSuite(
           useRunSuiteCallback<T, F, G>(suiteCallback, ...args),
@@ -82,9 +81,9 @@ function createSuite<
           () => VestRuntime.useAvailableRoot() as TIsolateSuite,
         ),
         get: VestRuntime.persist(useCreateSuiteResult),
-        remove: Bus.usePrepareEmitter<string>(Events.REMOVE_FIELD),
-        reset: Bus.usePrepareEmitter(Events.RESET_SUITE),
-        resetField: Bus.usePrepareEmitter<string>(Events.RESET_FIELD),
+        remove: Bus.usePrepareEmitter<string>('REMOVE_FIELD'),
+        reset: Bus.usePrepareEmitter('RESET_SUITE'),
+        resetField: Bus.usePrepareEmitter<string>('RESET_FIELD'),
         resume: VestRuntime.persist(useLoadSuite),
         runStatic: (...args: Parameters<T>): StaticSuiteRunResult<F, G> =>
           mountedStatic(...args) as StaticSuiteRunResult<F, G>,
@@ -105,7 +104,7 @@ function useRunSuiteCallback<
 
   return () => {
     suiteCallback(...args);
-    emit(Events.SUITE_CALLBACK_RUN_FINISHED);
+    emit('SUITE_CALLBACK_RUN_FINISHED');
     return useSuiteRunResult<F, G>();
   };
 }


### PR DESCRIPTION
Allowing usage of suite.subscribe with a more granular event, such as:

```ts
export type Events =
  | 'TEST_RUN_STARTED'
  | 'TEST_COMPLETED'
  | 'ALL_RUNNING_TESTS_FINISHED'
  | 'REMOVE_FIELD'
  | 'RESET_FIELD'
  | 'RESET_SUITE'
  | 'SUITE_RUN_STARTED'
  | 'SUITE_CALLBACK_RUN_FINISHED'
  | 'DONE_TEST_OMISSION_PASS';
```

This means that subscribe won't fire like crazy whenever being used.

This is the essence of the change, the rest is just to make it easier to use the events as strings:

```ts
  function subscribe(event: Events, cb: CB): CB<void>;
  function subscribe(cb: CB): CB<void>;
  function subscribe(...args: [event: Events, cb: CB] | [cb: CB]): CB<void> {
    const [cb, event] = args.reverse() as [CB, Events];
    return VestBus.on(event ?? '*', () => {
      cb();
    }).off;
  }
```