### PR TITLE
Revamp website hero and theme

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,18 +1,20 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-import { Highlight, themes } from 'prism-react-renderer';
+import { themes as prismThemes } from 'prism-react-renderer';
 
-// const darkCodeTheme = require('prism-react-renderer/themes/dracula');
-// const lightCodeTheme = require('prism-react-renderer/themes/github');
+function badgeLink(url, badge, name) {
+  return `<a href="${url}" class="header-badge" target="_blank">
+    <img src="${badge}" alt="${name}"/>
+  </a>`;
+}
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   baseUrl: '/',
   favicon: 'favicon.ico',
   title: 'Vest',
-  tagline:
-    'Declarative validations framework inspired by unit testing libraries',
+  tagline: 'Declarative validations framework inspired by unit testing libraries',
   url: 'https://vestjs.dev',
   onBrokenLinks: 'throw',
   markdown: {
@@ -23,12 +25,6 @@ const config = {
   },
   organizationName: 'ealush', // Usually your GitHub org/user name.
   plugins: [
-    // [
-    //   require.resolve('@easyops-cn/docusaurus-search-local'),
-    //   {
-    //     indexBlog: false,
-    //   },
-    // ],
     [
       '@docusaurus/plugin-google-gtag',
       {
@@ -43,10 +39,11 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
-          // Please change this to your repo.
+          sidebarPath: './sidebars.js',
           editUrl: 'https://github.com/ealush/vest/edit/latest/website/',
           lastVersion: 'current',
+          sidebarCollapsible: true,
+          sidebarCollapsed: true,
           versions: {
             '4.x': {
               label: '4.x',
@@ -76,7 +73,7 @@ const config = {
           beforeDefaultRehypePlugins: [],
         },
         theme: {
-          customCss: require.resolve('./src/css/custom.css'),
+          customCss: './src/css/custom.css',
         },
       }),
     ],
@@ -195,10 +192,6 @@ const config = {
           {
             title: 'More',
             items: [
-              // {
-              //   label: "Blog",
-              //   to: "/blog",
-              // },
               {
                 label: 'GitHub',
                 href: 'https://github.com/ealush/vest',
@@ -209,8 +202,8 @@ const config = {
         copyright: `Copyright © ${new Date().getFullYear()} ealush`,
       },
       prism: {
-        theme: themes.github,
-        darkTheme: themes.dracula,
+        theme: prismThemes.github,
+        darkTheme: prismThemes.vsDark,
       },
       announcementBar: {
         id: 'announcementBar-vest-6',
@@ -232,10 +225,4 @@ const config = {
     }),
 };
 
-module.exports = config;
-
-function badgeLink(url, badge, name) {
-  return `<a href="${url}" class="header-badge" target="_blank">
-    <img src="${badge}" alt="${name}"/>
-  </a>`;
-}
+export default config;

--- a/website/src/components/HomepageFeatures.js
+++ b/website/src/components/HomepageFeatures.js
@@ -1,101 +1,78 @@
 import clsx from 'clsx';
 import React from 'react';
+
 import commonStyles from './Common.module.css';
 import styles from './HomepageFeatures.module.css';
 
 const FeatureList = [
   {
-    title: 'Easy to learn',
-    emoji: '💡',
-    description: (
-      <>
-        Vest adopts the syntax and style of unit testing frameworks, so you can
-        leverage the knowledge you already have to write your form validations.
-      </>
-    ),
+    title: 'Test-inspired syntax',
+    tag: 'DX',
+    description:
+      'Write validations that read like unit tests. Vest keeps assertions predictable so teams can onboard quickly.',
   },
   {
-    title: 'Framework Agnostic',
-    emoji: '🎨',
-    description: (
-      <>
-        Bring your own UI. Vest is framework agnostic, so you can use it with
-        any UI framework you have.
-      </>
-    ),
+    title: 'Framework agnostic',
+    tag: 'Interop',
+    description:
+      'Drop Vest into any stack—React, Vue, Svelte, Angular, or vanilla. Keep your UI while Vest orchestrates validation logic.',
   },
   {
-    title: 'Really smart',
-    emoji: '🧠',
-    description: (
-      <>
-        Vest takes care of all the annoying parts for you. It manages its own
-        state, handles async validations and much more.
-      </>
-    ),
+    title: 'Async-ready & stateful',
+    tag: 'Reliability',
+    description:
+      'Handle async flows, reuse suites, and let Vest manage the state machinery so you can focus on user experience.',
   },
   {
-    title: 'Extendable',
-    emoji: '🧩',
-    description: (
-      <>
-        You can easily add new custom types of validations to Vest according to
-        your needs.
-      </>
-    ),
+    title: 'Extendable by design',
+    tag: 'Composable',
+    description:
+      'Add custom rules or suite patterns without rewriting your forms. Vest stays tiny while remaining flexible.',
   },
   {
-    title: 'Reusable',
-    emoji: '♻️',
-    description: (
-      <>
-        Validation logic in Vest can be shared across multiple features in your
-        app.
-      </>
-    ),
+    title: 'Tiny footprint',
+    tag: 'Performance',
+    description:
+      'Zero runtime dependencies and only a few KB gzipped—ideal for teams chasing fast startups and lean bundles.',
   },
   {
-    title: 'Tiny',
-    emoji: '🐜',
-    description: (
-      <>
-        Packed with features, but optimized for size. Vest brings no
-        dependencies, and only takes a few KBs.
-      </>
-    ),
+    title: 'Batteries included',
+    tag: 'Productivity',
+    description:
+      'From enforce rules to helpful errors, Vest ships sensible defaults that reduce boilerplate across your product.',
   },
 ];
 
-function Feature({ emoji, title, description }) {
+function Feature({ title, tag, description }) {
   return (
-    <div className={clsx('col col--4')}>
-      <div className={styles.featureCard}>
-        <div className="text--center">
-          <span className={styles.emoji}>{emoji}</span>
-        </div>
-        <div className="text--center padding-horiz--md">
-          <h3 className={styles.featureTitle}>{title}</h3>
-          <p className={styles.featureDescription}>{description}</p>
-        </div>
+    <div className={styles.featureCard}>
+      <div className={styles.featureMeta}>
+        <span className={styles.cardTag}>{tag}</span>
+        <h3 className={styles.featureTitle}>{title}</h3>
       </div>
+      <p className={styles.featureDescription}>{description}</p>
     </div>
   );
 }
 
 export default function HomepageFeatures() {
   return (
-    <>
-      <section
-        className={clsx(styles.features, commonStyles.main_section_centered)}
-      >
-        <div className="container">
-          <div className="row">
-            {FeatureList.map((props, idx) => (
-              <Feature key={idx} {...props} />
-            ))}
-          </div>
+    <section className={clsx(styles.features, commonStyles.main_section_centered)}>
+      <div className="container">
+        <div className={styles.sectionHeader}>
+          <span className={styles.sectionEyebrow}>Why Vest</span>
+          <h2 className={styles.sectionTitle}>Ship stable forms without boilerplate</h2>
+          <p className={styles.sectionLead}>
+            A declarative, test-like API that stays framework agnostic, handles async with grace,
+            and keeps bundles lean.
+          </p>
         </div>
-      </section>
-    </>
+        <div className={styles.grid}>
+          {FeatureList.map((props, idx) => (
+            <Feature key={idx} {...props} />
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }

--- a/website/src/components/HomepageFeatures.module.css
+++ b/website/src/components/HomepageFeatures.module.css
@@ -1,62 +1,117 @@
 .features {
-  display: flex;
+  position: relative;
+  padding: 5rem 0;
+}
+
+.sectionHeader {
+  text-align: center;
+  max-width: 780px;
+  margin: 0 auto 3rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.sectionEyebrow {
+  display: inline-flex;
   align-items: center;
-  padding: 6rem 0;
-  width: 100%;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  margin: 0 auto;
+}
+
+.sectionTitle {
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  margin: 0;
+}
+
+.sectionLead {
+  color: var(--ifm-color-emphasis-700);
+  margin: 0;
+}
+
+html[data-theme='dark'] .sectionLead {
+  color: #cbd5e1;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.2rem;
 }
 
 .featureCard {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(99, 102, 241, 0));
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  border-radius: 18px;
+  padding: 1.5rem;
   height: 100%;
-  padding: 2rem;
-  border-radius: 24px;
-  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
-  background: transparent;
-  border: 1px solid transparent;
-  margin-bottom: 2rem; /* Add vertical gap */
+  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.featureCard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.4), transparent 35%);
+  opacity: 0;
+  transition: opacity 200ms ease;
 }
 
 .featureCard:hover {
-  background: rgba(255, 255, 255, 0.5);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.05);
-  backdrop-filter: blur(4px);
+  transform: translateY(-6px);
+  box-shadow: 0 22px 60px rgba(15, 23, 42, 0.08);
+  border-color: var(--ifm-color-primary);
 }
 
-html[data-theme='dark'] .featureCard:hover {
-  background: rgba(255, 255, 255, 0.05);
+.featureCard:hover::before {
+  opacity: 1;
 }
 
-.emoji {
-  font-size: 3rem;
-  margin-bottom: 1.5rem;
+html[data-theme='dark'] .featureCard {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(15, 23, 42, 0.7));
+  border-color: rgba(129, 140, 248, 0.25);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35);
+}
+
+.featureMeta {
   display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.cardTag {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 80px;
-  height: 80px;
-  border-radius: 24px;
-  background: var(--ifm-color-emphasis-100); /* Simple background */
-  margin-left: auto;
-  margin-right: auto;
-  transition: transform 0.3s ease;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+  font-size: 0.85rem;
 }
 
 .featureTitle {
-  font-size: 1.5rem;
+  margin: 0;
+  font-size: 1.2rem;
   font-weight: 800;
-  margin-bottom: 1rem;
-  background: linear-gradient(
-    90deg,
-    var(--ifm-color-primary) 0%,
-    var(--ifm-color-primary-dark) 100%
-  );
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
 }
 
 .featureDescription {
-  color: var(--ifm-color-emphasis-600);
-  line-height: 1.8;
-  font-size: 1.1rem;
-  font-weight: 500;
+  margin: 0;
+  color: var(--ifm-color-emphasis-700);
+  line-height: 1.7;
+}
+
+html[data-theme='dark'] .featureDescription {
+  color: #cbd5e1;
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,97 +1,88 @@
-@import url('https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
-/**
- * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
- */
-
-/* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary-lightest: #fdfdfd;
-  --ifm-color-primary-lighter: #4b6889;
-  --ifm-color-primary-light: #486383;
-  --ifm-color-primary: #697098;
-  --ifm-color-primary-dark: #3b516b;
-  --ifm-color-primary-darker: #374d65;
-  --ifm-color-primary-darkest: #212432;
-  --ifm-font-family-base: 'Rubik', sans-serif;
+  --ifm-font-family-base: 'Inter', system-ui, -apple-system, sans-serif;
+  --ifm-font-family-monospace: 'JetBrains Mono', ui-monospace, SFMono-Regular,
+    SFMono-Regular, 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+
+  /* Primary Indigo gradient */
+  --ifm-color-primary: #6366f1;
+  --ifm-color-primary-dark: #4f46e5;
+  --ifm-color-primary-darker: #4338ca;
+  --ifm-color-primary-darkest: #3730a3;
+  --ifm-color-primary-light: #818cf8;
+  --ifm-color-primary-lighter: #a5b4fc;
+  --ifm-color-primary-lightest: #e0e7ff;
+
+  --ifm-background-color: #ffffff;
+  --ifm-navbar-background-color: rgba(255, 255, 255, 0.82);
+  --ifm-navbar-shadow: none;
+  --ifm-border-radius-base: 12px;
   --ifm-code-font-size: 95%;
-  --ifm-heading-color: var(--ifm-font-color-base);
-  --main-content-background-color: none;
-  --darkest-alt: #171819;
-  --announcement-bar-background: var(--ifm-color-primary-lightest);
-  --announcement-bar-color: var(--darkest-alt);
+  --ifm-line-height-base: 1.6;
+
+  --docusaurus-highlighted-code-line-bg: rgba(99, 102, 241, 0.08);
 }
 
 html[data-theme='dark'] {
-  --ifm-background-color: var(--darkest-alt);
-  --announcement-bar-background: var(--ifm-color-primary-light);
-  --announcement-bar-color: var(--ifm-color-primary-lightest);
+  --ifm-background-color: #0f172a;
+  --ifm-navbar-background-color: rgba(15, 23, 42, 0.75);
+  --ifm-color-primary: #818cf8;
+  --ifm-color-primary-dark: #6366f1;
+  --ifm-color-primary-darker: #4f46e5;
+  --ifm-color-primary-darkest: #4338ca;
+  --ifm-color-primary-light: #a5b4fc;
+  --ifm-color-primary-lighter: #c7d2fe;
+  --ifm-color-primary-lightest: #e0e7ff;
+  --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.08);
 }
 
-main {
-  background-color: var(--main-content-background-color);
+body {
+  background: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.08), transparent 25%),
+    radial-gradient(circle at 80% 0%, rgba(67, 56, 202, 0.08), transparent 22%),
+    var(--ifm-background-color);
 }
 
-.aa-DetachedSearchButton {
-  color: blue;
+.navbar {
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(99, 102, 241, 0.15);
+  transition: background-color 200ms ease, border-color 200ms ease;
 }
 
-h1 {
-  padding-bottom: 1rem;
+html[data-theme='dark'] .navbar {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+.footer {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.95), #0b1020);
 }
 
 .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: var(--docusaurus-highlighted-code-line-bg);
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
 
-.footer {
-  background-color: #272a36;
-}
-
-html[data-theme='dark'] .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.3);
-}
-
-html[data-theme='dark'] .navbar {
-  background-color: var(--ifm-background-color);
-  border-bottom: 1px solid var(--ifm-color-primary-darker);
-}
-
-html[data-theme='light'] .hero__primary.hero {
-  background-color: var(--ifm-color-primary-lightest);
-  color: var(--ifm-color-primary-darkest);
-}
-
-html[data-theme='dark'] .hero__primary.hero {
-  background-color: var(--ifm-background-color);
-  color: var(--ifm-color-primary-darkest);
-}
-
-html[data-theme='dark'] .hero__title {
-  color: var(--ifm-color-primary-lightest);
-}
-
-.hero__title {
-  text-transform: uppercase;
-  color: var(--ifm-heading-color);
-}
-
+.hero__title,
 .hero__subtitle {
-  color: var(--ifm-heading-color);
+  color: var(--ifm-color-emphasis-900);
+}
+
+html[data-theme='dark'] .hero__title,
+html[data-theme='dark'] .hero__subtitle {
+  color: #e2e8f0;
 }
 
 .header-badge {
   display: flex;
+  align-items: center;
 }
 
 .header-github-link {
   content: '';
-  background-color: var(--ifm-color-primary-darkest);
+  background-color: var(--ifm-color-emphasis-900);
   mask-image: url('/img/github.svg');
   mask-size: contain;
   mask-repeat: no-repeat;
@@ -102,5 +93,9 @@ html[data-theme='dark'] .hero__title {
 }
 
 html[data-theme='dark'] .header-github-link {
-  background-color: var(--ifm-color-primary-lightest);
+  background-color: #e2e8f0;
+}
+
+.aa-DetachedSearchButton {
+  color: inherit;
 }

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -2,10 +2,8 @@ import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
-import React from 'react';
+import React, { useState } from 'react';
 
-import GithubLogo from '../../static/img/github.svg';
-import LogoSvg from '../../static/img/logo.svg';
 import Demo from '../components/Demo';
 import HomepageFeatures from '../components/HomepageFeatures';
 import RawExample from '../components/RawExample';
@@ -14,39 +12,76 @@ import styles from './index.module.css';
 
 function HomepageHeader() {
   const { siteConfig } = useDocusaurusContext();
+  const [copied, setCopied] = useState(false);
+  const installCommand = 'npm i vest';
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(installCommand).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    });
+  };
+
   return (
     <header className={clsx('hero', styles.heroBanner)}>
-      <div className={styles.logoContainer}>
-        <LogoSvg className={styles.vestLogo} />
-      </div>
-      <div className={styles.titleContainer}>
-        <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className={clsx('hero__subtitle', styles.heroTagline)}>
-          {siteConfig.tagline}
-        </p>
-      </div>
-      <div className={styles.buttons}>
-        <Link
-          className={clsx('button', styles.btn, styles.btnQuickStart)}
-          to="/docs/get_started"
-        >
-          Quick Start Guide
-        </Link>
-        <Link
-          className={clsx('button', styles.btn, styles.btnGit)}
-          to="https://github.com/ealush/vest"
-        >
-          <GithubLogo
-            style={{ height: '22px', marginRight: '0.5rem', float: 'left' }}
-          />
-          Github
-        </Link>
-        <Link
-          className={clsx('button', styles.btn, styles.btnGit)}
-          to="/vest-6-is-ready"
-        >
-          Try V6 instead
-        </Link>
+      <div className={styles.heroGlow} />
+      <div className={styles.heroGrid}>
+        <div className={styles.heroContent}>
+          <div className={styles.eyebrow}>Modern validations framework</div>
+          <h1 className={clsx('hero__title', styles.heroTitle)}>
+            Declarative validations
+            <span className={styles.heroHighlight}> inspired by testing</span>
+          </h1>
+          <p className={clsx('hero__subtitle', styles.heroTagline)}>
+            {siteConfig.tagline}
+          </p>
+          <div className={styles.heroActions}>
+            <Link
+              className={clsx('button button--lg', styles.primaryCta)}
+              to="/docs/get_started"
+            >
+              Get Started
+            </Link>
+            <Link
+              className={clsx('button button--secondary button--lg', styles.secondaryCta)}
+              to="https://github.com/ealush/vest"
+            >
+              View on GitHub
+            </Link>
+          </div>
+          <div className={styles.installBar}>
+            <code className={styles.installCommand}>{installCommand}</code>
+            <button
+              type="button"
+              className={styles.copyButton}
+              onClick={handleCopy}
+              aria-live="polite"
+            >
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+        </div>
+        <div className={styles.heroShowcase}>
+          <div className={styles.showcaseCard}>
+            <div className={styles.cardGlow} />
+            <div className={styles.cardHeader}>Suite anatomy</div>
+            <pre className={styles.codeBlock}>
+              <code>{`import vest, { test, enforce } from 'vest';
+
+const suite = vest.create('signup', () => {
+  test('username', 'Must be at least 3 chars', () => {
+    enforce(username).longerThanOrEquals(3);
+  });
+});
+
+export default suite;`}</code>
+            </pre>
+            <div className={styles.cardFooter}>
+              Built for predictable DX
+              <span className={styles.cardPill}>Framework agnostic</span>
+            </div>
+          </div>
+        </div>
       </div>
     </header>
   );

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -1,131 +1,241 @@
-/**
- * CSS files with the .module.css suffix will be treated as CSS modules
- * and scoped locally.
- */
-
 .heroBanner {
-  text-align: center;
   position: relative;
   overflow: hidden;
-  padding: 4rem 2rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background: linear-gradient(
-    180deg,
-    var(--ifm-color-primary-lightest) 0%,
-    #ffffff 100%
-  );
+  padding: 5rem clamp(1rem, 5vw, 3rem);
+  background: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.08), transparent 35%),
+    radial-gradient(circle at 80% 0%, rgba(67, 56, 202, 0.1), transparent 30%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0.6));
+  backdrop-filter: blur(10px);
 }
 
 html[data-theme='dark'] .heroBanner {
-  background: linear-gradient(180deg, #1b1b1d 0%, #000000 100%);
+  background: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.16), transparent 32%),
+    radial-gradient(circle at 80% 10%, rgba(67, 56, 202, 0.18), transparent 28%),
+    linear-gradient(180deg, rgba(17, 24, 39, 0.85), rgba(15, 23, 42, 0.9));
 }
 
-.logoContainer {
-  margin-bottom: 2rem;
+.heroGlow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 20%, rgba(99, 102, 241, 0.15), transparent 40%),
+    radial-gradient(circle at 70% 10%, rgba(37, 99, 235, 0.1), transparent 35%),
+    radial-gradient(circle at 50% 80%, rgba(16, 185, 129, 0.08), transparent 35%);
+  filter: blur(50px);
+  z-index: 1;
+}
+
+.heroGrid {
   position: relative;
-  z-index: 10;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: clamp(2rem, 4vw, 3rem);
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
-.vestLogo {
-  width: 150px;
-  height: 150px;
-  filter: drop-shadow(0 10px 20px rgba(0, 0, 0, 0.15));
+.heroContent {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.titleContainer {
-  max-width: 800px;
-  margin: 0 auto 2rem;
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--ifm-color-primary);
+  font-weight: 600;
+  width: fit-content;
+  letter-spacing: 0.03em;
+  font-size: 0.95rem;
+}
+
+.heroTitle {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  line-height: 1.1;
+  margin: 0;
+}
+
+.heroHighlight {
+  display: inline-block;
+  margin-left: 0.35rem;
+  color: var(--ifm-color-primary);
+  text-shadow: 0 10px 40px rgba(99, 102, 241, 0.35);
 }
 
 .heroTagline {
-  font-size: 1.5rem;
-  line-height: 1.5;
+  max-width: 640px;
+  font-size: 1.1rem;
   color: var(--ifm-color-emphasis-700);
-  margin-top: 1rem;
-  font-weight: 400;
 }
 
-.buttons {
+html[data-theme='dark'] .heroTagline {
+  color: #cbd5e1;
+}
+
+.heroActions {
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
   align-items: center;
-  justify-content: center;
-  gap: 1.5rem;
-  margin-top: 2rem;
 }
 
-.btn {
+.primaryCta {
+  border-radius: 999px;
+  box-shadow: 0 20px 40px rgba(99, 102, 241, 0.2);
+  padding-inline: 1.6rem;
+}
+
+.secondaryCta {
+  border-radius: 999px;
+  border: 1px solid var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+  padding-inline: 1.6rem;
+}
+
+.installBar {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  font-size: 1.1rem;
-  padding: 0.8rem 2rem;
-  border-radius: 50px;
+  gap: 0.5rem;
+  background: rgba(15, 23, 42, 0.03);
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  margin-top: 0.35rem;
+  width: fit-content;
+}
+
+html[data-theme='dark'] .installBar {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(129, 140, 248, 0.35);
+}
+
+.installCommand {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.95rem;
+  color: inherit;
+}
+
+.copyButton {
+  border: 1px solid rgba(99, 102, 241, 0.5);
+  color: var(--ifm-color-primary);
+  background: rgba(99, 102, 241, 0.08);
+  border-radius: 10px;
+  padding: 0.45rem 0.85rem;
+  font-weight: 600;
   transition: all 0.2s ease;
-  text-decoration: none !important;
-  box-shadow: 0 4px 14px 0 rgba(0, 0, 0, 0.1);
+  cursor: pointer;
 }
 
-.btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+.copyButton:hover {
+  transform: translateY(-1px);
+  background: rgba(99, 102, 241, 0.14);
 }
 
-.btnQuickStart {
-  background-color: var(--ifm-color-primary);
-  color: #fff;
-  border: 2px solid var(--ifm-color-primary);
+.heroShowcase {
+  display: flex;
+  justify-content: center;
 }
 
-.btnQuickStart:hover {
-  background-color: var(--ifm-color-primary-dark);
-  border-color: var(--ifm-color-primary-dark);
-  color: #fff;
+.showcaseCard {
+  position: relative;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 20px;
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  padding: 1.25rem 1.5rem;
+  width: min(520px, 100%);
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
 }
 
-.btnGit {
-  background-color: var(--ifm-color-emphasis-200);
+html[data-theme='dark'] .showcaseCard {
+  background: rgba(17, 24, 39, 0.8);
+  border-color: rgba(129, 140, 248, 0.22);
+  box-shadow: 0 25px 80px rgba(0, 0, 0, 0.45);
+}
+
+.cardGlow {
+  position: absolute;
+  inset: -10%;
+  background: radial-gradient(circle at 30% 30%, rgba(99, 102, 241, 0.25), transparent 30%),
+    radial-gradient(circle at 80% 0%, rgba(56, 189, 248, 0.2), transparent 28%);
+  filter: blur(40px);
+  z-index: 1;
+}
+
+.cardHeader,
+.cardFooter,
+.codeBlock {
+  position: relative;
+  z-index: 2;
+}
+
+.cardHeader {
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--ifm-color-primary);
+  margin-bottom: 0.65rem;
+}
+
+.codeBlock {
+  font-family: var(--ifm-font-family-monospace);
+  background: rgba(15, 23, 42, 0.03);
+  border-radius: 14px;
+  padding: 1rem;
   color: var(--ifm-color-emphasis-900);
-  border: 2px solid transparent;
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  overflow-x: auto;
 }
 
-.btnGit:hover {
-  background-color: var(--ifm-color-emphasis-300);
-  border-color: transparent;
-  color: var(--ifm-color-emphasis-900);
+html[data-theme='dark'] .codeBlock {
+  background: rgba(15, 23, 42, 0.65);
+  color: #e2e8f0;
+  border-color: rgba(129, 140, 248, 0.28);
 }
 
-html[data-theme='dark'] .btnGit {
-  background-color: rgba(255, 255, 255, 0.1);
-  color: #fff;
+.cardFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 0.75rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-800);
 }
 
-html[data-theme='dark'] .btnGit:hover {
-  background-color: rgba(255, 255, 255, 0.2);
+html[data-theme='dark'] .cardFooter {
+  color: #cbd5e1;
 }
 
-.btnPromote {
-  display: none; /* Hiding promote button for cleaner look, or we can restyle it */
+.cardPill {
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  background: rgba(99, 102, 241, 0.15);
+  color: var(--ifm-color-primary);
+  font-size: 0.85rem;
+  font-weight: 700;
 }
 
-@media screen and (max-width: 768px) {
+html[data-theme='dark'] .cardPill {
+  background: rgba(129, 140, 248, 0.22);
+}
+
+@media screen and (max-width: 996px) {
   .heroBanner {
-    padding: 3rem 1rem;
+    padding-top: 3.5rem;
+    padding-bottom: 4rem;
   }
 
-  .heroTagline {
-    font-size: 1.2rem;
+  .heroGrid {
+    grid-template-columns: 1fr;
   }
 
-  .buttons {
-    flex-direction: column;
-    width: 100%;
-  }
-
-  .btn {
-    width: 100%;
-    max-width: 300px;
+  .heroContent,
+  .heroShowcase {
+    text-align: left;
   }
 }


### PR DESCRIPTION
## Summary
- refresh global typography, color tokens, and navbar/footer treatments for the docs site
- redesign homepage hero with gradient/glow visuals, dual CTAs, and inline install copy affordance
- update feature grid to bento-style cards with modern hover and responsive layout; modernize Docusaurus config and prism themes

## Testing
- yarn website:build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69341814a13c83309768718801e4be34)