### PR TITLE
Revamp docs site visuals

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,18 +1,14 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-import { Highlight, themes } from 'prism-react-renderer';
-
-// const darkCodeTheme = require('prism-react-renderer/themes/dracula');
-// const lightCodeTheme = require('prism-react-renderer/themes/github');
+import { themes } from 'prism-react-renderer';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   baseUrl: '/',
   favicon: 'favicon.ico',
   title: 'Vest',
-  tagline:
-    'Declarative validations framework inspired by unit testing libraries',
+  tagline: 'Declarative validations framework inspired by unit testing libraries',
   url: 'https://vestjs.dev',
   onBrokenLinks: 'throw',
   markdown: {
@@ -23,12 +19,6 @@ const config = {
   },
   organizationName: 'ealush', // Usually your GitHub org/user name.
   plugins: [
-    // [
-    //   require.resolve('@easyops-cn/docusaurus-search-local'),
-    //   {
-    //     indexBlog: false,
-    //   },
-    // ],
     [
       '@docusaurus/plugin-google-gtag',
       {
@@ -43,8 +33,7 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
-          // Please change this to your repo.
+          sidebarPath: './sidebars.js',
           editUrl: 'https://github.com/ealush/vest/edit/latest/website/',
           lastVersion: 'current',
           versions: {
@@ -76,7 +65,7 @@ const config = {
           beforeDefaultRehypePlugins: [],
         },
         theme: {
-          customCss: require.resolve('./src/css/custom.css'),
+          customCss: './src/css/custom.css',
         },
       }),
     ],
@@ -195,10 +184,6 @@ const config = {
           {
             title: 'More',
             items: [
-              // {
-              //   label: "Blog",
-              //   to: "/blog",
-              // },
               {
                 label: 'GitHub',
                 href: 'https://github.com/ealush/vest',
@@ -210,29 +195,23 @@ const config = {
       },
       prism: {
         theme: themes.github,
-        darkTheme: themes.dracula,
+        darkTheme: themes.vsDark,
       },
       announcementBar: {
         id: 'announcementBar-vest-6',
-        content:
-          'Vest 6 is ready for testing 🎉 <a href="/vest-6-is-ready">Try it out now!</a>',
+        content: 'Vest 6 is ready for testing 🎉 <a href="/vest-6-is-ready">Try it out now!</a>',
         textColor: 'var(--announcement-bar-color)',
         isCloseable: true,
       },
       algolia: {
-        // temporary disabled until the index gets updated
-        // The application ID provided by Algolia
         appId: '08EPW2MDNA',
-
-        // Public API key: it is safe to commit it
         apiKey: '68ec0830ab24fde651af5d85e19dddfe',
-
         indexName: 'vestjs',
       },
     }),
 };
 
-module.exports = config;
+export default config;
 
 function badgeLink(url, badge, name) {
   return `<a href="${url}" class="header-badge" target="_blank">

--- a/website/src/components/HomepageFeatures.js
+++ b/website/src/components/HomepageFeatures.js
@@ -1,101 +1,76 @@
 import clsx from 'clsx';
 import React from 'react';
-import commonStyles from './Common.module.css';
+
 import styles from './HomepageFeatures.module.css';
 
 const FeatureList = [
   {
     title: 'Easy to learn',
     emoji: '💡',
-    description: (
-      <>
-        Vest adopts the syntax and style of unit testing frameworks, so you can
-        leverage the knowledge you already have to write your form validations.
-      </>
-    ),
+    description:
+      'Vest mirrors the syntax of unit testing frameworks, so you write validations with familiar describe/test ergonomics.',
   },
   {
-    title: 'Framework Agnostic',
+    title: 'Framework agnostic',
     emoji: '🎨',
-    description: (
-      <>
-        Bring your own UI. Vest is framework agnostic, so you can use it with
-        any UI framework you have.
-      </>
-    ),
+    description:
+      'Use Vest with any UI stack you like. It stays focused on validation logic while you bring your own components.',
   },
   {
-    title: 'Really smart',
+    title: 'Smart runtime',
     emoji: '🧠',
-    description: (
-      <>
-        Vest takes care of all the annoying parts for you. It manages its own
-        state, handles async validations and much more.
-      </>
-    ),
+    description:
+      'Async handling, state management, and dependency-aware reruns are built in so validations stay fast and predictable.',
   },
   {
-    title: 'Extendable',
+    title: 'Extensible',
     emoji: '🧩',
-    description: (
-      <>
-        You can easily add new custom types of validations to Vest according to
-        your needs.
-      </>
-    ),
+    description:
+      'Craft custom validation types and behaviors that fit your domain without fighting the framework.',
   },
   {
     title: 'Reusable',
     emoji: '♻️',
-    description: (
-      <>
-        Validation logic in Vest can be shared across multiple features in your
-        app.
-      </>
-    ),
+    description: 'Share validation logic across forms and features to keep your UX consistent and maintainable.',
   },
   {
-    title: 'Tiny',
+    title: 'Tiny footprint',
     emoji: '🐜',
-    description: (
-      <>
-        Packed with features, but optimized for size. Vest brings no
-        dependencies, and only takes a few KBs.
-      </>
-    ),
+    description: 'Zero dependencies and a few kilobytes of code keep bundles lean and pages speedy.',
   },
 ];
 
 function Feature({ emoji, title, description }) {
   return (
-    <div className={clsx('col col--4')}>
-      <div className={styles.featureCard}>
-        <div className="text--center">
-          <span className={styles.emoji}>{emoji}</span>
-        </div>
-        <div className="text--center padding-horiz--md">
-          <h3 className={styles.featureTitle}>{title}</h3>
-          <p className={styles.featureDescription}>{description}</p>
-        </div>
+    <div className={styles.featureCard}>
+      <div className={styles.cardTop}>
+        <span className={styles.emoji}>{emoji}</span>
+        <h3 className={styles.featureTitle}>{title}</h3>
       </div>
+      <p className={styles.featureDescription}>{description}</p>
     </div>
   );
 }
 
 export default function HomepageFeatures() {
   return (
-    <>
-      <section
-        className={clsx(styles.features, commonStyles.main_section_centered)}
-      >
-        <div className="container">
-          <div className="row">
-            {FeatureList.map((props, idx) => (
-              <Feature key={idx} {...props} />
-            ))}
-          </div>
+    <section className={styles.features}>
+      <div className="container">
+        <div className={styles.featuresHeader}>
+          <p className={styles.kicker}>Why Vest</p>
+          <h2 className={styles.sectionTitle}>Validation that feels like testing</h2>
+          <p className={styles.sectionLead}>
+            Design suites the way you design specs: readable, declarative, and ready to ship across any frontend stack.
+          </p>
         </div>
-      </section>
-    </>
+        <div className={clsx('row', styles.grid)}>
+          {FeatureList.map((props, idx) => (
+            <div key={idx} className={clsx('col col--4', styles.gridItem)}>
+              <Feature {...props} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }

--- a/website/src/components/HomepageFeatures.module.css
+++ b/website/src/components/HomepageFeatures.module.css
@@ -1,62 +1,122 @@
 .features {
+  padding: 4rem 0 5rem;
+}
+
+.featuresHeader {
+  text-align: center;
+  max-width: 760px;
+  margin: 0 auto 2.5rem;
+}
+
+.kicker {
+  display: inline-flex;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  margin-bottom: 0.75rem;
+}
+
+.sectionTitle {
+  font-size: clamp(2rem, 3vw, 2.5rem);
+  margin-bottom: 0.75rem;
+}
+
+.sectionLead {
+  color: var(--ifm-color-emphasis-700);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+html[data-theme='dark'] .sectionLead {
+  color: var(--ifm-color-primary-lightest);
+  opacity: 0.9;
+}
+
+.grid {
+  row-gap: 1.5rem;
+}
+
+.gridItem {
   display: flex;
-  align-items: center;
-  padding: 6rem 0;
-  width: 100%;
 }
 
 .featureCard {
-  height: 100%;
-  padding: 2rem;
-  border-radius: 24px;
-  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
-  background: transparent;
-  border: 1px solid transparent;
-  margin-bottom: 2rem; /* Add vertical gap */
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: 16px;
+  padding: 1.5rem;
+  width: 100%;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+  position: relative;
+  overflow: hidden;
+}
+
+html[data-theme='dark'] .featureCard {
+  background: rgba(15, 23, 42, 0.7);
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+}
+
+.featureCard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(99, 102, 241, 0.12), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
 }
 
 .featureCard:hover {
-  background: rgba(255, 255, 255, 0.5);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.05);
-  backdrop-filter: blur(4px);
+  transform: translateY(-6px);
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 25px 60px rgba(99, 102, 241, 0.15);
 }
 
-html[data-theme='dark'] .featureCard:hover {
-  background: rgba(255, 255, 255, 0.05);
+.featureCard:hover::before {
+  opacity: 1;
+}
+
+.cardTop {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin-bottom: 0.75rem;
 }
 
 .emoji {
-  font-size: 3rem;
-  margin-bottom: 1.5rem;
-  display: flex;
+  font-size: 1.8rem;
+  width: 48px;
+  height: 48px;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 80px;
-  height: 80px;
-  border-radius: 24px;
-  background: var(--ifm-color-emphasis-100); /* Simple background */
-  margin-left: auto;
-  margin-right: auto;
-  transition: transform 0.3s ease;
+  border-radius: 14px;
+  background: rgba(99, 102, 241, 0.1);
 }
 
 .featureTitle {
-  font-size: 1.5rem;
+  margin: 0;
+  font-size: 1.3rem;
   font-weight: 800;
-  margin-bottom: 1rem;
-  background: linear-gradient(
-    90deg,
-    var(--ifm-color-primary) 0%,
-    var(--ifm-color-primary-dark) 100%
-  );
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
 }
 
 .featureDescription {
-  color: var(--ifm-color-emphasis-600);
-  line-height: 1.8;
-  font-size: 1.1rem;
-  font-weight: 500;
+  color: var(--ifm-color-emphasis-700);
+  line-height: 1.6;
+  margin: 0;
+}
+
+html[data-theme='dark'] .featureDescription {
+  color: var(--ifm-color-primary-lightest);
+  opacity: 0.92;
+}
+
+@media screen and (max-width: 996px) {
+  .gridItem {
+    width: 100%;
+  }
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,86 +1,72 @@
-@import url('https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
-/**
- * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
- */
-
-/* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary-lightest: #fdfdfd;
-  --ifm-color-primary-lighter: #4b6889;
-  --ifm-color-primary-light: #486383;
-  --ifm-color-primary: #697098;
-  --ifm-color-primary-dark: #3b516b;
-  --ifm-color-primary-darker: #374d65;
-  --ifm-color-primary-darkest: #212432;
-  --ifm-font-family-base: 'Rubik', sans-serif;
+  --ifm-font-family-base: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --ifm-font-family-monospace: 'JetBrains Mono', SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
   --ifm-code-font-size: 95%;
   --ifm-heading-color: var(--ifm-font-color-base);
+  --ifm-border-radius-base: 12px;
+  --ifm-color-primary: #6366f1;
+  --ifm-color-primary-dark: #4f46e5;
+  --ifm-color-primary-darker: #4338ca;
+  --ifm-color-primary-darkest: #3730a3;
+  --ifm-color-primary-light: #818cf8;
+  --ifm-color-primary-lighter: #a5b4fc;
+  --ifm-color-primary-lightest: #c7d2fe;
+  --ifm-background-color: #ffffff;
+  --ifm-navbar-background-color: rgba(255, 255, 255, 0.85);
+  --ifm-navbar-shadow: none;
+  --docusaurus-highlighted-code-line-bg: rgba(99, 102, 241, 0.08);
   --main-content-background-color: none;
-  --darkest-alt: #171819;
-  --announcement-bar-background: var(--ifm-color-primary-lightest);
-  --announcement-bar-color: var(--darkest-alt);
+  --announcement-bar-background: rgba(99, 102, 241, 0.08);
+  --announcement-bar-color: #0f172a;
 }
 
 html[data-theme='dark'] {
-  --ifm-background-color: var(--darkest-alt);
-  --announcement-bar-background: var(--ifm-color-primary-light);
-  --announcement-bar-color: var(--ifm-color-primary-lightest);
+  --ifm-background-color: #0f172a;
+  --ifm-navbar-background-color: rgba(15, 23, 42, 0.75);
+  --ifm-color-primary: #818cf8;
+  --ifm-color-primary-dark: #6366f1;
+  --ifm-color-primary-darker: #4f46e5;
+  --ifm-color-primary-darkest: #4338ca;
+  --ifm-color-primary-light: #a5b4fc;
+  --ifm-color-primary-lighter: #c7d2fe;
+  --ifm-color-primary-lightest: #e0e7ff;
+  --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.06);
+  --announcement-bar-background: rgba(99, 102, 241, 0.12);
+  --announcement-bar-color: #e0e7ff;
 }
 
 main {
   background-color: var(--main-content-background-color);
 }
 
-.aa-DetachedSearchButton {
-  color: blue;
+.navbar {
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
 }
 
-h1 {
-  padding-bottom: 1rem;
+html[data-theme='dark'] .navbar {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: var(--docusaurus-highlighted-code-line-bg);
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
 
 .footer {
-  background-color: #272a36;
+  background-color: #0b1220;
 }
 
-html[data-theme='dark'] .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.3);
+html[data-theme='dark'] .footer {
+  background-color: #0b1220;
 }
 
-html[data-theme='dark'] .navbar {
-  background-color: var(--ifm-background-color);
-  border-bottom: 1px solid var(--ifm-color-primary-darker);
-}
-
-html[data-theme='light'] .hero__primary.hero {
-  background-color: var(--ifm-color-primary-lightest);
-  color: var(--ifm-color-primary-darkest);
-}
-
-html[data-theme='dark'] .hero__primary.hero {
-  background-color: var(--ifm-background-color);
-  color: var(--ifm-color-primary-darkest);
-}
-
-html[data-theme='dark'] .hero__title {
-  color: var(--ifm-color-primary-lightest);
-}
-
-.hero__title {
-  text-transform: uppercase;
-  color: var(--ifm-heading-color);
-}
-
+.hero__title,
 .hero__subtitle {
   color: var(--ifm-heading-color);
 }

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -4,8 +4,6 @@ import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import React from 'react';
 
-import GithubLogo from '../../static/img/github.svg';
-import LogoSvg from '../../static/img/logo.svg';
 import Demo from '../components/Demo';
 import HomepageFeatures from '../components/HomepageFeatures';
 import RawExample from '../components/RawExample';
@@ -14,39 +12,77 @@ import styles from './index.module.css';
 
 function HomepageHeader() {
   const { siteConfig } = useDocusaurusContext();
+  const [copied, setCopied] = React.useState(false);
+  const installCommand = 'npm i vest';
+
+  const handleCopy = () => {
+    if (typeof navigator === 'undefined' || !navigator?.clipboard?.writeText) {
+      return;
+    }
+
+    navigator.clipboard
+      .writeText(installCommand)
+      .then(() => setCopied(true))
+      .catch(() => setCopied(true));
+
+    setTimeout(() => setCopied(false), 1400);
+  };
+
   return (
     <header className={clsx('hero', styles.heroBanner)}>
-      <div className={styles.logoContainer}>
-        <LogoSvg className={styles.vestLogo} />
-      </div>
-      <div className={styles.titleContainer}>
-        <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className={clsx('hero__subtitle', styles.heroTagline)}>
-          {siteConfig.tagline}
-        </p>
-      </div>
-      <div className={styles.buttons}>
-        <Link
-          className={clsx('button', styles.btn, styles.btnQuickStart)}
-          to="/docs/get_started"
-        >
-          Quick Start Guide
-        </Link>
-        <Link
-          className={clsx('button', styles.btn, styles.btnGit)}
-          to="https://github.com/ealush/vest"
-        >
-          <GithubLogo
-            style={{ height: '22px', marginRight: '0.5rem', float: 'left' }}
-          />
-          Github
-        </Link>
-        <Link
-          className={clsx('button', styles.btn, styles.btnGit)}
-          to="/vest-6-is-ready"
-        >
-          Try V6 instead
-        </Link>
+      <div className={styles.heroGlow} />
+      <div className={styles.heroMesh} />
+      <div className="container">
+        <div className={styles.heroContent}>
+          <div>
+            <p className={styles.kicker}>Modern validations for modern apps</p>
+            <h1 className={styles.heroTitle}>
+              Declarative validations
+              <br />
+              <span className={styles.heroHighlight}>inspired by unit testing</span>
+            </h1>
+            <p className={clsx('hero__subtitle', styles.heroSubtitle)}>
+              {siteConfig.tagline}
+            </p>
+            <div className={styles.actionRow}>
+              <Link className={clsx('button button--primary', styles.primaryButton)} to="/docs/get_started">
+                Get started
+              </Link>
+              <Link className={clsx('button button--secondary', styles.secondaryButton)} to="https://github.com/ealush/vest">
+                View on GitHub
+              </Link>
+            </div>
+            <div className={styles.installCard}>
+              <div className={styles.installLabel}>Install with npm</div>
+              <div className={styles.installRow}>
+                <code className={styles.installCommand}>{installCommand}</code>
+                <button type="button" className={styles.copyButton} onClick={handleCopy}>
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className={styles.heroVisual}>
+            <div className={styles.codeCard}>
+              <div className={styles.codeHeader}>
+                <span className={styles.dot} />
+                <span className={styles.dot} />
+                <span className={styles.dot} />
+              </div>
+              <pre className={styles.codeSnippet}>
+                <code>
+                  {`import vest, { test, enforce } from 'vest';
+
+const suite = vest.create('signup', () => {
+  test('password', 'Must be strong', () => {
+    enforce(password).longerThanOrEquals(8);
+  });
+});`}
+                </code>
+              </pre>
+            </div>
+          </div>
+        </div>
       </div>
     </header>
   );

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -1,131 +1,237 @@
-/**
- * CSS files with the .module.css suffix will be treated as CSS modules
- * and scoped locally.
- */
-
 .heroBanner {
-  text-align: center;
   position: relative;
   overflow: hidden;
-  padding: 4rem 2rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background: linear-gradient(
-    180deg,
-    var(--ifm-color-primary-lightest) 0%,
-    #ffffff 100%
-  );
+  padding: 5rem 1.5rem 4rem;
+  background: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.14), transparent 30%),
+    radial-gradient(circle at 80% 10%, rgba(59, 130, 246, 0.12), transparent 28%),
+    linear-gradient(180deg, #f8fafc 0%, #ffffff 60%);
 }
 
 html[data-theme='dark'] .heroBanner {
-  background: linear-gradient(180deg, #1b1b1d 0%, #000000 100%);
+  background: radial-gradient(circle at 20% 20%, rgba(129, 140, 248, 0.2), transparent 30%),
+    radial-gradient(circle at 80% 10%, rgba(56, 189, 248, 0.12), transparent 32%),
+    linear-gradient(180deg, #0f172a 0%, #0b1220 70%);
 }
 
-.logoContainer {
-  margin-bottom: 2rem;
+.heroGlow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 20%, rgba(99, 102, 241, 0.16), transparent 35%),
+    radial-gradient(circle at 80% 60%, rgba(56, 189, 248, 0.1), transparent 30%);
+  filter: blur(40px);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.heroMesh {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.08) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(255, 255, 255, 0.08) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(255, 255, 255, 0.05) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(255, 255, 255, 0.05) 75%);
+  background-size: 30px 30px;
+  background-position: 0 0, 0 15px, 15px -15px, -15px 0px;
+  opacity: 0.2;
+  pointer-events: none;
+}
+
+.heroContent {
   position: relative;
-  z-index: 10;
-}
-
-.vestLogo {
-  width: 150px;
-  height: 150px;
-  filter: drop-shadow(0 10px 20px rgba(0, 0, 0, 0.15));
-}
-
-.titleContainer {
-  max-width: 800px;
-  margin: 0 auto 2rem;
-}
-
-.heroTagline {
-  font-size: 1.5rem;
-  line-height: 1.5;
-  color: var(--ifm-color-emphasis-700);
-  margin-top: 1rem;
-  font-weight: 400;
-}
-
-.buttons {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 3rem;
   align-items: center;
-  justify-content: center;
-  gap: 1.5rem;
-  margin-top: 2rem;
 }
 
-.btn {
+.kicker {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  font-weight: 700;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--ifm-color-primary);
+  font-weight: 600;
+  width: fit-content;
+  margin-bottom: 1rem;
+}
+
+.heroTitle {
+  font-size: clamp(2.4rem, 4vw, 3rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin-bottom: 1rem;
+}
+
+.heroHighlight {
+  color: var(--ifm-color-primary);
+  text-shadow: 0 10px 40px rgba(99, 102, 241, 0.3);
+}
+
+.heroSubtitle {
+  max-width: 620px;
+  color: var(--ifm-color-emphasis-700);
   font-size: 1.1rem;
-  padding: 0.8rem 2rem;
-  border-radius: 50px;
-  transition: all 0.2s ease;
-  text-decoration: none !important;
-  box-shadow: 0 4px 14px 0 rgba(0, 0, 0, 0.1);
+  line-height: 1.6;
+  margin-bottom: 2rem;
 }
 
-.btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+html[data-theme='dark'] .heroSubtitle {
+  color: var(--ifm-color-primary-lightest);
+  opacity: 0.92;
 }
 
-.btnQuickStart {
-  background-color: var(--ifm-color-primary);
-  color: #fff;
-  border: 2px solid var(--ifm-color-primary);
+.actionRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 
-.btnQuickStart:hover {
-  background-color: var(--ifm-color-primary-dark);
-  border-color: var(--ifm-color-primary-dark);
-  color: #fff;
+.primaryButton,
+.secondaryButton {
+  border-radius: 999px;
+  padding: 0.9rem 1.4rem;
+  font-weight: 700;
+  font-size: 1rem;
+  box-shadow: 0 10px 30px rgba(99, 102, 241, 0.2);
 }
 
-.btnGit {
-  background-color: var(--ifm-color-emphasis-200);
+.secondaryButton {
+  background: transparent;
+  color: var(--ifm-color-primary);
+  border: 1px solid var(--ifm-color-primary);
+  box-shadow: none;
+}
+
+.installCard {
+  margin-top: 1.5rem;
+  padding: 1.2rem 1.5rem;
+  border-radius: 16px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  max-width: 520px;
+}
+
+html[data-theme='dark'] .installCard {
+  background: rgba(15, 23, 42, 0.7);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.installLabel {
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+  margin-bottom: 0.45rem;
+}
+
+.installRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.installCommand {
+  font-family: var(--ifm-font-family-monospace);
+  background: rgba(99, 102, 241, 0.08);
+  padding: 0.65rem 0.9rem;
+  border-radius: 10px;
+  color: var(--ifm-color-primary-dark);
+  flex: 1;
+  font-size: 0.95rem;
+}
+
+html[data-theme='dark'] .installCommand {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--ifm-color-primary-lightest);
+}
+
+.copyButton {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  padding: 0.65rem 1rem;
+  background: var(--ifm-background-color);
   color: var(--ifm-color-emphasis-900);
-  border: 2px solid transparent;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.btnGit:hover {
-  background-color: var(--ifm-color-emphasis-300);
-  border-color: transparent;
+.copyButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(99, 102, 241, 0.18);
+}
+
+.heroVisual {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+
+.codeCard {
+  width: 100%;
+  max-width: 520px;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.8), rgba(99, 102, 241, 0.05));
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.15);
+}
+
+html[data-theme='dark'] .codeCard {
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.7), rgba(99, 102, 241, 0.08));
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+.codeHeader {
+  display: flex;
+  gap: 0.45rem;
+  padding: 0.9rem 1rem;
+  background: rgba(15, 23, 42, 0.9);
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.codeSnippet {
+  margin: 0;
+  padding: 1.25rem 1.5rem 1.5rem;
+  background: transparent;
   color: var(--ifm-color-emphasis-900);
+  font-family: var(--ifm-font-family-monospace);
+  white-space: pre-wrap;
+  line-height: 1.6;
 }
 
-html[data-theme='dark'] .btnGit {
-  background-color: rgba(255, 255, 255, 0.1);
-  color: #fff;
-}
-
-html[data-theme='dark'] .btnGit:hover {
-  background-color: rgba(255, 255, 255, 0.2);
-}
-
-.btnPromote {
-  display: none; /* Hiding promote button for cleaner look, or we can restyle it */
+html[data-theme='dark'] .codeSnippet {
+  color: var(--ifm-color-primary-lightest);
 }
 
 @media screen and (max-width: 768px) {
   .heroBanner {
-    padding: 3rem 1rem;
+    padding: 4rem 1.25rem 3rem;
   }
 
-  .heroTagline {
-    font-size: 1.2rem;
+  .actionRow {
+    width: 100%;
   }
 
-  .buttons {
+  .installRow {
     flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .installCommand {
     width: 100%;
   }
 
-  .btn {
+  .copyButton {
     width: 100%;
-    max-width: 300px;
   }
 }


### PR DESCRIPTION
## Summary
- apply new typography, color palette, and glass navbar styling for the docs site
- redesign the homepage hero with modern CTAs, install snippet, and highlighted code card
- refresh feature grid into bento-style cards with updated copy and hover treatments

## Testing
- yarn website:build *(fails: yarn not found in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69341814a13c83309768718801e4be34)