### PR TITLE
Modernize website styling and hero layout

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,18 +1,19 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-import { Highlight, themes } from 'prism-react-renderer';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { themes } from 'prism-react-renderer';
 
-// const darkCodeTheme = require('prism-react-renderer/themes/dracula');
-// const lightCodeTheme = require('prism-react-renderer/themes/github');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   baseUrl: '/',
   favicon: 'favicon.ico',
   title: 'Vest',
-  tagline:
-    'Declarative validations framework inspired by unit testing libraries',
+  tagline: 'Declarative validations framework inspired by unit testing libraries',
   url: 'https://vestjs.dev',
   onBrokenLinks: 'throw',
   markdown: {
@@ -23,12 +24,6 @@ const config = {
   },
   organizationName: 'ealush', // Usually your GitHub org/user name.
   plugins: [
-    // [
-    //   require.resolve('@easyops-cn/docusaurus-search-local'),
-    //   {
-    //     indexBlog: false,
-    //   },
-    // ],
     [
       '@docusaurus/plugin-google-gtag',
       {
@@ -43,7 +38,7 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
+          sidebarPath: path.resolve(__dirname, './sidebars.js'),
           // Please change this to your repo.
           editUrl: 'https://github.com/ealush/vest/edit/latest/website/',
           lastVersion: 'current',
@@ -76,7 +71,7 @@ const config = {
           beforeDefaultRehypePlugins: [],
         },
         theme: {
-          customCss: require.resolve('./src/css/custom.css'),
+          customCss: path.resolve(__dirname, './src/css/custom.css'),
         },
       }),
     ],
@@ -195,10 +190,6 @@ const config = {
           {
             title: 'More',
             items: [
-              // {
-              //   label: "Blog",
-              //   to: "/blog",
-              // },
               {
                 label: 'GitHub',
                 href: 'https://github.com/ealush/vest',
@@ -210,7 +201,7 @@ const config = {
       },
       prism: {
         theme: themes.github,
-        darkTheme: themes.dracula,
+        darkTheme: themes.vsDark ?? themes.dracula,
       },
       announcementBar: {
         id: 'announcementBar-vest-6',
@@ -232,7 +223,7 @@ const config = {
     }),
 };
 
-module.exports = config;
+export default config;
 
 function badgeLink(url, badge, name) {
   return `<a href="${url}" class="header-badge" target="_blank">

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -28,4 +28,4 @@ const sidebars = {
    */
 };
 
-module.exports = sidebars;
+export default sidebars;

--- a/website/src/components/HomepageFeatures.js
+++ b/website/src/components/HomepageFeatures.js
@@ -1,82 +1,52 @@
 import clsx from 'clsx';
 import React from 'react';
-import commonStyles from './Common.module.css';
+
 import styles from './HomepageFeatures.module.css';
 
 const FeatureList = [
   {
-    title: 'Easy to learn',
-    emoji: '💡',
-    description: (
-      <>
-        Vest adopts the syntax and style of unit testing frameworks, so you can
-        leverage the knowledge you already have to write your form validations.
-      </>
-    ),
+    title: 'Unit test mindset',
+    emoji: '🧪',
+    subtitle: 'Declarative suites built like specs',
+    description:
+      'Write validations with the same ergonomics as your favorite testing library—clear assertions, readable suites, and predictable runs.',
+    bullets: ['Familiar describe/it flow', 'Deterministic orchestration', 'Readable failures'],
   },
   {
-    title: 'Framework Agnostic',
-    emoji: '🎨',
-    description: (
-      <>
-        Bring your own UI. Vest is framework agnostic, so you can use it with
-        any UI framework you have.
-      </>
-    ),
+    title: 'Framework agnostic',
+    emoji: '🔌',
+    subtitle: 'Drop into any stack',
+    description:
+      'Use Vest with React, Vue, Svelte, or vanilla JS. Keep your UI agnostic while sharing validation logic across apps.',
+    bullets: ['No UI dependencies', 'Composable rules', 'Shareable between projects'],
   },
   {
-    title: 'Really smart',
-    emoji: '🧠',
-    description: (
-      <>
-        Vest takes care of all the annoying parts for you. It manages its own
-        state, handles async validations and much more.
-      </>
-    ),
-  },
-  {
-    title: 'Extendable',
-    emoji: '🧩',
-    description: (
-      <>
-        You can easily add new custom types of validations to Vest according to
-        your needs.
-      </>
-    ),
-  },
-  {
-    title: 'Reusable',
-    emoji: '♻️',
-    description: (
-      <>
-        Validation logic in Vest can be shared across multiple features in your
-        app.
-      </>
-    ),
-  },
-  {
-    title: 'Tiny',
-    emoji: '🐜',
-    description: (
-      <>
-        Packed with features, but optimized for size. Vest brings no
-        dependencies, and only takes a few KBs.
-      </>
-    ),
+    title: 'Production-ready',
+    emoji: '🚀',
+    subtitle: 'Async safe and lightweight',
+    description:
+      'Handle async flows confidently with built-in orchestration while keeping bundles lean and dependency-free.',
+    bullets: ['Async-first primitives', 'Tiny footprint', 'Type-safe APIs'],
   },
 ];
 
-function Feature({ emoji, title, description }) {
+function Feature({ emoji, title, subtitle, description, bullets }) {
   return (
-    <div className={clsx('col col--4')}>
+    <div className={clsx('col col--4', styles.featureCol)}>
       <div className={styles.featureCard}>
-        <div className="text--center">
+        <div className={styles.cardHeader}>
           <span className={styles.emoji}>{emoji}</span>
+          <div>
+            <p className={styles.featureSubtitle}>{subtitle}</p>
+            <h3 className={styles.featureTitle}>{title}</h3>
+          </div>
         </div>
-        <div className="text--center padding-horiz--md">
-          <h3 className={styles.featureTitle}>{title}</h3>
-          <p className={styles.featureDescription}>{description}</p>
-        </div>
+        <p className={styles.featureDescription}>{description}</p>
+        <ul className={styles.featureList}>
+          {bullets.map(item => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
       </div>
     </div>
   );
@@ -84,18 +54,22 @@ function Feature({ emoji, title, description }) {
 
 export default function HomepageFeatures() {
   return (
-    <>
-      <section
-        className={clsx(styles.features, commonStyles.main_section_centered)}
-      >
-        <div className="container">
-          <div className="row">
-            {FeatureList.map((props, idx) => (
-              <Feature key={idx} {...props} />
-            ))}
-          </div>
+    <section className={styles.features}>
+      <div className="container">
+        <div className={styles.sectionHeader}>
+          <p className={styles.kicker}>Why teams choose Vest</p>
+          <h2 className={styles.sectionTitle}>Reliable validations without the ceremony</h2>
+          <p className={styles.sectionLead}>
+            Vest keeps validations simple, expressive, and portable—so you can
+            ship confidently without rewriting business logic for every stack.
+          </p>
         </div>
-      </section>
-    </>
+        <div className="row">
+          {FeatureList.map(feature => (
+            <Feature key={feature.title} {...feature} />
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }

--- a/website/src/components/HomepageFeatures.module.css
+++ b/website/src/components/HomepageFeatures.module.css
@@ -1,62 +1,150 @@
 .features {
-  display: flex;
+  padding: 4rem 0 5rem;
+}
+
+.sectionHeader {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.kicker {
+  display: inline-flex;
   align-items: center;
-  padding: 6rem 0;
-  width: 100%;
+  justify-content: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-primary-dark);
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(99, 102, 241, 0.22);
+}
+
+.sectionTitle {
+  margin: 0.6rem 0;
+  font-size: clamp(1.9rem, 2.5vw, 2.4rem);
+  letter-spacing: -0.02em;
+}
+
+.sectionLead {
+  margin: 0 auto;
+  max-width: 720px;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+html[data-theme='dark'] .sectionLead {
+  color: #cbd5e1;
+}
+
+.featureCol {
+  margin-bottom: 1.5rem;
 }
 
 .featureCard {
   height: 100%;
   padding: 2rem;
-  border-radius: 24px;
-  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
-  background: transparent;
-  border: 1px solid transparent;
-  margin-bottom: 2rem; /* Add vertical gap */
+  border-radius: 18px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-card-background-color);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.featureCard::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.12), transparent 40%);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
 }
 
 .featureCard:hover {
-  background: rgba(255, 255, 255, 0.5);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.05);
-  backdrop-filter: blur(4px);
+  transform: translateY(-6px);
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 22px 45px rgba(99, 102, 241, 0.18);
+}
+
+.featureCard:hover::after {
+  opacity: 1;
+}
+
+html[data-theme='dark'] .featureCard {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(30, 41, 59, 0.6);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
 }
 
 html[data-theme='dark'] .featureCard:hover {
-  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 25px 55px rgba(99, 102, 241, 0.3);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
 }
 
 .emoji {
-  font-size: 3rem;
-  margin-bottom: 1.5rem;
-  display: flex;
+  width: 52px;
+  height: 52px;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 80px;
-  height: 80px;
-  border-radius: 24px;
-  background: var(--ifm-color-emphasis-100); /* Simple background */
-  margin-left: auto;
-  margin-right: auto;
-  transition: transform 0.3s ease;
+  border-radius: 14px;
+  font-size: 1.6rem;
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(99, 102, 241, 0.22);
+}
+
+.featureSubtitle {
+  margin: 0;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  letter-spacing: 0.01em;
 }
 
 .featureTitle {
-  font-size: 1.5rem;
-  font-weight: 800;
-  margin-bottom: 1rem;
-  background: linear-gradient(
-    90deg,
-    var(--ifm-color-primary) 0%,
-    var(--ifm-color-primary-dark) 100%
-  );
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  margin: 0.25rem 0 0;
+  font-size: 1.4rem;
+  letter-spacing: -0.01em;
 }
 
 .featureDescription {
-  color: var(--ifm-color-emphasis-600);
-  line-height: 1.8;
-  font-size: 1.1rem;
-  font-weight: 500;
+  margin: 0 0 1rem;
+  color: var(--ifm-color-emphasis-700);
+  line-height: 1.7;
+}
+
+html[data-theme='dark'] .featureDescription {
+  color: #e2e8f0;
+}
+
+.featureList {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--ifm-color-emphasis-700);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.featureList li {
+  position: relative;
+  line-height: 1.5;
+}
+
+.featureList li::marker {
+  color: var(--ifm-color-primary);
+  font-size: 0.9rem;
+}
+
+html[data-theme='dark'] .featureList {
+  color: #cbd5e1;
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,88 +1,85 @@
-@import url('https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
-/**
- * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
- */
-
-/* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary-lightest: #fdfdfd;
-  --ifm-color-primary-lighter: #4b6889;
-  --ifm-color-primary-light: #486383;
-  --ifm-color-primary: #697098;
-  --ifm-color-primary-dark: #3b516b;
-  --ifm-color-primary-darker: #374d65;
-  --ifm-color-primary-darkest: #212432;
-  --ifm-font-family-base: 'Rubik', sans-serif;
+  --ifm-font-family-base: 'Inter', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --ifm-font-family-monospace: 'JetBrains Mono', SFMono-Regular, Consolas,
+    'Liberation Mono', Menlo, monospace;
+
+  --ifm-color-primary: #6366f1;
+  --ifm-color-primary-dark: #4f46e5;
+  --ifm-color-primary-darker: #4338ca;
+  --ifm-color-primary-darkest: #3730a3;
+  --ifm-color-primary-light: #818cf8;
+  --ifm-color-primary-lighter: #a5b4fc;
+  --ifm-color-primary-lightest: #e0e7ff;
+
+  --ifm-background-color: #ffffff;
+  --ifm-navbar-background-color: rgba(255, 255, 255, 0.85);
+  --ifm-navbar-shadow: none;
+  --ifm-border-radius-base: 12px;
   --ifm-code-font-size: 95%;
-  --ifm-heading-color: var(--ifm-font-color-base);
-  --main-content-background-color: none;
-  --darkest-alt: #171819;
-  --announcement-bar-background: var(--ifm-color-primary-lightest);
-  --announcement-bar-color: var(--darkest-alt);
+  --ifm-heading-color: #0f172a;
+  --ifm-card-background-color: #f8fafc;
+  --docusaurus-highlighted-code-line-bg: rgba(99, 102, 241, 0.12);
+  --main-content-background-color: transparent;
 }
 
 html[data-theme='dark'] {
-  --ifm-background-color: var(--darkest-alt);
-  --announcement-bar-background: var(--ifm-color-primary-light);
-  --announcement-bar-color: var(--ifm-color-primary-lightest);
+  --ifm-background-color: #0f172a;
+  --ifm-navbar-background-color: rgba(15, 23, 42, 0.7);
+  --ifm-color-primary: #818cf8;
+  --ifm-color-primary-dark: #6366f1;
+  --ifm-color-primary-darker: #4f46e5;
+  --ifm-color-primary-darkest: #4338ca;
+  --ifm-color-primary-light: #a5b4fc;
+  --ifm-color-primary-lighter: #c7d2fe;
+  --ifm-color-primary-lightest: #e0e7ff;
+  --ifm-card-background-color: rgba(30, 41, 59, 0.6);
+  --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.08);
+  --announcement-bar-background: #1e293b;
+  --announcement-bar-color: #e2e8f0;
 }
 
 main {
   background-color: var(--main-content-background-color);
 }
 
-.aa-DetachedSearchButton {
-  color: blue;
+.navbar {
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
 }
 
-h1 {
-  padding-bottom: 1rem;
+html[data-theme='dark'] .navbar {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 }
 
 .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: var(--docusaurus-highlighted-code-line-bg);
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
 
-.footer {
-  background-color: #272a36;
-}
-
-html[data-theme='dark'] .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.3);
-}
-
-html[data-theme='dark'] .navbar {
-  background-color: var(--ifm-background-color);
-  border-bottom: 1px solid var(--ifm-color-primary-darker);
-}
-
-html[data-theme='light'] .hero__primary.hero {
-  background-color: var(--ifm-color-primary-lightest);
-  color: var(--ifm-color-primary-darkest);
-}
-
-html[data-theme='dark'] .hero__primary.hero {
-  background-color: var(--ifm-background-color);
-  color: var(--ifm-color-primary-darkest);
-}
-
-html[data-theme='dark'] .hero__title {
-  color: var(--ifm-color-primary-lightest);
-}
-
 .hero__title {
-  text-transform: uppercase;
   color: var(--ifm-heading-color);
+  letter-spacing: -0.04em;
+  text-transform: none;
 }
 
 .hero__subtitle {
-  color: var(--ifm-heading-color);
+  color: var(--ifm-color-emphasis-700);
+}
+
+html[data-theme='dark'] .hero__subtitle {
+  color: #cbd5e1;
+}
+
+.footer {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.9), #0b1220);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .header-badge {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -4,49 +4,117 @@ import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import React from 'react';
 
-import GithubLogo from '../../static/img/github.svg';
-import LogoSvg from '../../static/img/logo.svg';
 import Demo from '../components/Demo';
 import HomepageFeatures from '../components/HomepageFeatures';
 import RawExample from '../components/RawExample';
 
 import styles from './index.module.css';
 
+const installCommand = 'npm i vest';
+
+function InstallSnippet() {
+  const [copied, setCopied] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!copied) {
+      return undefined;
+    }
+
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  const copyToClipboard = () => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) {
+      return;
+    }
+
+    navigator.clipboard.writeText(installCommand).then(() => setCopied(true));
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={copyToClipboard}
+      className={styles.installSnippet}
+    >
+      <code className={styles.installText}>{installCommand}</code>
+      <span className={styles.copyLabel}>{copied ? 'Copied' : 'Copy'}</span>
+    </button>
+  );
+}
+
 function HomepageHeader() {
   const { siteConfig } = useDocusaurusContext();
+
   return (
-    <header className={clsx('hero', styles.heroBanner)}>
-      <div className={styles.logoContainer}>
-        <LogoSvg className={styles.vestLogo} />
+    <header className={clsx('hero', styles.hero)}>
+      <div className={styles.heroBackdrop}>
+        <span className={styles.heroGlow} />
+        <span className={styles.heroGradient} />
       </div>
-      <div className={styles.titleContainer}>
-        <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className={clsx('hero__subtitle', styles.heroTagline)}>
-          {siteConfig.tagline}
-        </p>
-      </div>
-      <div className={styles.buttons}>
-        <Link
-          className={clsx('button', styles.btn, styles.btnQuickStart)}
-          to="/docs/get_started"
-        >
-          Quick Start Guide
-        </Link>
-        <Link
-          className={clsx('button', styles.btn, styles.btnGit)}
-          to="https://github.com/ealush/vest"
-        >
-          <GithubLogo
-            style={{ height: '22px', marginRight: '0.5rem', float: 'left' }}
-          />
-          Github
-        </Link>
-        <Link
-          className={clsx('button', styles.btn, styles.btnGit)}
-          to="/vest-6-is-ready"
-        >
-          Try V6 instead
-        </Link>
+
+      <div className={clsx('container', styles.heroContainer)}>
+        <div className={styles.heroContent}>
+          <p className={styles.eyebrow}>Modern validation toolkit</p>
+          <h1 className="hero__title">
+            Declarative validations
+            <br />
+            <span className={styles.heroHighlight}>inspired by unit testing</span>
+          </h1>
+          <p className={clsx('hero__subtitle', styles.heroLead)}>
+            {siteConfig.tagline}
+          </p>
+
+          <div className={styles.ctaGroup}>
+            <Link
+              className={clsx('button button--primary button--lg', styles.primaryCta)}
+              to="/docs/get_started"
+            >
+              Get started
+            </Link>
+            <Link
+              className={clsx('button button--outline button--lg', styles.secondaryCta)}
+              to="https://github.com/ealush/vest"
+            >
+              View on GitHub
+            </Link>
+            <InstallSnippet />
+          </div>
+
+          <ul className={styles.heroMeta}>
+            <li>Framework agnostic</li>
+            <li>Async-safe validations</li>
+            <li>Zero dependencies</li>
+          </ul>
+        </div>
+
+        <div className={styles.heroPanel}>
+          <div className={styles.panelHeader}>Confidence without ceremony</div>
+          <div className={styles.panelBody}>
+            <div className={styles.panelRow}>
+              <span className={styles.pill}>DX Focused</span>
+              <p>
+                Vest mirrors the testing APIs you already know, so writing and
+                reading validations feels effortless.
+              </p>
+            </div>
+            <div className={styles.panelRow}>
+              <span className={styles.pill}>Predictable</span>
+              <p>
+                Deterministic runs with async orchestration keep suites stable
+                across complex forms and flows.
+              </p>
+            </div>
+            <div className={styles.panelRow}>
+              <span className={styles.pill}>Composable</span>
+              <p>
+                Share and reuse validation logic across apps while keeping
+                bundles lean and dependency-free.
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
     </header>
   );
@@ -54,6 +122,7 @@ function HomepageHeader() {
 
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
+
   return (
     <Layout
       title={`${siteConfig.title} Validations Framework`}

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -3,129 +3,276 @@
  * and scoped locally.
  */
 
-.heroBanner {
-  text-align: center;
+.hero {
   position: relative;
   overflow: hidden;
-  padding: 4rem 2rem;
+  padding: 6rem 1.5rem 4rem;
+  background: radial-gradient(circle at 20% 20%, rgba(129, 140, 248, 0.2), transparent 35%),
+    radial-gradient(circle at 80% 0%, rgba(45, 212, 191, 0.12), transparent 40%),
+    var(--ifm-background-color);
+}
+
+.heroBackdrop {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.heroGlow {
+  position: absolute;
+  width: 320px;
+  height: 320px;
+  right: 10%;
+  top: 20%;
+  background: radial-gradient(circle, rgba(99, 102, 241, 0.4), transparent 60%);
+  filter: blur(60px);
+}
+
+.heroGradient {
+  position: absolute;
+  width: 40%;
+  height: 100%;
+  left: -10%;
+  top: 0;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.2), rgba(129, 140, 248, 0.05));
+  transform: skewX(-8deg);
+}
+
+.heroContainer {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+  z-index: 1;
+}
+
+.heroContent {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  background: linear-gradient(
-    180deg,
-    var(--ifm-color-primary-lightest) 0%,
-    #ffffff 100%
-  );
-}
-
-html[data-theme='dark'] .heroBanner {
-  background: linear-gradient(180deg, #1b1b1d 0%, #000000 100%);
-}
-
-.logoContainer {
-  margin-bottom: 2rem;
-  position: relative;
-  z-index: 10;
-}
-
-.vestLogo {
-  width: 150px;
-  height: 150px;
-  filter: drop-shadow(0 10px 20px rgba(0, 0, 0, 0.15));
-}
-
-.titleContainer {
-  max-width: 800px;
-  margin: 0 auto 2rem;
-}
-
-.heroTagline {
-  font-size: 1.5rem;
-  line-height: 1.5;
-  color: var(--ifm-color-emphasis-700);
-  margin-top: 1rem;
-  font-weight: 400;
-}
-
-.buttons {
-  display: flex;
-  align-items: center;
-  justify-content: center;
   gap: 1.5rem;
-  margin-top: 2rem;
 }
 
-.btn {
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-primary-dark);
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(99, 102, 241, 0.25);
+}
+
+.heroHighlight {
+  color: var(--ifm-color-primary);
+}
+
+.heroLead {
+  max-width: 560px;
+  font-size: 1.15rem;
+  line-height: 1.7;
+  color: var(--ifm-color-emphasis-700);
+}
+
+html[data-theme='dark'] .heroLead {
+  color: #cbd5e1;
+}
+
+.ctaGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.primaryCta {
+  box-shadow: 0 10px 30px rgba(99, 102, 241, 0.35);
+}
+
+.secondaryCta {
+  border-color: rgba(99, 102, 241, 0.4);
+  color: var(--ifm-color-primary);
+}
+
+.secondaryCta:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-darkest);
+}
+
+html[data-theme='dark'] .secondaryCta {
+  color: var(--ifm-color-primary-lightest);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+html[data-theme='dark'] .secondaryCta:hover {
+  color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+}
+
+.installSnippet {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.8rem 1.2rem;
+  border-radius: 14px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(99, 102, 241, 0.05));
+  color: var(--ifm-color-primary-darkest);
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.installSnippet:hover {
+  transform: translateY(-2px);
+  border-color: var(--ifm-color-primary-light);
+  box-shadow: 0 12px 28px rgba(99, 102, 241, 0.2);
+}
+
+html[data-theme='dark'] .installSnippet {
+  border-color: rgba(255, 255, 255, 0.12);
+  color: #e2e8f0;
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.16), rgba(14, 165, 233, 0.05));
+}
+
+.installText {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.95rem;
+}
+
+.copyLabel {
+  font-weight: 600;
+  color: var(--ifm-color-primary-dark);
+}
+
+html[data-theme='dark'] .copyLabel {
+  color: var(--ifm-color-primary-lightest);
+}
+
+.heroMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.heroMeta li {
+  padding: 0.5rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: rgba(99, 102, 241, 0.08);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+html[data-theme='dark'] .heroMeta li {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #e2e8f0;
+}
+
+.heroPanel {
+  border-radius: 20px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.8), rgba(248, 250, 252, 0.95));
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.15);
+  overflow: hidden;
+  position: relative;
+  z-index: 1;
+}
+
+.panelHeader {
+  padding: 1.1rem 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--ifm-color-primary-darkest);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.panelBody {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 1.5rem;
+}
+
+.panelRow {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.panelRow p {
+  margin: 0;
+  color: var(--ifm-color-emphasis-700);
+  line-height: 1.6;
+}
+
+.pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  height: 36px;
+  padding: 0 0.9rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--ifm-color-primary-dark);
+  border: 1px solid rgba(99, 102, 241, 0.25);
   font-weight: 700;
-  font-size: 1.1rem;
-  padding: 0.8rem 2rem;
-  border-radius: 50px;
-  transition: all 0.2s ease;
-  text-decoration: none !important;
-  box-shadow: 0 4px 14px 0 rgba(0, 0, 0, 0.1);
+  letter-spacing: 0.02em;
 }
 
-.btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+html[data-theme='dark'] .heroPanel {
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.8), rgba(15, 23, 42, 0.95));
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 40px 80px rgba(0, 0, 0, 0.5);
 }
 
-.btnQuickStart {
-  background-color: var(--ifm-color-primary);
-  color: #fff;
-  border: 2px solid var(--ifm-color-primary);
+html[data-theme='dark'] .panelHeader {
+  color: #e2e8f0;
+  border-color: rgba(255, 255, 255, 0.08);
 }
 
-.btnQuickStart:hover {
-  background-color: var(--ifm-color-primary-dark);
-  border-color: var(--ifm-color-primary-dark);
-  color: #fff;
+html[data-theme='dark'] .panelRow p {
+  color: #cbd5e1;
 }
 
-.btnGit {
-  background-color: var(--ifm-color-emphasis-200);
-  color: var(--ifm-color-emphasis-900);
-  border: 2px solid transparent;
+html[data-theme='dark'] .pill {
+  background: rgba(129, 140, 248, 0.16);
+  color: #e0e7ff;
+  border-color: rgba(255, 255, 255, 0.12);
 }
 
-.btnGit:hover {
-  background-color: var(--ifm-color-emphasis-300);
-  border-color: transparent;
-  color: var(--ifm-color-emphasis-900);
-}
-
-html[data-theme='dark'] .btnGit {
-  background-color: rgba(255, 255, 255, 0.1);
-  color: #fff;
-}
-
-html[data-theme='dark'] .btnGit:hover {
-  background-color: rgba(255, 255, 255, 0.2);
-}
-
-.btnPromote {
-  display: none; /* Hiding promote button for cleaner look, or we can restyle it */
-}
-
-@media screen and (max-width: 768px) {
-  .heroBanner {
-    padding: 3rem 1rem;
+@media screen and (max-width: 996px) {
+  .hero {
+    padding-top: 5rem;
   }
 
-  .heroTagline {
-    font-size: 1.2rem;
+  .panelRow {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .hero {
+    padding: 4rem 1rem 3rem;
   }
 
-  .buttons {
+  .ctaGroup {
     flex-direction: column;
-    width: 100%;
+    align-items: stretch;
   }
 
-  .btn {
+  .installSnippet {
     width: 100%;
-    max-width: 300px;
+    justify-content: space-between;
   }
 }


### PR DESCRIPTION
## Summary
- refresh global theme tokens and color palette for the website, adding glassmorphism and updated typography
- redesign the homepage hero and feature cards with modern layout, gradients, and richer calls-to-action
- convert Docusaurus config to ES module syntax and update Prism theme defaults

## Testing
- yarn website:build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69341814a13c83309768718801e4be34)