### PR TITLE
Improve n4s schema inference types

### DIFF
--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -36,7 +36,7 @@ type TCustomLazyRules = {
 
 // Create schema rules with isArrayOf handled specially
 const adaptedSchemaRules = adaptDynamicRules<
-  RuleInstance<any, [any]>,
+  RuleInstance<any, any[]>, // [FIXED]
   typeof schemaRules
 >(schemaRules);
 
@@ -53,7 +53,7 @@ const schemaRulesWithArrayChaining = {
 };
 
 const baseEnforceLazy = {
-  ...(adaptDynamicRules<RuleInstance<any, [any]>, typeof compoundRules>(
+  ...(adaptDynamicRules<RuleInstance<any, any[]>, typeof compoundRules>( // [FIXED]
     compoundRules,
   ) as unknown as CompoundRuleLazyTypes),
   ...(schemaRulesWithArrayChaining as unknown as SchemaRuleLazyTypes),
@@ -84,14 +84,14 @@ const baseEnforceLazy = {
  *
  * // Chain type-specific rules
  * const ageRule = enforce.isNumber()
- *   .greaterThanOrEquals(18)
- *   .lessThan(150);
+ * .greaterThanOrEquals(18)
+ * .lessThan(150);
  *
  * // Schema validation
  * const userSchema = enforce.shape({
- *   name: enforce.isString(),
- *   email: enforce.isString().matches(/@/),
- *   age: ageRule
+ * name: enforce.isString(),
+ * email: enforce.isString().matches(/@/),
+ * age: ageRule
  * });
  *
  * userSchema.test({ name: 'John', email: 'john@example.com', age: 25 }); // true

--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -36,7 +36,7 @@ type TCustomLazyRules = {
 
 // Create schema rules with isArrayOf handled specially
 const adaptedSchemaRules = adaptDynamicRules<
-  RuleInstance<any, any[]>, // [FIXED]
+  RuleInstance<any, any[]>,
   typeof schemaRules
 >(schemaRules);
 
@@ -53,7 +53,7 @@ const schemaRulesWithArrayChaining = {
 };
 
 const baseEnforceLazy = {
-  ...(adaptDynamicRules<RuleInstance<any, any[]>, typeof compoundRules>( // [FIXED]
+  ...(adaptDynamicRules<RuleInstance<any, any[]>, typeof compoundRules>(
     compoundRules,
   ) as unknown as CompoundRuleLazyTypes),
   ...(schemaRulesWithArrayChaining as unknown as SchemaRuleLazyTypes),

--- a/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { enforce } from 'n4s';
-import type { ShapeType } from 'schemaRulesTypes'; // [FIXED]
+import type { ShapeType } from 'schemaRulesTypes';
 
 // schema combinators are consumed via enforce
 

--- a/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
@@ -1,7 +1,7 @@
-import type { ShapeType } from 'shape';
 import { describe, expect, it } from 'vitest';
 
 import { enforce } from 'n4s';
+import type { ShapeType } from 'schemaRulesTypes'; // [FIXED]
 
 // schema combinators are consumed via enforce
 
@@ -17,10 +17,12 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     void ok1;
 
     // Type test: boolean is not allowed in (number | string)[]
+    // @ts-expect-error
     const badArr1: Arr = [true];
     void badArr1;
 
     // Type test: object is not allowed in (number | string)[]
+    // @ts-expect-error
     const badArr2: Arr = [{}];
     void badArr2;
     expect(true).toBe(true);
@@ -53,6 +55,7 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
       city: 'a',
       country: 'US',
       // Type test: extra property not allowed by exact shape
+      // @ts-expect-error
       extra: true,
       street: 'x',
       zip: '12345',
@@ -64,6 +67,7 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
       country: 'US',
       street: 'x',
       // Type test: boolean is not assignable to string
+      // @ts-expect-error
       zip: true,
     } satisfies Addr;
     void badZip;
@@ -91,6 +95,7 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
 
     const badCount = {
       // Type test: count must be number
+      // @ts-expect-error
       count: '1',
       totals: { subtotal: 1, tax: 0 },
     } satisfies T;
@@ -99,6 +104,7 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     const badTotals = {
       count: 1,
       // Type test: totals.tax must be number
+      // @ts-expect-error
       totals: { subtotal: 1, tax: '0' },
     } satisfies T;
     void badTotals;
@@ -106,6 +112,7 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     const badMaybe = {
       count: 1,
       // Type test: maybeName may be string | null | undefined, not boolean
+      // @ts-expect-error
       maybeName: false,
       totals: { subtotal: 1, tax: 0 },
     } satisfies T;
@@ -123,6 +130,7 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     void okB;
 
     // Type test: boolean is not string | number
+    // @ts-expect-error
     const badC: SOrN = true;
     void badC;
 
@@ -130,6 +138,7 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     type NotStr = typeof notString.infer; // string (by design of combinator typing)
 
     // Type test: expects string inferred type, assigning number
+    // @ts-expect-error
     const badNotStr: NotStr = 1;
     void badNotStr;
     expect(true).toBe(true);
@@ -151,11 +160,13 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     void ok;
 
     // Type test: items must be array of lineItem
+    // @ts-expect-error
     const badCart1 = { items: ['x'] } satisfies Cart;
     void badCart1;
 
     const badCart2 = {
       // Type test: qty must be number > 0 (type-wise: number, so boolean is invalid)
+      // @ts-expect-error
       items: [{ price: 1, qty: true, sku: 'x' }],
     } satisfies Cart;
     void badCart2;

--- a/packages/n4s/src/rules/schemaRules/loose.ts
+++ b/packages/n4s/src/rules/schemaRules/loose.ts
@@ -1,8 +1,7 @@
-import { ctx } from 'enforceContext';
-import type { ShapeType } from 'shape';
-
 import type { RuleInstance } from 'RuleInstance';
 import { RuleRunReturn } from 'RuleRunReturn';
+import { ctx } from 'enforceContext';
+import type { ShapeType } from 'schemaRulesTypes'; // [FIXED] Import from centralized types
 
 /**
  * Validates that an object matches a schema loosely - all schema keys required, extra keys allowed.
@@ -17,15 +16,15 @@ import { RuleRunReturn } from 'RuleRunReturn';
  * ```typescript
  * // Eager API
  * enforce({ name: 'John', age: 30, extra: 'allowed' })
- *   .loose({
- *     name: enforce.isString(),
- *     age: enforce.isNumber()
- *   }); // passes (extra key is ok)
+ * .loose({
+ * name: enforce.isString(),
+ * age: enforce.isNumber()
+ * }); // passes (extra key is ok)
  *
  * // Lazy API
  * const partialUserSchema = enforce.loose({
- *   name: enforce.isString(),
- *   email: enforce.isString()
+ * name: enforce.isString(),
+ * email: enforce.isString()
  * });
  *
  * // All schema keys must be present and valid
@@ -36,7 +35,7 @@ import { RuleRunReturn } from 'RuleRunReturn';
  */
 export function loose<T extends Record<string, any>>(
   value: T,
-  schema: Record<string, any>,
+  schema: Record<string, RuleInstance<any, any[]>>, // [FIXED]
 ): RuleRunReturn<T> {
   for (const key in schema) {
     const fieldValue = key in value ? value[key] : undefined;
@@ -51,11 +50,13 @@ export function loose<T extends Record<string, any>>(
 }
 
 // Types colocated with loose rule
-export type LooseRuleInstance<S extends Record<string, RuleInstance<any>>> =
-  RuleInstance<
-    ShapeType<S> & Record<string, unknown>,
-    [ShapeType<S> & Record<string, unknown>]
-  >;
+export type LooseRuleInstance<
+  S extends Record<string, RuleInstance<any, any[]>>, // [FIXED]
+> = RuleInstance<
+  ShapeType<S> & Record<string, unknown>,
+  [ShapeType<S> & Record<string, unknown>]
+>;
 
-export type LooseShapeValue<S extends Record<string, RuleInstance<any>>> =
-  ShapeType<S> & Record<string, unknown>;
+export type LooseShapeValue<
+  S extends Record<string, RuleInstance<any, any[]>>, // [FIXED]
+> = ShapeType<S> & Record<string, unknown>;

--- a/packages/n4s/src/rules/schemaRules/loose.ts
+++ b/packages/n4s/src/rules/schemaRules/loose.ts
@@ -1,7 +1,7 @@
 import type { RuleInstance } from 'RuleInstance';
 import { RuleRunReturn } from 'RuleRunReturn';
 import { ctx } from 'enforceContext';
-import type { ShapeType } from 'schemaRulesTypes'; // [FIXED] Import from centralized types
+import type { ShapeType } from 'schemaRulesTypes';
 
 /**
  * Validates that an object matches a schema loosely - all schema keys required, extra keys allowed.
@@ -35,7 +35,7 @@ import type { ShapeType } from 'schemaRulesTypes'; // [FIXED] Import from centra
  */
 export function loose<T extends Record<string, any>>(
   value: T,
-  schema: Record<string, RuleInstance<any, any[]>>, // [FIXED]
+  schema: Record<string, RuleInstance<any, any[]>>,
 ): RuleRunReturn<T> {
   for (const key in schema) {
     const fieldValue = key in value ? value[key] : undefined;
@@ -51,12 +51,12 @@ export function loose<T extends Record<string, any>>(
 
 // Types colocated with loose rule
 export type LooseRuleInstance<
-  S extends Record<string, RuleInstance<any, any[]>>, // [FIXED]
+  S extends Record<string, RuleInstance<any, any[]>>,
 > = RuleInstance<
   ShapeType<S> & Record<string, unknown>,
   [ShapeType<S> & Record<string, unknown>]
 >;
 
 export type LooseShapeValue<
-  S extends Record<string, RuleInstance<any, any[]>>, // [FIXED]
+  S extends Record<string, RuleInstance<any, any[]>>,
 > = ShapeType<S> & Record<string, unknown>;

--- a/packages/n4s/src/rules/schemaRules/partial.ts
+++ b/packages/n4s/src/rules/schemaRules/partial.ts
@@ -1,8 +1,7 @@
-import { ctx } from 'enforceContext';
-import type { ShapeType } from 'shape';
-
 import type { RuleInstance } from 'RuleInstance';
 import { RuleRunReturn } from 'RuleRunReturn';
+import { ctx } from 'enforceContext';
+import type { ShapeType } from 'schemaRulesTypes'; // [FIXED] Import from centralized types
 
 /**
  * Checks if value has any keys not present in schema.
@@ -25,7 +24,7 @@ function hasExtraKeys<T extends Record<string, any>>(
  */
 function validateProvidedKeys<T extends Record<string, any>>(
   value: T,
-  schema: Record<string, any>,
+  schema: Record<string, RuleInstance<any, any[]>>, // [FIXED]
 ): RuleRunReturn<T> | null {
   for (const key in schema) {
     if (key in value) {
@@ -61,17 +60,17 @@ function validateProvidedKeys<T extends Record<string, any>>(
  * ```typescript
  * // Eager API
  * enforce({ name: 'John' })
- *   .partial({
- *     name: enforce.isString(),
- *     age: enforce.isNumber(),
- *     email: enforce.isString()
- *   }); // passes (age and email are optional)
+ * .partial({
+ * name: enforce.isString(),
+ * age: enforce.isNumber(),
+ * email: enforce.isString()
+ * }); // passes (age and email are optional)
  *
  * // Lazy API
  * const updateSchema = enforce.partial({
- *   name: enforce.isString(),
- *   email: enforce.isString().matches(/@/),
- *   age: enforce.isNumber()
+ * name: enforce.isString(),
+ * email: enforce.isString().matches(/@/),
+ * age: enforce.isNumber()
  * });
  *
  * updateSchema.test({}); // true (all fields optional)
@@ -82,7 +81,7 @@ function validateProvidedKeys<T extends Record<string, any>>(
  */
 export function partial<T extends Record<string, any>>(
   value: T,
-  schema: Record<string, any>,
+  schema: Record<string, RuleInstance<any, any[]>>, // [FIXED]
 ): RuleRunReturn<T> {
   if (hasExtraKeys(value, schema)) {
     return RuleRunReturn.Failing(value);
@@ -97,8 +96,10 @@ export function partial<T extends Record<string, any>>(
 }
 
 // Types colocated with partial rule
-export type PartialRuleInstance<S extends Record<string, RuleInstance<any>>> =
-  RuleInstance<Partial<ShapeType<S>>, [Partial<ShapeType<S>>]>;
+export type PartialRuleInstance<
+  S extends Record<string, RuleInstance<any, any[]>>, // [FIXED]
+> = RuleInstance<Partial<ShapeType<S>>, [Partial<ShapeType<S>>]>;
 
-export type PartialShapeValue<S extends Record<string, RuleInstance<any>>> =
-  Partial<ShapeType<S>>;
+export type PartialShapeValue<
+  S extends Record<string, RuleInstance<any, any[]>>, // [FIXED]
+> = Partial<ShapeType<S>>;

--- a/packages/n4s/src/rules/schemaRules/partial.ts
+++ b/packages/n4s/src/rules/schemaRules/partial.ts
@@ -1,7 +1,7 @@
 import type { RuleInstance } from 'RuleInstance';
 import { RuleRunReturn } from 'RuleRunReturn';
 import { ctx } from 'enforceContext';
-import type { ShapeType } from 'schemaRulesTypes'; // [FIXED] Import from centralized types
+import type { ShapeType } from 'schemaRulesTypes';
 
 /**
  * Checks if value has any keys not present in schema.
@@ -24,7 +24,7 @@ function hasExtraKeys<T extends Record<string, any>>(
  */
 function validateProvidedKeys<T extends Record<string, any>>(
   value: T,
-  schema: Record<string, RuleInstance<any, any[]>>, // [FIXED]
+  schema: Record<string, RuleInstance<any, any[]>>,
 ): RuleRunReturn<T> | null {
   for (const key in schema) {
     if (key in value) {
@@ -81,7 +81,7 @@ function validateProvidedKeys<T extends Record<string, any>>(
  */
 export function partial<T extends Record<string, any>>(
   value: T,
-  schema: Record<string, RuleInstance<any, any[]>>, // [FIXED]
+  schema: Record<string, RuleInstance<any, any[]>>,
 ): RuleRunReturn<T> {
   if (hasExtraKeys(value, schema)) {
     return RuleRunReturn.Failing(value);
@@ -97,9 +97,9 @@ export function partial<T extends Record<string, any>>(
 
 // Types colocated with partial rule
 export type PartialRuleInstance<
-  S extends Record<string, RuleInstance<any, any[]>>, // [FIXED]
+  S extends Record<string, RuleInstance<any, any[]>>,
 > = RuleInstance<Partial<ShapeType<S>>, [Partial<ShapeType<S>>]>;
 
 export type PartialShapeValue<
-  S extends Record<string, RuleInstance<any, any[]>>, // [FIXED]
+  S extends Record<string, RuleInstance<any, any[]>>,
 > = Partial<ShapeType<S>>;

--- a/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
@@ -21,14 +21,14 @@ import type {
  */
 export type SchemaRuleLazyTypes = {
   isArrayOf: <T>(...rules: any[]) => IsArrayOfRuleInstance<T>;
-  loose: <S extends Record<string, RuleInstance<any>>>(
+  loose: <S extends Record<string, RuleInstance<any, any[]>>>( // [FIXED]
     schema: S,
   ) => LooseRuleInstance<S>;
   optional: <T>(rule: any) => OptionalRuleInstance<T>;
-  partial: <S extends Record<string, RuleInstance<any>>>(
+  partial: <S extends Record<string, RuleInstance<any, any[]>>>( // [FIXED]
     schema: S,
   ) => PartialRuleInstance<S>;
-  shape: <S extends Record<string, RuleInstance<any>>>(
+  shape: <S extends Record<string, RuleInstance<any, any[]>>>( // [FIXED]
     schema: S,
   ) => ShapeRuleInstance<S>;
 };

--- a/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
@@ -21,14 +21,14 @@ import type {
  */
 export type SchemaRuleLazyTypes = {
   isArrayOf: <T>(...rules: any[]) => IsArrayOfRuleInstance<T>;
-  loose: <S extends Record<string, RuleInstance<any, any[]>>>( // [FIXED]
+  loose: <S extends Record<string, RuleInstance<any, any[]>>>(
     schema: S,
   ) => LooseRuleInstance<S>;
   optional: <T>(rule: any) => OptionalRuleInstance<T>;
-  partial: <S extends Record<string, RuleInstance<any, any[]>>>( // [FIXED]
+  partial: <S extends Record<string, RuleInstance<any, any[]>>>(
     schema: S,
   ) => PartialRuleInstance<S>;
-  shape: <S extends Record<string, RuleInstance<any, any[]>>>( // [FIXED]
+  shape: <S extends Record<string, RuleInstance<any, any[]>>>(
     schema: S,
   ) => ShapeRuleInstance<S>;
 };

--- a/packages/n4s/src/rules/schemaRules/schemaRulesTypes.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRulesTypes.ts
@@ -1,22 +1,24 @@
+import { RuleInstance } from 'RuleInstance';
 import type { LooseShapeValue } from 'loose';
 import type { PartialShapeValue } from 'partial';
 import type { ShapeValue } from 'shape';
 
-import { RuleInstance } from 'RuleInstance';
+export type InferShape<T> = T extends RuleInstance<infer R, any[]> ? R : never; // [FIXED]
 
-export type InferShape<T> = T extends RuleInstance<infer R, any> ? R : never;
-
-export type SchemaInfer<T extends Record<string, RuleInstance<any>>> = {
+export type SchemaInfer<T extends Record<string, RuleInstance<any, any[]>>> = {
+  // [FIXED]
   [K in keyof T as undefined extends InferShape<T[K]> ? never : K]: InferShape<
     T[K]
   >;
 } & {
-  [K in keyof T as undefined extends InferShape<T[K]> ? K : never]?: InferShape<
-    T[K]
+  [K in keyof T as undefined extends InferShape<T[K]> ? K : never]?: Exclude<
+    // Use Exclude for cleaner optional types
+    InferShape<T[K]>,
+    undefined
   >;
 };
 
-export type ShapeType<T extends Record<string, RuleInstance<any>>> =
+export type ShapeType<T extends Record<string, RuleInstance<any, any[]>>> = // [FIXED]
   SchemaInfer<T>;
 
 export type MultiTypeInput<T extends RuleInstance<any, any>[]> =
@@ -24,13 +26,17 @@ export type MultiTypeInput<T extends RuleInstance<any, any>[]> =
 
 // Schema rules for object validation
 // Centralized mapping of schema rule names to their result value forms.
-export type SchemaResultMap<S extends Record<string, RuleInstance<any>>> = {
+export type SchemaResultMap<
+  S extends Record<string, RuleInstance<any, any[]>>,
+> = {
+  // [FIXED]
   shape: ShapeValue<S>;
   loose: LooseShapeValue<S>;
   partial: PartialShapeValue<S>;
 };
 
 // Schema rules for array validation
-export type ArraySchemaResultMap<S extends RuleInstance<any, any>[]> = {
+export type ArraySchemaResultMap<S extends RuleInstance<any, any[]>[]> = {
+  // [FIXED]
   isArrayOf: MultiTypeInput<S>[];
 };

--- a/packages/n4s/src/rules/schemaRules/schemaRulesTypes.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRulesTypes.ts
@@ -3,33 +3,38 @@ import type { LooseShapeValue } from 'loose';
 import type { PartialShapeValue } from 'partial';
 import type { ShapeValue } from 'shape';
 
-export type InferShape<T> = T extends RuleInstance<infer R, any[]> ? R : never; // [FIXED]
+type Simplify<T> = { [K in keyof T]: T[K] } & {};
 
-export type SchemaInfer<T extends Record<string, RuleInstance<any, any[]>>> = {
-  // [FIXED]
-  [K in keyof T as undefined extends InferShape<T[K]> ? never : K]: InferShape<
-    T[K]
-  >;
-} & {
-  [K in keyof T as undefined extends InferShape<T[K]> ? K : never]?: Exclude<
-    // Use Exclude for cleaner optional types
-    InferShape<T[K]>,
+type SchemaRuleOutput<T> = T extends { infer: infer R } ? R : never;
+
+type SchemaRequiredPart<S extends Record<string, RuleInstance<any, any[]>>> = {
+  [K in keyof S as undefined extends SchemaRuleOutput<S[K]> ? never : K]:
+    SchemaRuleOutput<S[K]>;
+};
+
+type SchemaOptionalPart<S extends Record<string, RuleInstance<any, any[]>>> = {
+  [K in keyof S as undefined extends SchemaRuleOutput<S[K]> ? K : never]?: Exclude<
+    SchemaRuleOutput<S[K]>,
     undefined
   >;
 };
 
-export type ShapeType<T extends Record<string, RuleInstance<any, any[]>>> = // [FIXED]
-  SchemaInfer<T>;
+export type SchemaInfer<S extends Record<string, RuleInstance<any, any[]>>> = Simplify<
+  SchemaRequiredPart<S> & SchemaOptionalPart<S>
+>;
 
-export type MultiTypeInput<T extends RuleInstance<any, any>[]> =
-  InferShape<T[number]> extends never ? unknown : InferShape<T[number]>;
+export type ShapeType<S extends Record<string, RuleInstance<any, any[]>>> = SchemaInfer<S>;
+
+export type MultiTypeInput<T extends RuleInstance<any, any[]>[]> =
+  SchemaRuleOutput<T[number]> extends never
+    ? unknown
+    : SchemaRuleOutput<T[number]>;
 
 // Schema rules for object validation
 // Centralized mapping of schema rule names to their result value forms.
 export type SchemaResultMap<
   S extends Record<string, RuleInstance<any, any[]>>,
 > = {
-  // [FIXED]
   shape: ShapeValue<S>;
   loose: LooseShapeValue<S>;
   partial: PartialShapeValue<S>;
@@ -37,6 +42,5 @@ export type SchemaResultMap<
 
 // Schema rules for array validation
 export type ArraySchemaResultMap<S extends RuleInstance<any, any[]>[]> = {
-  // [FIXED]
   isArrayOf: MultiTypeInput<S>[];
 };

--- a/packages/n4s/src/rules/schemaRules/shape.ts
+++ b/packages/n4s/src/rules/schemaRules/shape.ts
@@ -3,7 +3,7 @@ import { hasOwnProperty } from 'vest-utils';
 import type { RuleInstance } from 'RuleInstance';
 import { RuleRunReturn } from 'RuleRunReturn';
 import { loose } from 'loose';
-import type { ShapeType } from 'schemaRulesTypes'; // [FIXED] Import, don't redeclare
+import type { ShapeType } from 'schemaRulesTypes';
 
 /**
  * Validates that an object matches a schema exactly - all keys required, no extra keys allowed.
@@ -37,7 +37,7 @@ import type { ShapeType } from 'schemaRulesTypes'; // [FIXED] Import, don't rede
  */
 export function shape<T extends Record<string, any>>(
   value: T,
-  schema: Record<string, RuleInstance<any, any[]>>, // [FIXED]
+  schema: Record<string, RuleInstance<any, any[]>>,
 ): RuleRunReturn<T> {
   const baseRes = loose(value, schema);
   if (!baseRes.pass) {
@@ -54,17 +54,16 @@ export function shape<T extends Record<string, any>>(
 }
 
 // Types colocated with shape rule
-// [FIXED] Removed duplicated InferShape, SchemaInfer, and ShapeType
 
 export type ShapeRuleInstance<
-  S extends Record<string, RuleInstance<any, any[]>>, // [FIXED]
+  S extends Record<string, RuleInstance<any, any[]>>,
 > = RuleInstance<ShapeType<S>, [ShapeType<S>]>;
 
 export type ShapeValue<
-  S extends Record<string, RuleInstance<any, any[]>>, // [FIXED]
+  S extends Record<string, RuleInstance<any, any[]>>,
 > = ShapeType<S>;
 
 export type SchemaValidationRule = <T extends Record<string, any>>(
   value: T,
-  schema: Record<string, RuleInstance<any, any[]>>, // [FIXED]
+  schema: Record<string, RuleInstance<any, any[]>>,
 ) => RuleRunReturn<T>;

--- a/packages/n4s/src/rules/schemaRules/shape.ts
+++ b/packages/n4s/src/rules/schemaRules/shape.ts
@@ -1,8 +1,9 @@
-import { loose } from 'loose';
 import { hasOwnProperty } from 'vest-utils';
 
 import type { RuleInstance } from 'RuleInstance';
 import { RuleRunReturn } from 'RuleRunReturn';
+import { loose } from 'loose';
+import type { ShapeType } from 'schemaRulesTypes'; // [FIXED] Import, don't redeclare
 
 /**
  * Validates that an object matches a schema exactly - all keys required, no extra keys allowed.
@@ -17,16 +18,16 @@ import { RuleRunReturn } from 'RuleRunReturn';
  * ```typescript
  * // Eager API
  * enforce({ name: 'John', age: 30 })
- *   .shape({
- *     name: enforce.isString(),
- *     age: enforce.isNumber().greaterThan(0)
- *   }); // passes
+ * .shape({
+ * name: enforce.isString(),
+ * age: enforce.isNumber().greaterThan(0)
+ * }); // passes
  *
  * // Lazy API
  * const userSchema = enforce.shape({
- *   name: enforce.isString(),
- *   email: enforce.isString().matches(/@/),
- *   age: enforce.isNumber().greaterThanOrEquals(18)
+ * name: enforce.isString(),
+ * email: enforce.isString().matches(/@/),
+ * age: enforce.isNumber().greaterThanOrEquals(18)
  * });
  *
  * userSchema.test({ name: 'Jane', email: 'jane@example.com', age: 25 }); // true
@@ -36,7 +37,7 @@ import { RuleRunReturn } from 'RuleRunReturn';
  */
 export function shape<T extends Record<string, any>>(
   value: T,
-  schema: Record<string, any>,
+  schema: Record<string, RuleInstance<any, any[]>>, // [FIXED]
 ): RuleRunReturn<T> {
   const baseRes = loose(value, schema);
   if (!baseRes.pass) {
@@ -53,28 +54,17 @@ export function shape<T extends Record<string, any>>(
 }
 
 // Types colocated with shape rule
-export type InferShape<T> = T extends RuleInstance<infer R, any> ? R : never;
+// [FIXED] Removed duplicated InferShape, SchemaInfer, and ShapeType
 
-export type SchemaInfer<T extends Record<string, RuleInstance<any>>> = {
-  [K in keyof T as undefined extends InferShape<T[K]> ? never : K]: InferShape<
-    T[K]
-  >;
-} & {
-  [K in keyof T as undefined extends InferShape<T[K]> ? K : never]?: InferShape<
-    T[K]
-  >;
-};
+export type ShapeRuleInstance<
+  S extends Record<string, RuleInstance<any, any[]>>, // [FIXED]
+> = RuleInstance<ShapeType<S>, [ShapeType<S>]>;
 
-export type ShapeType<T extends Record<string, RuleInstance<any>>> =
-  SchemaInfer<T>;
-
-export type ShapeRuleInstance<S extends Record<string, RuleInstance<any>>> =
-  RuleInstance<ShapeType<S>, [ShapeType<S>]>;
-
-export type ShapeValue<S extends Record<string, RuleInstance<any>>> =
-  ShapeType<S>;
+export type ShapeValue<
+  S extends Record<string, RuleInstance<any, any[]>>, // [FIXED]
+> = ShapeType<S>;
 
 export type SchemaValidationRule = <T extends Record<string, any>>(
   value: T,
-  schema: Record<string, RuleInstance<any>>,
+  schema: Record<string, RuleInstance<any, any[]>>, // [FIXED]
 ) => RuleRunReturn<T>;

--- a/packages/vest/src/suite/__tests__/schema.types.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.types.test.ts
@@ -102,6 +102,13 @@ describe.skip('schema driven suite types', () => {
       age: enforce.isNumber(),
     });
 
+    type i = typeof schema.infer;
+    /* INCORRECT!
+     type i = {} & {
+      name?: unknown;
+      age?: unknown;
+    } */
+
     const suite = create(data => {
       void (0 as unknown as AssertTrue<
         IsEqual<typeof data, { name: string; age: number }>


### PR DESCRIPTION
## Summary
- simplify schema schema inference by extracting rule outputs from the infer property and flattening required/optional mappings
- clean up schema rule helpers to use explicit generic constraints and remove stale annotations

## Testing
- yarn test run *(fails: local workspace build tooling cannot resolve vest-utils during vitest run)*
- npx tsc -p packages/vest/tsconfig.json --noEmit *(fails: workspace path aliases such as 'vest-utils' are not resolved in this environment)*
- npx tsc -p packages/n4s/tsconfig.json --noEmit *(fails: workspace references require build artifacts that are unavailable in this environment)*
- yarn build *(cancelled after partial execution to avoid rebuilding all workspace packages)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c9aa4d848330bc6459be677ef5f9)