### PR TITLE
refactor: rename suite.after to afterEach

### DIFF
--- a/packages/vest/src/__tests__/integration.async-tests.test.ts
+++ b/packages/vest/src/__tests__/integration.async-tests.test.ts
@@ -52,7 +52,7 @@ describe('Stateful behavior', () => {
     TestPromise(done => {
       // ❗️Why is this test async? Because of the `resetState` beforeEach.
       // We must not clean up before the suite is actually done.
-      result = suite.after(done).run();
+      result = suite.afterEach(done).run();
       expect(result.tests).toHaveProperty('field_1');
       expect(result.tests).toHaveProperty('field_2');
       expect(result.tests).toHaveProperty('field_4');
@@ -66,8 +66,8 @@ describe('Stateful behavior', () => {
   it('Should invoke after callback specified with sync field immediately, and the others after finishing', async () => {
     result = suite
       .afterField('field_1', callback_1)
-      .after(callback_2)
-      .after(callback_3)
+      .afterEach(callback_2)
+      .afterEach(callback_3)
       .run();
 
     expect(callback_1).toHaveBeenCalled();

--- a/packages/vest/src/__tests__/integration.base.test.ts
+++ b/packages/vest/src/__tests__/integration.base.test.ts
@@ -40,7 +40,7 @@ describe('Base behavior', () => {
 
   it('Should run done callbacks immediately', () => {
     const callback = vi.fn();
-    genSuite().after(callback).run();
+    genSuite().afterEach(callback).run();
 
     expect(callback).toHaveBeenCalled();
   });

--- a/packages/vest/src/core/test/__tests__/key.test.ts
+++ b/packages/vest/src/core/test/__tests__/key.test.ts
@@ -237,19 +237,19 @@ describe('key', () => {
         });
 
         suite
-          .after(() => {
+          .afterEach(() => {
             expect(suite.hasErrors('test_a')).toBe(true);
             expect(suite.hasErrors('test_b')).toBe(true);
           })
           .run({ a: '', b: '' });
         suite
-          .after(() => {
+          .afterEach(() => {
             expect(suite.hasErrors('test_a')).toBe(false);
             expect(suite.hasErrors('test_b')).toBe(true);
           })
           .run({ a: 's', b: '' }, ['test_a']);
         suite
-          .after(() => {
+          .afterEach(() => {
             expect(suite.hasErrors('test_a')).toBe(false);
             expect(suite.hasErrors('test_b')).toBe(false);
           })
@@ -272,17 +272,17 @@ describe('key', () => {
         });
 
         suite
-          .after(() => {
+          .afterEach(() => {
             expect(suite.hasErrors('test_a')).toBe(true);
           })
           .run({ a: '' }, false);
         suite
-          .after(() => {
+          .afterEach(() => {
             expect(suite.hasErrors('test_a')).toBe(true);
           })
           .run({ a: '' }, false);
         suite
-          .after(() => {
+          .afterEach(() => {
             expect(suite.hasErrors('test_a')).toBe(false);
           })
           .run({ a: 's' }, true);

--- a/packages/vest/src/core/test/__tests__/runAsyncTest.test.ts
+++ b/packages/vest/src/core/test/__tests__/runAsyncTest.test.ts
@@ -43,7 +43,7 @@ describe('runAsyncTest', () => {
         });
 
         suite
-          .after(cb1)
+          .afterEach(cb1)
           .afterField('field_1' as TFieldName, cb2)
           .afterField('field_3' as TFieldName, cb3)
           .run();
@@ -79,7 +79,7 @@ describe('runAsyncTest', () => {
         });
 
         suite
-          .after(cb1)
+          .afterEach(cb1)
           .afterField('field_2' as TFieldName, cb2)
           .afterField('field_3' as TFieldName, cb3)
           .run();

--- a/packages/vest/src/hooks/__tests__/mode.test.ts
+++ b/packages/vest/src/hooks/__tests__/mode.test.ts
@@ -50,7 +50,7 @@ describe('mode', () => {
                   });
                 });
                 suite
-                  .after(() => {
+                  .afterEach(() => {
                     expect(suite.getErrors()).toEqual({
                       t1: ['f1'],
                     });

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -77,7 +77,7 @@ type AfterMethods<
   T extends CB,
   S extends TSchema,
 > = {
-  after: CB<AfterMethods<F, G, T, S>, [callback: CB]>;
+  afterEach: CB<AfterMethods<F, G, T, S>, [callback: CB]>;
   afterField: CB<
     AfterMethods<F, G, T, S>,
     [fieldName: F | string, callback: CB]

--- a/packages/vest/src/suite/__tests__/__snapshots__/focus.test.ts.snap
+++ b/packages/vest/src/suite/__tests__/__snapshots__/focus.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`suite.focus: only > focus return value > should be the rest of the suite methods 1`] = `
 {
-  "after": [Function],
+  "afterEach": [Function],
   "afterField": [Function],
   "dump": [Function],
   "focus": [Function],

--- a/packages/vest/src/suite/__tests__/focus.test.ts
+++ b/packages/vest/src/suite/__tests__/focus.test.ts
@@ -17,7 +17,7 @@ describe('suite.focus: only', () => {
       const focused = suite.focus({ only: ['field_1'] });
 
       expect(focused).toBeTypeOf('object');
-      expect(focused.after).toBeTypeOf('function');
+      expect(focused.afterEach).toBeTypeOf('function');
       expect(focused.afterField).toBeTypeOf('function');
       expect(focused.run).toBeTypeOf('function');
       expect(focused).toMatchSnapshot();

--- a/packages/vest/src/suite/__tests__/typedSuite.test.ts
+++ b/packages/vest/src/suite/__tests__/typedSuite.test.ts
@@ -61,14 +61,14 @@ describe('typed suite', () => {
     res.hasWarnings('F10');
 
     suite
-      .after(() => {
+      .afterEach(() => {
         expect(suite.get().tests.F1).toBeUndefined();
         // @ts-expect-error
         expect(suite.get().tests.F14).toBeUndefined();
       })
       .run();
 
-    suite.after(() => {}).run();
+    suite.afterEach(() => {}).run();
   });
 });
 

--- a/packages/vest/src/suite/after/__tests__/__snapshots__/afterEach.test.ts.snap
+++ b/packages/vest/src/suite/after/__tests__/__snapshots__/afterEach.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`suite resolve > awaiting suite > should resolve when all tests finish and after() runs 1`] = `
+exports[`suite resolve > awaiting suite > should resolve when all tests finish and afterEach() runs 1`] = `
 {
   "field_1": SummaryBase {
     "errorCount": 1,

--- a/packages/vest/src/suite/after/__tests__/afterEach.additional.test.ts
+++ b/packages/vest/src/suite/after/__tests__/afterEach.additional.test.ts
@@ -5,9 +5,9 @@ import { dummyTest } from '../../../testUtils/testDummy';
 
 import * as vest from '../../../vest';
 
-describe('after - additional test coverage', () => {
-  describe('Chaining multiple after callbacks', () => {
-    it('should execute multiple chained after callbacks in the order they were added', () => {
+describe('afterEach - additional test coverage', () => {
+  describe('Chaining multiple afterEach callbacks', () => {
+    it('should execute multiple chained afterEach callbacks in the order they were added', () => {
       const executionOrder: number[] = [];
       const callback1 = vi.fn(() => {
         executionOrder.push(1);
@@ -24,7 +24,7 @@ describe('after - additional test coverage', () => {
         dummyTest.failing();
       });
 
-      suite.after(callback1).after(callback2).after(callback3).run();
+      suite.afterEach(callback1).afterEach(callback2).afterEach(callback3).run();
 
       expect(callback1).toHaveBeenCalledOnce();
       expect(callback2).toHaveBeenCalledOnce();
@@ -33,22 +33,22 @@ describe('after - additional test coverage', () => {
     });
   });
 
-  describe('Return value of after', () => {
+  describe('Return value of afterEach', () => {
     it('should return a runnable', () => {
       const suite = vest.create(() => {
         dummyTest.passing();
       });
 
-      const returnValue = suite.after(() => {});
+      const returnValue = suite.afterEach(() => {});
 
       expect(typeof returnValue.run).toBe('function');
-      expect(typeof returnValue.after).toBe('function');
+      expect(typeof returnValue.afterEach).toBe('function');
       expect(typeof returnValue.afterField).toBe('function');
       expect(typeof returnValue.focus).toBe('function');
     });
   });
 
-  describe('Error handling in after callbacks', () => {
+  describe('Error handling in afterEach callbacks', () => {
     it('should not prevent other callbacks from running when one throws an error', () => {
       const callback1 = vi.fn(() => {
         throw new Error('Test error');
@@ -60,7 +60,7 @@ describe('after - additional test coverage', () => {
       });
 
       // We need to catch the error to prevent it from failing the test
-      suite.after(callback1).after(callback2).run();
+      suite.afterEach(callback1).afterEach(callback2).run();
 
       expect(callback1).toHaveBeenCalledOnce();
       expect(callback2).toHaveBeenCalledOnce();
@@ -75,7 +75,7 @@ describe('after - additional test coverage', () => {
         dummyTest.passing();
       });
 
-      suite.after(callback).run();
+      suite.afterEach(callback).run();
 
       expect(callback).toHaveBeenCalledOnce();
       expect(callback).toHaveReturnedWith('arrow');
@@ -91,14 +91,14 @@ describe('after - additional test coverage', () => {
         dummyTest.passing();
       });
 
-      suite.after(spy).run();
+      suite.afterEach(spy).run();
 
       expect(spy).toHaveBeenCalledOnce();
       expect(spy).toHaveReturnedWith('regular');
     });
   });
 
-  describe('after with async tests and multiple callbacks', () => {
+  describe('afterEach with async tests and multiple callbacks', () => {
     it('should call all callbacks after each async test completes', async () => {
       const callback1 = vi.fn();
       const callback2 = vi.fn();
@@ -108,7 +108,7 @@ describe('after - additional test coverage', () => {
         dummyTest.failingAsync('field_2', { time: 20 });
       });
 
-      const result = suite.after(callback1).after(callback2).run();
+      const result = suite.afterEach(callback1).afterEach(callback2).run();
 
       // Initial sync run
       expect(callback1).toHaveBeenCalledTimes(1);
@@ -128,7 +128,7 @@ describe('after - additional test coverage', () => {
     });
   });
 
-  describe('after callback parameters', () => {
+  describe('afterEach callback parameters', () => {
     test('should not receive any arguments', () => {
       const callback = vi.fn();
 
@@ -142,7 +142,7 @@ describe('after - additional test coverage', () => {
         });
       });
 
-      suite.after(callback).run();
+      suite.afterEach(callback).run();
 
       expect(callback).toHaveBeenCalledOnce();
 

--- a/packages/vest/src/suite/after/__tests__/afterEach.test.ts
+++ b/packages/vest/src/suite/after/__tests__/afterEach.test.ts
@@ -6,9 +6,9 @@ import { TFieldName } from '../../../suiteResult/SuiteResultTypes';
 import { dummyTest } from '../../../testUtils/testDummy';
 import * as vest from '../../../vest';
 
-describe('after', () => {
+describe('afterEach', () => {
   describe('When no async tests', () => {
-    it('should call the after callback immediately once', async () => {
+    it('should call the afterEach callback immediately once', async () => {
       const afterCallback = vi.fn();
 
       const res = vest
@@ -20,7 +20,7 @@ describe('after', () => {
           dummyTest.passing();
           dummyTest.failingWarning('field_2');
         })
-        .after(afterCallback)
+        .afterEach(afterCallback)
         .run();
 
       expect(afterCallback).toHaveBeenCalledOnce();
@@ -31,14 +31,14 @@ describe('after', () => {
   });
 
   describe('When both sync and async tests', () => {
-    it('should call the `after` callback once when the sync tests are done and again for each async test', async () => {
+    it('should call the `afterEach` callback once when the sync tests are done and again for each async test', async () => {
       const afterCallback = vi.fn();
       const suite = vest.create(() => {
         dummyTest.passing();
         dummyTest.failingAsync('field_1', { time: 10 });
         dummyTest.failingAsync('field_2', { time: 15 });
       });
-      suite.after(afterCallback).run();
+      suite.afterEach(afterCallback).run();
       expect(afterCallback).toHaveBeenCalledTimes(1);
       await wait(10);
       expect(afterCallback).toHaveBeenCalledTimes(2);
@@ -65,9 +65,9 @@ describe('after', () => {
       const secondCall_1 = vi.fn(() => 'c');
       const secondCall_2 = vi.fn(() => 'd');
 
-      suite.after(firstCall_1).after(firstCall_2).run();
+      suite.afterEach(firstCall_1).afterEach(firstCall_2).run();
 
-      await suite.after(secondCall_1).after(secondCall_2).run();
+      await suite.afterEach(secondCall_1).afterEach(secondCall_2).run();
       // the second run canceled the first run callbacks so they only ran once
       expect(firstCall_1).toHaveBeenCalledTimes(1);
       expect(firstCall_2).toHaveBeenCalledTimes(1);
@@ -90,7 +90,7 @@ describe('after', () => {
           dummyTest.failing();
           dummyTest.passing();
         })
-        .after(afterCallback)
+        .afterEach(afterCallback)
         .run();
 
       expect(afterCallback).toHaveBeenCalledTimes(1);
@@ -113,7 +113,7 @@ describe('after', () => {
 
       const suite = vest.create(() => {});
 
-      suite.after(cb).run();
+      suite.afterEach(cb).run();
 
       expect(cb).toHaveBeenCalled();
     });
@@ -129,7 +129,7 @@ describe('after', () => {
           vest.test(f1, () => {});
         });
 
-        suite.after(cb).run();
+        suite.afterEach(cb).run();
         expect(suite.get().tests[f1].testCount).toBe(0);
         expect(cb).toHaveBeenCalled();
       });
@@ -150,7 +150,7 @@ describe('after', () => {
           });
         });
 
-        const res = suite.after(cb).run();
+        const res = suite.afterEach(cb).run();
 
         expect(cb).toHaveBeenCalledOnce();
 
@@ -171,7 +171,7 @@ describe('after', () => {
           });
         });
 
-        suite.after(cb).run();
+        suite.afterEach(cb).run();
         await wait(100);
         expect(cb).toHaveBeenCalled();
       });
@@ -198,7 +198,7 @@ describe('suite resolve', () => {
     expect(result.tests).toMatchSnapshot();
   });
   describe('awaiting suite', () => {
-    it('should resolve when all tests finish and after() runs', async () => {
+    it('should resolve when all tests finish and afterEach() runs', async () => {
       const suite = vest.create(() => {
         vest.test('field_1', 'field_statement_1', async () => {
           await wait(100);

--- a/packages/vest/src/suite/useCreateSuiteMethods.ts
+++ b/packages/vest/src/suite/useCreateSuiteMethods.ts
@@ -122,7 +122,7 @@ function useGetLifecycleMethods<
   const { persistedRun, staticRunner, subscribe } = ctx;
 
   return {
-    after: VestRuntime.persist((cb: CB) => useAddAfterHelper(ctx, cb)),
+    afterEach: VestRuntime.persist((cb: CB) => useAddAfterHelper(ctx, cb)),
     afterField: VestRuntime.persist((fieldName: F | string, cb: CB) =>
       useAddAfterHelper(ctx, cb, makeBrand<TFieldName>(fieldName) as F),
     ),
@@ -178,7 +178,7 @@ export function bindSuiteLifecycle<
 ): ReturnType<typeof useCreateSuiteMethods<F, G, T, S>> {
   return {
     ...methods,
-    after: VestRuntime.persist(initCallback(methods.after)),
+    afterEach: VestRuntime.persist(initCallback(methods.afterEach)),
     afterField: VestRuntime.persist(initCallback(methods.afterField)),
     run: VestRuntime.persist(initCallback(methods.run)),
   };

--- a/website/docs/api_reference.md
+++ b/website/docs/api_reference.md
@@ -107,11 +107,11 @@ Prepares a focused run.
 - `config`: `{ only?: string | string[], skip?: string | string[] }`
 - [Read more about Focused Updates](./writing_your_suite/focused_updates.md)
 
-#### `suite.after(callback)`
+#### `suite.afterEach(callback)`
 
-Registers a callback to run when the suite finishes execution.
+Registers a callback to run after each test completes (including the initial sync run and every async completion).
 
-- [Read more about `suite.after`](./writing_your_suite/handling_completion.md#2-using-suiteaftercallback)
+- [Read more about `suite.afterEach`](./writing_your_suite/handling_completion.md#2-using-suiteaftereachcallback)
 
 #### `suite.afterField(fieldName, callback)`
 

--- a/website/docs/typescript_support.md
+++ b/website/docs/typescript_support.md
@@ -56,7 +56,7 @@ result.getErrors('username'); // typed
 // result.getErrors('full_name'); // 🚨 compile-time error
 ```
 
-The typed selectors include `getError`, `getErrors`, `getWarnings`, `hasErrors`, `hasWarnings`, `isValid`, `isValidByGroup`, and `suite.after`.
+The typed selectors include `getError`, `getErrors`, `getWarnings`, `hasErrors`, `hasWarnings`, `isValid`, `isValidByGroup`, and `suite.afterEach`.
 
 ## Typing Runtime Functions
 

--- a/website/docs/understanding_state.md
+++ b/website/docs/understanding_state.md
@@ -17,7 +17,7 @@ When you skip fields in your validation suite, Vest will merge their results fro
 
 - _Skipped field merge_: Vest merges skipped fields' previous results with the current result object.
 
-- _Lagging async test completion blocking_: When an async test doesn't finish from the previous suite run, Vest blocks the [`after()` callbacks](./writing_your_suite/accessing_the_result.md#after-and-await-suiterun) or `await suite.run()` for that field from running for the previous suite result. This ensures that only the latest result is processed and prevents outdated callbacks from running.
+- _Lagging async test completion blocking_: When an async test doesn't finish from the previous suite run, Vest blocks the [`afterEach()` callbacks](./writing_your_suite/accessing_the_result.md#aftereach-and-await-suiterun) or `await suite.run()` for that field from running for the previous suite result. This ensures that only the latest result is processed and prevents outdated callbacks from running.
 
 # Drawbacks when using stateful validations
 

--- a/website/docs/upgrade_guide.md
+++ b/website/docs/upgrade_guide.md
@@ -69,12 +69,12 @@ create(data => {
 
 ## `done()` callback removed from Result
 
-The `.done()` method on the result object has been removed. Use `suite.after()` or `await suite.run()` instead.
+The `.done()` method on the result object has been removed. Use `suite.afterEach()` or `await suite.run()` instead.
 
 ```diff
 - suite(data).done(result => { ... });
 
-+ suite.after(result => { ... }).run(data);
++ suite.afterEach(result => { ... }).run(data);
 // OR
 + const result = await suite.run(data);
 ```
@@ -111,7 +111,7 @@ I am migrating my Vest validation suites from version 5 to version 6. Please ref
     - Remove `import { promisify } from 'vest'`.
     - Remove `promisify(suite)`.
     - Change `await suite(data)` or `promisified(data)` to `await suite.run(data)`.
-    - Remove `.done()` callbacks. Use `await suite.run()` or `suite.after()`.
+    - Remove `.done()` callbacks. Use `await suite.run()` or `suite.afterEach()`.
 
 4.  **Memoization**:
 

--- a/website/docs/writing_tests/async_tests.md
+++ b/website/docs/writing_tests/async_tests.md
@@ -59,14 +59,14 @@ if (result.isPending('username')) {
 await result;
 ```
 
-### Option 2: Using `.after()`
+### Option 2: Using `.afterEach()`
 
-If you prefer callbacks, or cannot use `await` at the call site, use the `.after()` hook.
+If you prefer callbacks, or cannot use `await` at the call site, use the `.afterEach()` hook.
 
 ```javascript
 suite
-  .after(result => {
-    // This runs when all tests (sync and async) are finished
+  .afterEach(result => {
+    // This runs after the initial sync completion and after each async test finishes
     if (result.isValid()) {
       submitForm();
     }
@@ -75,7 +75,7 @@ suite
 ```
 
 :::info
-Unlike `await`, the `after` callback may run **multiple times** (once for sync completion, and again for each async completion). [Read more about Handling Suite Completion](../writing_your_suite/handling_completion.md).
+Unlike `await`, the `afterEach` callback may run **multiple times** (once for sync completion, and again for each async completion). [Read more about Handling Suite Completion](../writing_your_suite/handling_completion.md).
 :::
 
 ## Using AbortSignal

--- a/website/docs/writing_your_suite/accessing_the_result.md
+++ b/website/docs/writing_your_suite/accessing_the_result.md
@@ -272,20 +272,20 @@ result.getWarningsByGroup('groupName');
 
 [Read more about groups](../writing_tests/advanced_test_features/grouping_tests.md).
 
-## `.after()` and `await suite.run()`
+## `.afterEach()` and `await suite.run()`
 
 [Read the full guide on Handling Suite Completion](./handling_completion.md).
 
-Use `.after()` to register a callback that will be called when the suite finishes running. This is the recommended way to handle completion logic, including async suites. You can also use `await suite.run()` to get the result when all tests are finished.
+Use `.afterEach()` to register a callback that will be called after the initial sync completion and again after each async test finishes. This is the recommended way to handle completion logic, including async suites. You can also use `await suite.run()` to get the result when all tests are finished.
 
-| Parameter           | Type       | Required? | Description                                                                                                     |
-| ------------------- | ---------- | --------- | --------------------------------------------------------------------------------------------------------------- |
-| `callback`          | `Function` | Yes       | A callback to be run when the suite finishes running. Use with `.after(callback).run()` for completion logic.   |
+| Parameter           | Type       | Required? | Description                                   |
+| ------------------- | ---------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `callback`          | `Function` | Yes       | A callback to be run after each completion cycle. Use with `.afterEach(callback).run()` for completion logic.   |
 | `await suite.run()` | `Promise`  | No        | Returns a promise that resolves when the suite is done running. Use with async/await for modern async handling. |
 
 If you need to check for completion of specific fields, do so inside your callback logic.
 
-`.after()` can be chained before calling `.run()`, and multiple callbacks can be registered if needed.
+`.afterEach()` can be chained before calling `.run()`, and multiple callbacks can be registered if needed.
 
 Example:
 
@@ -307,7 +307,7 @@ const suite = create(data => {
 });
 
 suite
-  .after(res => {
+  .afterEach(res => {
     if (res.hasErrors('UserName')) {
       showUserNameErrors(res.errors);
     }
@@ -318,7 +318,7 @@ suite
 ```
 
 :::danger IMPORTANT
-Do not use `.after()` conditionally, especially with async tests. This might cause unexpected behavior or missed callbacks. Instead, perform your conditional logic within your callback.
+Do not use `.afterEach()` conditionally, especially with async tests. This might cause unexpected behavior or missed callbacks. Instead, perform your conditional logic within your callback.
 :::
 
 ```js
@@ -326,7 +326,7 @@ Do not use `.after()` conditionally, especially with async tests. This might cau
 
 if (field === 'username') {
   suite
-    .after(result => {
+    .afterEach(result => {
       /*do something*/
     })
     .run();
@@ -337,7 +337,7 @@ if (field === 'username') {
 // ✅ Instead, perform your checks within your after callback
 
 suite
-  .after(result => {
+  .afterEach(result => {
     if (field === 'username') {
       /*do something*/
     }
@@ -347,7 +347,7 @@ suite
 
 ## `.afterField()`
 
-Similar to `.after()`, but runs when a specific field finishes validation.
+Similar to `.afterEach()`, but runs when a specific field finishes validation.
 
 ```javascript
 suite.afterField('username', res => {

--- a/website/docs/writing_your_suite/focused_updates.md
+++ b/website/docs/writing_your_suite/focused_updates.md
@@ -42,12 +42,12 @@ suite.focus({ skip: 'terms_of_service' }).run(formData);
 
 ## Fluent Chain
 
-`focus` returns a "runnable" interface, allowing you to chain it with `after` or `run`.
+`focus` returns a "runnable" interface, allowing you to chain it with `afterEach` or `run`.
 
 ```javascript
 suite
   .focus({ only: 'email' })
-  .after(res => updateUI(res))
+  .afterEach(res => updateUI(res))
   .run(formData);
 ```
 

--- a/website/docs/writing_your_suite/handling_completion.md
+++ b/website/docs/writing_your_suite/handling_completion.md
@@ -3,7 +3,7 @@ sidebar_position: 4
 title: Handling Suite Completion
 description: Learn how to handle the completion of your validation suite using Promises or callbacks.
 keywords:
-  [Vest, suite, completion, async, await, after, afterField, promise, callback]
+  [Vest, suite, completion, async, await, afterEach, afterField, promise, callback]
 ---
 
 # Handling Suite Completion
@@ -11,7 +11,7 @@ keywords:
 Vest suites run synchronously by default, but they often contain asynchronous tests (e.g., checking if a username is taken). Vest provides two main ways to handle the completion of your suite:
 
 1.  **Promises (Recommended)**: `await suite.run()`
-2.  **Event Callbacks**: `suite.after()` and `suite.afterField()`
+2.  **Event Callbacks**: `suite.afterEach()` and `suite.afterField()`
 
 ## 1. Promise-based Handling (Recommended)
 
@@ -36,15 +36,15 @@ if (result.isValid()) {
 - When you need to block an action (like form submission) until validation is complete.
 - When you want linear, readable code using `async/await`.
 
-## 2. Using `suite.after(callback)`
+## 2. Using `suite.afterEach(callback)`
 
-If you prefer an event-driven approach, or if you need to react to updates _during_ the validation process (e.g., updating the UI as individual async tests complete), use `suite.after()`.
+If you prefer an event-driven approach, or if you need to react to updates _during_ the validation process (e.g., updating the UI as individual async tests complete), use `suite.afterEach()`.
 
-`suite.after()` registers a callback that runs when the suite finishes. It is chainable and can be attached before or during the run.
+`suite.afterEach()` registers a callback that runs after the initial sync completion and again after each async test finishes. It is chainable and can be attached before or during the run.
 
 ### Key Behavior
 
-Unlike a Promise which resolves only once, **`after` callbacks may run multiple times**:
+Unlike a Promise which resolves only once, **`afterEach` callbacks may run multiple times**:
 
 1.  It runs **immediately** after the synchronous pass.
 2.  It runs **again** whenever an async test completes.
@@ -53,7 +53,7 @@ This makes it perfect for keeping your UI in sync with the validation state.
 
 ```javascript
 suite
-  .after(res => {
+  .afterEach(res => {
     // Called when the suite finishes sync execution
     // AND whenever an async test completes
     updateUI(res);
@@ -89,11 +89,11 @@ suite
 
 ## 4. Chaining Methods
 
-Both `after` and `afterField` return the suite API, allowing for fluent chaining.
+Both `afterEach` and `afterField` return the suite API, allowing for fluent chaining.
 
 ```javascript
 suite
-  .after(updateGeneralUI)
+  .afterEach(updateGeneralUI)
   .afterField('email', handleEmailCompletion)
   .afterField('username', handleUsernameCompletion)
   .run(data);
@@ -105,5 +105,5 @@ In Vest 5, the `done()` method was used on the result object. In Vest 6, this ha
 
 | Vest 5                  | Vest 6                                |
 | :---------------------- | :------------------------------------ |
-| `res.done(cb)`          | `suite.after(cb).run()`               |
+| `res.done(cb)`          | `suite.afterEach(cb).run()`           |
 | `res.done('field', cb)` | `suite.afterField('field', cb).run()` |

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -63,11 +63,11 @@ Prepares a focused run.
 - `config`: `{ only?: string | string[], skip?: string | string[] }`
 - [Read more about Focused Updates](./writing_your_suite/focused_updates.md)
 
-#### `suite.after(callback)`
+#### `suite.afterEach(callback)`
 
-Registers a callback to run when the suite finishes execution.
+Registers a callback to run after each test completes (initial sync completion and every async completion).
 
-- [Read more about `suite.after`](./writing_your_suite/handling_completion.md#2-using-suiteaftercallback)
+- [Read more about `suite.afterEach`](./writing_your_suite/handling_completion.md#2-using-suiteaftereachcallback)
 
 #### `suite.afterField(fieldName, callback)`
 
@@ -2966,7 +2966,7 @@ result.getErrors('username'); // typed
 // result.getErrors('full_name'); // 🚨 compile-time error
 ```
 
-The typed selectors include `getError`, `getErrors`, `getWarnings`, `hasErrors`, `hasWarnings`, `isValid`, `isValidByGroup`, and `suite.after`.
+The typed selectors include `getError`, `getErrors`, `getWarnings`, `hasErrors`, `hasWarnings`, `isValid`, `isValidByGroup`, and `suite.afterEach`.
 
 ## Typing Runtime Functions
 
@@ -3162,12 +3162,12 @@ create(data => {
 
 ## `done()` callback removed from Result
 
-The `.done()` method on the result object has been removed. Use `suite.after()` or `await suite.run()` instead.
+The `.done()` method on the result object has been removed. Use `suite.afterEach()` or `await suite.run()` instead.
 
 ```diff
 - suite(data).done(result => { ... });
 
-+ suite.after(result => { ... }).run(data);
++ suite.afterEach(result => { ... }).run(data);
 // OR
 + const result = await suite.run(data);
 ```
@@ -3204,7 +3204,7 @@ I am migrating my Vest validation suites from version 5 to version 6. Please ref
     - Remove `import { promisify } from 'vest'`.
     - Remove `promisify(suite)`.
     - Change `await suite(data)` or `promisified(data)` to `await suite.run(data)`.
-    - Remove `.done()` callbacks. Use `await suite.run()` or `suite.after()`.
+    - Remove `.done()` callbacks. Use `await suite.run()` or `suite.afterEach()`.
 
 4.  **Memoization**:
 
@@ -3846,13 +3846,13 @@ if (result.isPending('username')) {
 await result;
 ```
 
-### Option 2: Using `.after()`
+### Option 2: Using `.afterEach()`
 
-If you prefer callbacks, or cannot use `await` at the call site, use the `.after()` hook.
+If you prefer callbacks, or cannot use `await` at the call site, use the `.afterEach()` hook.
 
 ```javascript
 suite
-  .after(result => {
+  .afterEach(result => {
     // This runs when all tests (sync and async) are finished
     if (result.isValid()) {
       submitForm();
@@ -4418,20 +4418,20 @@ result.getWarningsByGroup('groupName');
 
 [Read more about groups](../writing_tests/advanced_test_features/grouping_tests.md).
 
-## `.after()` and `await suite.run()`
+## `.afterEach()` and `await suite.run()`
 
 [Read the full guide on Handling Suite Completion](./handling_completion.md).
 
-Use `.after()` to register a callback that will be called when the suite finishes running. This is the recommended way to handle completion logic, including async suites. You can also use `await suite.run()` to get the result when all tests are finished.
+Use `.afterEach()` to register a callback that will be called after the initial sync completion and again after each async test finishes. This is the recommended way to handle completion logic, including async suites. You can also use `await suite.run()` to get the result when all tests are finished.
 
-| Parameter           | Type       | Required? | Description                                                                                                     |
-| ------------------- | ---------- | --------- | --------------------------------------------------------------------------------------------------------------- |
-| `callback`          | `Function` | Yes       | A callback to be run when the suite finishes running. Use with `.after(callback).run()` for completion logic.   |
+| Parameter           | Type       | Required? | Description                                   |
+| ------------------- | ---------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `callback`          | `Function` | Yes       | A callback to be run after each completion cycle. Use with `.afterEach(callback).run()` for completion logic.   |
 | `await suite.run()` | `Promise`  | No        | Returns a promise that resolves when the suite is done running. Use with async/await for modern async handling. |
 
 If you need to check for completion of specific fields, do so inside your callback logic.
 
-`.after()` can be chained before calling `.run()`, and multiple callbacks can be registered if needed.
+`.afterEach()` can be chained before calling `.run()`, and multiple callbacks can be registered if needed.
 
 Example:
 
@@ -4453,7 +4453,7 @@ const suite = create(data => {
 });
 
 suite
-  .after(res => {
+  .afterEach(res => {
     if (res.hasErrors('UserName')) {
       showUserNameErrors(res.errors);
     }
@@ -4464,7 +4464,7 @@ suite
 ```
 
 :::danger IMPORTANT
-Do not use `.after()` conditionally, especially with async tests. This might cause unexpected behavior or missed callbacks. Instead, perform your conditional logic within your callback.
+Do not use `.afterEach()` conditionally, especially with async tests. This might cause unexpected behavior or missed callbacks. Instead, perform your conditional logic within your callback.
 :::
 
 ```js
@@ -4472,7 +4472,7 @@ Do not use `.after()` conditionally, especially with async tests. This might cau
 
 if (field === 'username') {
   suite
-    .after(result => {
+    .afterEach(result => {
       /*do something*/
     })
     .run();
@@ -4483,7 +4483,7 @@ if (field === 'username') {
 // ✅ Instead, perform your checks within your after callback
 
 suite
-  .after(result => {
+  .afterEach(result => {
     if (field === 'username') {
       /*do something*/
     }
@@ -4493,7 +4493,7 @@ suite
 
 ## `.afterField()`
 
-Similar to `.after()`, but runs when a specific field finishes validation.
+Similar to `.afterEach()`, but runs when a specific field finishes validation.
 
 ```javascript
 suite.afterField('username', res => {
@@ -4698,7 +4698,7 @@ suite.focus({ skip: 'terms_of_service' }).run(formData);
 ```javascript
 suite
   .focus({ only: 'email' })
-  .after(res => updateUI(res))
+  .afterEach(res => updateUI(res))
   .run(formData);
 ```
 
@@ -4716,7 +4716,7 @@ suite
 Vest suites run synchronously by default, but they often contain asynchronous tests (e.g., checking if a username is taken). Vest provides two main ways to handle the completion of your suite:
 
 1.  **Promises (Recommended)**: `await suite.run()`
-2.  **Event Callbacks**: `suite.after()` and `suite.afterField()`
+2.  **Event Callbacks**: `suite.afterEach()` and `suite.afterField()`
 
 ## 1. Promise-based Handling (Recommended)
 
@@ -4741,24 +4741,24 @@ if (result.isValid()) {
 - When you need to block an action (like form submission) until validation is complete.
 - When you want linear, readable code using `async/await`.
 
-## 2. Using `suite.after(callback)`
+## 2. Using `suite.afterEach(callback)`
 
-If you prefer an event-driven approach, or if you need to react to updates _during_ the validation process (e.g., updating the UI as individual async tests complete), use `suite.after()`.
+If you prefer an event-driven approach, or if you need to react to updates _during_ the validation process (e.g., updating the UI as individual async tests complete), use `suite.afterEach()`.
 
-`suite.after()` registers a callback that runs when the suite finishes. It is chainable and can be attached before or during the run.
+`suite.afterEach()` registers a callback that runs after the initial sync completion and again after each async test finishes. It is chainable and can be attached before or during the run.
 
 ### Key Behavior
 
-Unlike a Promise which resolves only once, **`after` callbacks may run multiple times**:
+Unlike a Promise which resolves only once, **`afterEach` callbacks may run multiple times**:
 
-1.  It runs **immediately** if there are no pending tests (synchronous completion).
-2.  It runs **again** whenever an async test completes and the suite state updates.
+1.  It runs **immediately** after the synchronous pass.
+2.  It runs **again** whenever an async test completes.
 
 This makes it perfect for keeping your UI in sync with the validation state.
 
 ```javascript
 suite
-  .after(res => {
+  .afterEach(res => {
     // Called when the suite finishes sync execution
     // AND whenever an async test completes
     updateUI(res);
@@ -4796,7 +4796,7 @@ Both `after` and `afterField` return the suite API, allowing for fluent chaining
 
 ```javascript
 suite
-  .after(updateGeneralUI)
+  .afterEach(updateGeneralUI)
   .afterField('email', handleEmailCompletion)
   .afterField('username', handleUsernameCompletion)
   .run(data);
@@ -4808,7 +4808,7 @@ In Vest 5, the `done()` method was used on the result object. In Vest 6, this ha
 
 | Vest 5                  | Vest 6                                |
 | :---------------------- | :------------------------------------ |
-| `res.done(cb)`          | `suite.after(cb).run()`               |
+| `res.done(cb)`          | `suite.afterEach(cb).run()`               |
 | `res.done('field', cb)` | `suite.afterField('field', cb).run()` |
 
 


### PR DESCRIPTION
## Summary
- rename the suite lifecycle hook to `afterEach`, updating suite methods, types, and tests
- refresh documentation and static content to describe the new `afterEach` behavior
- adjust snapshots to reflect the renamed lifecycle hook

## Testing
- Not run (environment missing yarn/npm tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932aac308988330acb550d51f78af30)