### PR TITLE
Rebuild Vest Devtools panel with React and add page-script unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ packages/*/*
 !packages/*/vitest.config.ts
 !packages/*/bench
 !packages/*/docs
+!packages/vest-devtools-extension/*
+!packages/vest-devtools-extension/**
 .env
 
 playground.*

--- a/packages/vest-devtools-extension/README.md
+++ b/packages/vest-devtools-extension/README.md
@@ -1,0 +1,37 @@
+# Vest Devtools Chrome Extension
+
+This package provides a manifest v3 Chrome extension for inspecting Vest suite
+activity in an event-based log, similar to Redux DevTools. The panel UI is built
+with React 19, Zustand, TanStack Query, and Emotion.
+
+## Load the extension
+
+1. Build or clone this repo.
+2. Run `yarn workspace vest-devtools-extension build`.
+3. Open **chrome://extensions**.
+4. Enable **Developer mode**.
+5. Click **Load unpacked** and select `packages/vest-devtools-extension/dist`.
+
+## Register a suite
+
+The extension listens for registered suites and uses `suite.subscribe` for
+events plus `suite.get()` for state snapshots.
+
+```ts
+import vest from 'vest';
+
+const suite = vest.create((data) => {
+  // validations...
+});
+
+if (window.__VEST_DEVTOOLS__) {
+  window.__VEST_DEVTOOLS__.registerSuite(suite, { name: 'signup' });
+}
+```
+
+## What you’ll see
+
+- Event log (one row per Vest event).
+- Suite summary (validity, counts).
+- Field status (passing, failing, pending, warning, idle).
+- Last input parameters used to run the suite.

--- a/packages/vest-devtools-extension/__tests__/page-script.test.ts
+++ b/packages/vest-devtools-extension/__tests__/page-script.test.ts
@@ -1,0 +1,157 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import { create, enforce, test } from '../../vest/src/vest';
+
+type PostedMessage = {
+  source: string;
+  type: string;
+  payload: any;
+};
+
+type MockWindow = {
+  postMessage: (data: PostedMessage) => void;
+  addEventListener: (
+    type: string,
+    handler: (event: { source: MockWindow; data: any }) => void,
+  ) => void;
+  __VEST_DEVTOOLS__?: { registerSuite: (suite: any, opts?: any) => void };
+};
+
+const PAGE_SCRIPT_PATH = path.resolve(
+  __dirname,
+  '..',
+  'public',
+  'page-script.js',
+);
+
+describe('vest devtools page script', () => {
+  afterEach(() => {
+    // @ts-expect-error clearing global mock
+    delete globalThis.window;
+  });
+
+  it('registers suite and emits state snapshots with focus tags', () => {
+    const { window, messages } = setupWindow();
+    loadPageScript(window);
+
+    const callbacks = new Map();
+    const suite = {
+      subscribe: (event: string, cb: () => void) => {
+        callbacks.set(event, cb);
+        return () => undefined;
+      },
+      get: () => ({
+        valid: false,
+        errorCount: 1,
+        warnCount: 1,
+        pendingCount: 0,
+        testCount: 2,
+        tests: {
+          username: {
+            valid: false,
+            errorCount: 1,
+            warnCount: 0,
+            pendingCount: 0,
+            testCount: 1,
+            errors: ['Required'],
+            warnings: [],
+          },
+          email: {
+            valid: true,
+            errorCount: 0,
+            warnCount: 1,
+            pendingCount: 0,
+            testCount: 1,
+            errors: [],
+            warnings: ['Suspicious domain'],
+          },
+        },
+      }),
+      dump: () => ({
+        $type: 'Focused',
+        data: {
+          focusMode: 0,
+          matchAll: false,
+          match: ['username'],
+        },
+        children: [],
+      }),
+    };
+
+    window.__VEST_DEVTOOLS__?.registerSuite(suite, {
+      id: 'suite-1',
+      name: 'signup',
+    });
+
+    expect(messages[0].payload.eventName).toBe('SUITE_REGISTERED');
+    expect(messages[0].payload.state.focus).toEqual({
+      mode: 'only',
+      matchAll: false,
+      match: ['username'],
+    });
+
+    const callback = callbacks.get('TEST_COMPLETED') as () => void;
+    callback();
+
+    const eventMessage = messages.find(
+      msg => msg.payload.eventName === 'TEST_COMPLETED',
+    );
+    expect(eventMessage).toBeTruthy();
+    expect(eventMessage.payload.state.fields[0].status).toBe('failing');
+    expect(eventMessage.payload.state.fields[1].status).toBe('warning');
+  });
+
+  it('runs a real vest suite when receiving RUN_SUITE commands', () => {
+    const { window, handlers, messages } = setupWindow();
+    loadPageScript(window);
+
+    const suite = create((data: { username?: string }) => {
+      test('username', 'required', () => {
+        enforce(data.username).isNotBlank();
+      });
+    });
+
+    window.__VEST_DEVTOOLS__?.registerSuite(suite, {
+      id: 'suite-run',
+      name: 'signup',
+    });
+
+    const handler = handlers[0];
+    handler({
+      source: window,
+      data: {
+        source: 'vest-devtools-command',
+        type: 'RUN_SUITE',
+        suiteId: 'suite-run',
+        input: { username: '' },
+      },
+    });
+
+    const eventNames = messages.map(msg => msg.payload.eventName);
+    expect(eventNames).toContain('SUITE_RUN_STARTED');
+  });
+});
+
+function loadPageScript(window: MockWindow) {
+  const script = readFileSync(PAGE_SCRIPT_PATH, 'utf8');
+  const runner = new Function('window', script);
+  runner(window);
+}
+
+function setupWindow() {
+  const messages: PostedMessage[] = [];
+  const handlers: Array<(event: { source: MockWindow; data: any }) => void> = [];
+  const window: MockWindow = {
+    postMessage: data => messages.push(data),
+    addEventListener: (type, handler) => {
+      if (type === 'message') {
+        handlers.push(handler);
+      }
+    },
+  };
+
+  globalThis.window = window as any;
+
+  return { window, messages, handlers };
+}

--- a/packages/vest-devtools-extension/package.json
+++ b/packages/vest-devtools-extension/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "vest-devtools-extension",
+  "private": true,
+  "version": "0.2.0",
+  "description": "Chrome extension for inspecting Vest suite activity.",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@tanstack/react-query": "^5.83.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "zustand": "^5.0.6"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.0.268",
+    "@vitejs/plugin-react": "^4.7.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/packages/vest-devtools-extension/public/background.js
+++ b/packages/vest-devtools-extension/public/background.js
@@ -1,0 +1,57 @@
+const devtoolsPorts = new Map();
+const contentPorts = new Map();
+
+chrome.runtime.onConnect.addListener(port => {
+  if (port.name === 'devtools') {
+    let tabId = null;
+
+    port.onMessage.addListener(message => {
+      if (message?.type === 'init') {
+        tabId = message.tabId;
+        devtoolsPorts.set(tabId, port);
+
+        const contentPort = contentPorts.get(tabId);
+        if (contentPort) {
+          contentPort.postMessage({ type: 'devtools-attached' });
+        }
+        return;
+      }
+
+      if (message?.type === 'command' && tabId !== null) {
+        const contentPort = contentPorts.get(tabId);
+        if (contentPort) {
+          contentPort.postMessage(message);
+        }
+      }
+    });
+
+    port.onDisconnect.addListener(() => {
+      if (tabId !== null) {
+        devtoolsPorts.delete(tabId);
+      }
+    });
+
+    return;
+  }
+
+  if (port.name === 'content') {
+    const tabId = port.sender?.tab?.id;
+
+    if (tabId == null) {
+      return;
+    }
+
+    contentPorts.set(tabId, port);
+
+    port.onMessage.addListener(message => {
+      const devtoolsPort = devtoolsPorts.get(tabId);
+      if (devtoolsPort) {
+        devtoolsPort.postMessage(message);
+      }
+    });
+
+    port.onDisconnect.addListener(() => {
+      contentPorts.delete(tabId);
+    });
+  }
+});

--- a/packages/vest-devtools-extension/public/content-script.js
+++ b/packages/vest-devtools-extension/public/content-script.js
@@ -1,0 +1,45 @@
+const port = chrome.runtime.connect({ name: 'content' });
+
+function injectScript() {
+  if (document.querySelector('script[data-vest-devtools]')) {
+    return;
+  }
+
+  const script = document.createElement('script');
+  script.src = chrome.runtime.getURL('page-script.js');
+  script.dataset.vestDevtools = 'true';
+  script.onload = () => {
+    script.remove();
+  };
+
+  (document.head || document.documentElement).appendChild(script);
+}
+
+injectScript();
+
+window.addEventListener('message', event => {
+  if (event.source !== window) {
+    return;
+  }
+
+  const data = event.data;
+  if (!data || data.source !== 'vest-devtools') {
+    return;
+  }
+
+port.postMessage(data);
+});
+
+port.onMessage.addListener(message => {
+  if (message?.type !== 'command') {
+    return;
+  }
+
+  window.postMessage(
+    {
+      source: 'vest-devtools-command',
+      ...message.payload,
+    },
+    '*',
+  );
+});

--- a/packages/vest-devtools-extension/public/devtools.html
+++ b/packages/vest-devtools-extension/public/devtools.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Vest Devtools</title>
+  </head>
+  <body>
+    <script src="devtools.js"></script>
+  </body>
+</html>

--- a/packages/vest-devtools-extension/public/devtools.js
+++ b/packages/vest-devtools-extension/public/devtools.js
@@ -1,0 +1,6 @@
+chrome.devtools.panels.create(
+  'Vest',
+  '',
+  'panel.html',
+  () => undefined,
+);

--- a/packages/vest-devtools-extension/public/manifest.json
+++ b/packages/vest-devtools-extension/public/manifest.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 3,
+  "name": "Vest Devtools",
+  "description": "Event-based Vest validation inspector inspired by Redux DevTools.",
+  "version": "0.2.0",
+  "permissions": ["scripting", "tabs"],
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "devtools_page": "devtools.html",
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-script.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["page-script.js"],
+      "matches": ["<all_urls>"]
+    }
+  ]
+}

--- a/packages/vest-devtools-extension/public/page-script.js
+++ b/packages/vest-devtools-extension/public/page-script.js
@@ -1,0 +1,296 @@
+(() => {
+  const HOOK_KEY = '__VEST_DEVTOOLS__';
+
+  if (window[HOOK_KEY]) {
+    return;
+  }
+
+  const eventNames = [
+    'TEST_RUN_STARTED',
+    'TEST_COMPLETED',
+    'ALL_RUNNING_TESTS_FINISHED',
+    'REMOVE_FIELD',
+    'RESET_FIELD',
+    'RESET_SUITE',
+    'SUITE_RUN_STARTED',
+    'SUITE_CALLBACK_RUN_FINISHED',
+    'DONE_TEST_OMISSION_PASS',
+    'INITIALIZING_CALLBACKS',
+    'DEFER_THROW',
+    'ASYNC_ISOLATE_DONE',
+    'ISOLATE_DONE',
+    'ISOLATE_ENTER',
+    'ISOLATE_PENDING',
+    'ISOLATE_RECONCILED',
+  ];
+
+  const registeredSuites = new Map();
+
+  function registerSuite(suite, options = {}) {
+    if (!suite || typeof suite.subscribe !== 'function') {
+      return;
+    }
+
+    const suiteId =
+      options.id ||
+      `suite-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+    const suiteName = options.name || suiteId;
+
+    if (registeredSuites.has(suiteId)) {
+      return;
+    }
+
+    const suiteData = {
+      id: suiteId,
+      name: suiteName,
+      suite,
+      lastRunArgs: [],
+      lastRunMethod: 'run',
+    };
+
+    registeredSuites.set(suiteId, suiteData);
+    wrapSuiteMethods(suiteData);
+
+    eventNames.forEach(eventName => {
+      suite.subscribe(eventName, payload => {
+        emitEvent({
+          suiteId,
+          suiteName,
+          eventName,
+          payload,
+          lastRunArgs: suiteData.lastRunArgs,
+          state: serializeState(suite),
+        });
+      });
+    });
+
+    emitEvent({
+      suiteId,
+      suiteName,
+      eventName: 'SUITE_REGISTERED',
+      payload: null,
+      lastRunArgs: suiteData.lastRunArgs,
+      state: serializeState(suite),
+    });
+  }
+
+  function wrapSuiteMethods(suiteData) {
+    ['run', 'runStatic', 'validate'].forEach(methodName => {
+      const method = suiteData.suite[methodName];
+      if (typeof method !== 'function' || method.__vestDevtoolsWrapped) {
+        return;
+      }
+
+      const wrapped = function (...args) {
+        suiteData.lastRunArgs = toSerializable(args);
+        suiteData.lastRunMethod = methodName;
+        return method.apply(this, args);
+      };
+
+      wrapped.__vestDevtoolsWrapped = true;
+      suiteData.suite[methodName] = wrapped;
+    });
+  }
+
+  function serializeState(suite) {
+    const result = suite.get();
+    const focus = getFocusState(suite);
+    const tests = result.tests || {};
+    const fields = Object.keys(tests).map(name => {
+      const summary = tests[name] || {};
+
+      return {
+        name,
+        status: resolveStatus(summary),
+        errorCount: summary.errorCount ?? 0,
+        warnCount: summary.warnCount ?? 0,
+        pendingCount: summary.pendingCount ?? 0,
+        testCount: summary.testCount ?? 0,
+        errors: toSerializable(summary.errors ?? []),
+        warnings: toSerializable(summary.warnings ?? []),
+        valid: summary.valid ?? null,
+      };
+    });
+
+    return {
+      valid: result.valid ?? null,
+      errorCount: result.errorCount ?? 0,
+      warnCount: result.warnCount ?? 0,
+      pendingCount: result.pendingCount ?? 0,
+      testCount: result.testCount ?? 0,
+      fields,
+      focus,
+    };
+  }
+
+  function resolveStatus(summary) {
+    if ((summary.pendingCount ?? 0) > 0) {
+      return 'pending';
+    }
+
+    if (summary.valid === false || (summary.errorCount ?? 0) > 0) {
+      return 'failing';
+    }
+
+    if ((summary.warnCount ?? 0) > 0) {
+      return 'warning';
+    }
+
+    if (summary.valid === true) {
+      return 'passing';
+    }
+
+    return 'idle';
+  }
+
+  function getFocusState(suite) {
+    try {
+      const root = suite.dump();
+      const focusIsolate = findIsolate(
+        root,
+        isolate => isolate?.$type === 'Focused',
+      );
+      if (!focusIsolate) {
+        return { mode: null, matchAll: false, match: [] };
+      }
+      const focusMode = focusIsolate.data?.focusMode;
+      const matchAll = Boolean(focusIsolate.data?.matchAll);
+      const match = Array.isArray(focusIsolate.data?.match)
+        ? focusIsolate.data?.match
+        : [];
+
+      return {
+        mode: focusMode === 0 ? 'only' : focusMode === 1 ? 'skip' : null,
+        matchAll,
+        match,
+      };
+    } catch (error) {
+      return { mode: null, matchAll: false, match: [] };
+    }
+  }
+
+  function findIsolate(root, predicate) {
+    if (!root) {
+      return null;
+    }
+
+    const queue = [root];
+
+    while (queue.length) {
+      const current = queue.shift();
+      if (predicate(current)) {
+        return current;
+      }
+      if (Array.isArray(current.children)) {
+        queue.push(...current.children);
+      }
+    }
+
+    return null;
+  }
+
+  function emitEvent({
+    suiteId,
+    suiteName,
+    eventName,
+    payload,
+    lastRunArgs,
+    state,
+  }) {
+    window.postMessage(
+      {
+        source: 'vest-devtools',
+        type: 'event',
+        payload: {
+          suiteId,
+          suiteName,
+          eventName,
+          timestamp: Date.now(),
+          payload: toSerializable(payload),
+          lastRunArgs,
+          state,
+        },
+      },
+      '*',
+    );
+  }
+
+  function toSerializable(value) {
+    const seen = new WeakSet();
+
+    try {
+      return JSON.parse(
+        JSON.stringify(value, (_key, val) => {
+          if (typeof val === 'function') {
+            return '[Function]';
+          }
+          if (typeof val === 'symbol') {
+            return val.toString();
+          }
+          if (typeof val === 'bigint') {
+            return val.toString();
+          }
+          if (val instanceof Error) {
+            return {
+              name: val.name,
+              message: val.message,
+              stack: val.stack,
+            };
+          }
+          if (typeof val === 'undefined') {
+            return '[Undefined]';
+          }
+          if (val && typeof val === 'object') {
+            if (seen.has(val)) {
+              return '[Circular]';
+            }
+            seen.add(val);
+          }
+          return val;
+        }),
+      );
+    } catch (error) {
+      return String(value);
+    }
+  }
+
+  window[HOOK_KEY] = {
+    registerSuite,
+  };
+
+  window.addEventListener('message', event => {
+    if (event.source !== window) {
+      return;
+    }
+
+    const data = event.data;
+    if (!data || data.source !== 'vest-devtools-command') {
+      return;
+    }
+
+    if (data.type === 'RUN_SUITE') {
+      const suiteData = registeredSuites.get(data.suiteId);
+      if (!suiteData) {
+        return;
+      }
+
+      const mode = data.mode ?? suiteData.lastRunMethod ?? 'run';
+      const args = Array.isArray(suiteData.lastRunArgs)
+        ? [...suiteData.lastRunArgs]
+        : [];
+
+      if (data.input !== undefined) {
+        if (args.length) {
+          args[0] = data.input;
+        } else {
+          args.push(data.input);
+        }
+      }
+
+      const runner = suiteData.suite[mode] ?? suiteData.suite.run;
+      if (typeof runner === 'function') {
+        runner(...args);
+      }
+    }
+  });
+})();

--- a/packages/vest-devtools-extension/public/panel.html
+++ b/packages/vest-devtools-extension/public/panel.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="script-src 'self'; object-src 'self';"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vest Devtools</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/panel/main.tsx"></script>
+  </body>
+</html>

--- a/packages/vest-devtools-extension/src/panel/App.tsx
+++ b/packages/vest-devtools-extension/src/panel/App.tsx
@@ -1,0 +1,158 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { useMemo, useState } from 'react';
+
+import { FieldPanel } from './components/FieldPanel';
+import { HeaderBar } from './components/HeaderBar';
+import { HistoryDrawer } from './components/HistoryDrawer';
+import { SuiteHeader } from './components/SuiteHeader';
+import { SuiteInputPanel } from './components/SuiteInputPanel';
+import { THEME } from './constants';
+import { parseJson } from './domain/formatters';
+import { getInputFromArgs } from './domain/suite';
+import { useDevtoolsPort } from './hooks/useDevtoolsPort';
+import { useEventHistory } from './hooks/useEventHistory';
+import { useSuiteActions } from './hooks/useSuiteActions';
+import { useDevtoolsStore } from './store';
+
+export function App() {
+  const { events, selectedEvent, selectedEventId, addEvent, selectEvent } =
+    useEventHistory();
+  const { connected, sendCommand } = useDevtoolsPort(addEvent);
+  const { runSuite } = useSuiteActions(sendCommand);
+  const historyOpen = useDevtoolsStore(state => state.historyOpen);
+  const setHistoryOpen = useDevtoolsStore(state => state.setHistoryOpen);
+  const fieldFilter = useDevtoolsStore(state => state.fieldFilter);
+  const setFieldFilter = useDevtoolsStore(state => state.setFieldFilter);
+  const manualInputs = useDevtoolsStore(state => state.manualInputs);
+  const setManualInput = useDevtoolsStore(state => state.setManualInput);
+  const [manualInputError, setManualInputError] = useState<string | null>(null);
+
+  const activeSuiteId = selectedEvent?.suiteId ?? events[0]?.suiteId ?? null;
+  const snapshot = selectedEvent?.state;
+
+  const inputData = useMemo(() => {
+    if (!selectedEvent) {
+      return {};
+    }
+    return getInputFromArgs(selectedEvent.lastRunArgs);
+  }, [selectedEvent]);
+
+  const manualInput = activeSuiteId ? manualInputs[activeSuiteId] ?? '' : '';
+
+  const handleRunSuite = (payload?: unknown) => {
+    if (!activeSuiteId) {
+      return;
+    }
+    runSuite(activeSuiteId, payload);
+  };
+
+  const handleApplyInput = () => {
+    if (!activeSuiteId) {
+      return;
+    }
+    const parsed = parseJson(manualInput);
+    if (parsed.error) {
+      setManualInputError(parsed.error.message);
+      return;
+    }
+    setManualInputError(null);
+    runSuite(activeSuiteId, parsed.value);
+  };
+
+  const handleTriggerValidation = () => {
+    if (!activeSuiteId) {
+      return;
+    }
+    if (manualInput.trim().length) {
+      const parsed = parseJson(manualInput);
+      if (parsed.error) {
+        setManualInputError(parsed.error.message);
+        return;
+      }
+      setManualInputError(null);
+      runSuite(activeSuiteId, parsed.value);
+      return;
+    }
+    runSuite(activeSuiteId, inputData);
+  };
+
+  return (
+    <div css={styles.root}>
+      <HeaderBar
+        connected={connected}
+        onToggleHistory={() => setHistoryOpen(!historyOpen)}
+        onRunSuite={() => handleRunSuite(inputData)}
+        historyOpen={historyOpen}
+      />
+      <main css={styles.layout}>
+        <section css={styles.leftPanel}>
+          <FieldPanel
+            snapshot={snapshot}
+            filter={fieldFilter}
+            onFilterChange={setFieldFilter}
+          />
+        </section>
+        <section css={styles.mainPanel}>
+          <SuiteHeader event={selectedEvent} />
+          <SuiteInputPanel
+            inputData={inputData}
+            manualInput={manualInput}
+            error={manualInputError}
+            onManualInputChange={value => {
+              if (activeSuiteId) {
+                setManualInput(activeSuiteId, value);
+                setManualInputError(null);
+              }
+            }}
+            onApplyInput={handleApplyInput}
+            onTriggerValidation={handleTriggerValidation}
+          />
+        </section>
+      </main>
+      <HistoryDrawer
+        open={historyOpen}
+        events={events}
+        selectedEventId={selectedEventId}
+        onSelect={id => {
+          selectEvent(id);
+          setHistoryOpen(false);
+        }}
+        onClose={() => setHistoryOpen(false)}
+      />
+    </div>
+  );
+}
+
+const styles = {
+  root: css`
+    color-scheme: light dark;
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+      sans-serif;
+    background: ${THEME.background};
+    color: ${THEME.textPrimary};
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+  `,
+  layout: css`
+    display: grid;
+    grid-template-columns: 300px 1fr;
+    flex: 1;
+    min-height: 0;
+  `,
+  leftPanel: css`
+    padding: 16px;
+    border-right: 1px solid ${THEME.panelBorder};
+    background: rgba(11, 14, 27, 0.92);
+    overflow: auto;
+  `,
+  mainPanel: css`
+    padding: 16px 20px;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  `,
+};

--- a/packages/vest-devtools-extension/src/panel/components/FieldPanel.tsx
+++ b/packages/vest-devtools-extension/src/panel/components/FieldPanel.tsx
@@ -1,0 +1,163 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+
+import { LABELS, THEME } from '../constants';
+import type { FieldSnapshot, SuiteSnapshot } from '../types';
+import {
+  deriveSuiteStatus,
+  filterFields,
+  getFieldStatusLabel,
+  getFocusTag,
+} from '../domain/suite';
+import { FieldRow } from './FieldRow';
+
+type FieldPanelProps = {
+  snapshot?: SuiteSnapshot;
+  filter: string;
+  onFilterChange: (value: string) => void;
+};
+
+export function FieldPanel({ snapshot, filter, onFilterChange }: FieldPanelProps) {
+  const fields = snapshot?.fields ?? [];
+  const visibleFields = filterFields(fields, filter);
+  const totalCount = fields.length;
+  const visibleCount = visibleFields.length;
+  const suiteStatus = deriveSuiteStatus(snapshot);
+
+  return (
+    <div css={styles.root}>
+      <div css={styles.card}>
+        <div css={styles.cardHeader}>
+          <h2 css={styles.cardTitle}>{LABELS.suiteResult}</h2>
+        </div>
+        <div css={styles.cardContent}>
+          <div css={styles.suiteStatus(suiteStatus)}>
+            {suiteStatus === 'unknown' ? 'Unknown' : suiteStatus === 'valid' ? 'Valid' : 'Invalid'}
+          </div>
+          <div css={styles.suiteMeta}>
+            <span css={styles.metaItem}>
+              <span css={styles.dot(THEME.status.error)} />
+              {snapshot?.errorCount ?? 0} Errors
+            </span>
+            <span css={styles.metaItem}>
+              <span css={styles.dot(THEME.status.warning)} />
+              {snapshot?.warnCount ?? 0} Warnings
+            </span>
+            <span css={styles.metaItem}>
+              {snapshot?.testCount ?? 0} Total
+            </span>
+          </div>
+        </div>
+      </div>
+      <div css={styles.filterRow}>
+        <input
+          css={styles.filterInput}
+          placeholder={LABELS.fieldFilterPlaceholder}
+          value={filter}
+          onChange={event => onFilterChange(event.target.value)}
+        />
+      </div>
+      <div css={styles.fields}>
+        {visibleFields.length ? (
+          visibleFields.map(field => (
+            <FieldRow
+              key={field.name}
+              field={field}
+              focusTag={getFocusTag(
+                snapshot?.focus ?? { mode: null, match: [], matchAll: false },
+                field.name,
+              )}
+              statusLabel={getFieldStatusLabel(field.status)}
+            />
+          ))
+        ) : (
+          <p css={styles.empty}>No fields available.</p>
+        )}
+      </div>
+      <div css={styles.footer}>
+        Showing {visibleCount} of {totalCount} fields
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  root: css`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    height: 100%;
+  `,
+  card: css`
+    background: ${THEME.panelElevated};
+    border: 1px solid ${THEME.panelBorder};
+    border-radius: 12px;
+    padding: 12px 14px;
+    box-shadow: 0 12px 24px rgba(7, 10, 20, 0.4);
+  `,
+  cardHeader: css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  `,
+  cardTitle: css`
+    margin: 0;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: ${THEME.textMuted};
+  `,
+  cardContent: css`
+    margin-top: 12px;
+  `,
+  suiteStatus: (status: 'valid' | 'invalid' | 'unknown') => css`
+    font-size: 18px;
+    font-weight: 600;
+    color: ${status === 'unknown' ? THEME.textMuted : THEME.suiteStatus.valid};
+  `,
+  suiteMeta: css`
+    margin-top: 10px;
+    display: flex;
+    gap: 12px;
+    color: ${THEME.textSecondary};
+    font-size: 12px;
+  `,
+  metaItem: css`
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  `,
+  dot: (color: string) => css`
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: ${color};
+  `,
+  filterRow: css`
+    padding: 0 2px;
+  `,
+  filterInput: css`
+    width: 100%;
+    padding: 8px 12px;
+    border-radius: 10px;
+    border: 1px solid ${THEME.panelBorder};
+    background: ${THEME.panel};
+    color: ${THEME.textPrimary};
+    font-size: 12px;
+  `,
+  fields: css`
+    flex: 1;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  `,
+  empty: css`
+    color: ${THEME.textMuted};
+  `,
+  footer: css`
+    color: ${THEME.textMuted};
+    font-size: 12px;
+    padding-top: 4px;
+  `,
+};

--- a/packages/vest-devtools-extension/src/panel/components/FieldRow.tsx
+++ b/packages/vest-devtools-extension/src/panel/components/FieldRow.tsx
@@ -1,0 +1,98 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+
+import { FOCUS_LABELS, THEME } from '../constants';
+import type { FieldSnapshot } from '../types';
+
+type FieldRowProps = {
+  field: FieldSnapshot;
+  statusLabel: string;
+  focusTag: 'only' | 'skip' | null;
+};
+
+export function FieldRow({ field, statusLabel, focusTag }: FieldRowProps) {
+  return (
+    <div css={styles.root}>
+      <div css={styles.titleRow}>
+        <span css={styles.fieldName}>{field.name}</span>
+        <div css={styles.tagRow}>
+          {focusTag ? <span css={styles.focusTag(focusTag)}>{FOCUS_LABELS[focusTag]}</span> : null}
+          <span css={styles.statusTag(statusLabel)}>{statusLabel}</span>
+        </div>
+      </div>
+      <div css={styles.meta}>
+        <span>{field.errorCount} errors</span>
+        <span>{field.warnCount} warnings</span>
+        <span>{field.pendingCount} pending</span>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  root: css`
+    padding: 10px 12px;
+    border-radius: 12px;
+    background: ${THEME.panel};
+    border: 1px solid ${THEME.panelBorder};
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  `,
+  titleRow: css`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  `,
+  fieldName: css`
+    font-weight: 600;
+    color: ${THEME.textPrimary};
+  `,
+  tagRow: css`
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  `,
+  statusTag: (status: string) => css`
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: ${resolveStatusColor(status)};
+    background: rgba(15, 19, 35, 0.7);
+    border: 1px solid ${THEME.panelBorder};
+  `,
+  focusTag: (mode: 'only' | 'skip') => css`
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: ${mode === 'only' ? THEME.accent : THEME.textSecondary};
+    background: ${mode === 'only' ? THEME.accentSoft : 'rgba(148, 163, 184, 0.12)'};
+    border: 1px solid ${THEME.panelBorder};
+  `,
+  meta: css`
+    display: flex;
+    gap: 12px;
+    font-size: 11px;
+    color: ${THEME.textMuted};
+  `,
+};
+
+function resolveStatusColor(status: string) {
+  switch (status) {
+    case 'error':
+      return THEME.status.error;
+    case 'warning':
+      return THEME.status.warning;
+    case 'pending':
+      return THEME.status.pending;
+    case 'passing':
+      return THEME.status.passing;
+    default:
+      return THEME.textMuted;
+  }
+}

--- a/packages/vest-devtools-extension/src/panel/components/HeaderBar.tsx
+++ b/packages/vest-devtools-extension/src/panel/components/HeaderBar.tsx
@@ -1,0 +1,102 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+
+import { LABELS, THEME } from '../constants';
+
+type HeaderBarProps = {
+  connected: boolean;
+  onToggleHistory: () => void;
+  onRunSuite: () => void;
+  historyOpen: boolean;
+};
+
+export function HeaderBar({
+  connected,
+  onToggleHistory,
+  onRunSuite,
+  historyOpen,
+}: HeaderBarProps) {
+  return (
+    <header css={styles.root}>
+      <div css={styles.titleRow}>
+        <div css={styles.logo} aria-hidden />
+        <div>
+          <h1 css={styles.title}>{LABELS.appTitle}</h1>
+          <span css={styles.statusBadge(connected)}>
+            {connected ? LABELS.connected : LABELS.disconnected}
+          </span>
+        </div>
+      </div>
+      <div css={styles.actions}>
+        <button type="button" css={styles.secondaryButton} onClick={onToggleHistory}>
+          {historyOpen ? 'Close History' : LABELS.history}
+        </button>
+        <button type="button" css={styles.primaryButton} onClick={onRunSuite}>
+          {LABELS.rerun}
+        </button>
+      </div>
+    </header>
+  );
+}
+
+const styles = {
+  root: css`
+    padding: 12px 16px;
+    border-bottom: 1px solid ${THEME.panelBorder};
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(12, 16, 32, 0.9);
+  `,
+  titleRow: css`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  `,
+  logo: css`
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+    background: linear-gradient(135deg, ${THEME.accent}, ${THEME.accentStrong});
+    box-shadow: 0 6px 16px rgba(99, 102, 241, 0.35);
+  `,
+  title: css`
+    margin: 0;
+    font-size: 16px;
+    color: ${THEME.textPrimary};
+  `,
+  statusBadge: (connected: boolean) => css`
+    display: inline-flex;
+    margin-top: 4px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    background: ${connected ? 'rgba(74, 222, 128, 0.18)' : 'rgba(248, 113, 113, 0.2)'};
+    color: ${connected ? THEME.status.passing : THEME.status.error};
+  `,
+  actions: css`
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  `,
+  primaryButton: css`
+    border: none;
+    border-radius: 10px;
+    padding: 8px 14px;
+    font-weight: 600;
+    cursor: pointer;
+    color: ${THEME.textPrimary};
+    background: linear-gradient(135deg, ${THEME.accent}, ${THEME.accentStrong});
+    box-shadow: 0 10px 20px rgba(99, 102, 241, 0.28);
+  `,
+  secondaryButton: css`
+    border: 1px solid ${THEME.panelBorder};
+    border-radius: 10px;
+    padding: 8px 14px;
+    font-weight: 600;
+    cursor: pointer;
+    color: ${THEME.textPrimary};
+    background: ${THEME.panel};
+  `,
+};

--- a/packages/vest-devtools-extension/src/panel/components/HistoryDrawer.tsx
+++ b/packages/vest-devtools-extension/src/panel/components/HistoryDrawer.tsx
@@ -1,0 +1,115 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+
+import { THEME } from '../constants';
+import { formatTime } from '../domain/formatters';
+import type { EventRecord } from '../hooks/useEventHistory';
+
+type HistoryDrawerProps = {
+  open: boolean;
+  events: EventRecord[];
+  selectedEventId: string | null;
+  onSelect: (id: string) => void;
+  onClose: () => void;
+};
+
+export function HistoryDrawer({
+  open,
+  events,
+  selectedEventId,
+  onSelect,
+  onClose,
+}: HistoryDrawerProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div css={styles.overlay} role="dialog">
+      <div css={styles.drawer}>
+        <div css={styles.header}>
+          <h2 css={styles.title}>Event History</h2>
+          <button type="button" css={styles.closeButton} onClick={onClose}>
+            Close
+          </button>
+        </div>
+        <div css={styles.list}>
+          {events.map(event => (
+            <button
+              key={event.id}
+              type="button"
+              css={styles.item(event.id === selectedEventId)}
+              onClick={() => onSelect(event.id)}
+            >
+              <div css={styles.itemTitle}>{event.eventName}</div>
+              <div css={styles.itemMeta}>
+                {event.suiteName} · {formatTime(event.timestamp)}
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  overlay: css`
+    position: absolute;
+    inset: 0;
+    background: rgba(5, 8, 18, 0.72);
+    display: flex;
+    justify-content: flex-end;
+    z-index: 10;
+  `,
+  drawer: css`
+    width: 320px;
+    background: ${THEME.panelElevated};
+    border-left: 1px solid ${THEME.panelBorder};
+    display: flex;
+    flex-direction: column;
+    padding: 16px;
+    gap: 12px;
+  `,
+  header: css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  `,
+  title: css`
+    margin: 0;
+    font-size: 14px;
+    color: ${THEME.textPrimary};
+  `,
+  closeButton: css`
+    border: 1px solid ${THEME.panelBorder};
+    background: ${THEME.panel};
+    color: ${THEME.textPrimary};
+    border-radius: 8px;
+    padding: 6px 10px;
+    cursor: pointer;
+  `,
+  list: css`
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    overflow: auto;
+  `,
+  item: (active: boolean) => css`
+    text-align: left;
+    border-radius: 10px;
+    padding: 8px 10px;
+    border: 1px solid ${active ? THEME.accent : THEME.panelBorder};
+    background: ${active ? 'rgba(99, 102, 241, 0.18)' : THEME.panel};
+    color: ${THEME.textPrimary};
+    cursor: pointer;
+  `,
+  itemTitle: css`
+    font-weight: 600;
+  `,
+  itemMeta: css`
+    font-size: 11px;
+    color: ${THEME.textMuted};
+    margin-top: 4px;
+  `,
+};

--- a/packages/vest-devtools-extension/src/panel/components/SuiteHeader.tsx
+++ b/packages/vest-devtools-extension/src/panel/components/SuiteHeader.tsx
@@ -1,0 +1,61 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+
+import { THEME } from '../constants';
+import { formatTime } from '../domain/formatters';
+import type { EventRecord } from '../hooks/useEventHistory';
+
+type SuiteHeaderProps = {
+  event?: EventRecord;
+};
+
+export function SuiteHeader({ event }: SuiteHeaderProps) {
+  return (
+    <div css={styles.root}>
+      <div>
+        <div css={styles.label}>Active Suite</div>
+        <div css={styles.title}>{event?.suiteName ?? 'Waiting for suite'}</div>
+      </div>
+      <div css={styles.meta}>
+        <span css={styles.metaItem}>{event?.eventName ?? 'No events yet'}</span>
+        {event ? <span css={styles.metaItem}>{formatTime(event.timestamp)}</span> : null}
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  root: css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    border-radius: 14px;
+    background: ${THEME.panelElevated};
+    border: 1px solid ${THEME.panelBorder};
+    box-shadow: 0 12px 22px rgba(7, 10, 20, 0.4);
+  `,
+  label: css`
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: ${THEME.textMuted};
+  `,
+  title: css`
+    font-size: 16px;
+    font-weight: 600;
+    color: ${THEME.textPrimary};
+  `,
+  meta: css`
+    display: flex;
+    gap: 10px;
+    color: ${THEME.textSecondary};
+    font-size: 12px;
+  `,
+  metaItem: css`
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid ${THEME.panelBorder};
+    background: ${THEME.panel};
+  `,
+};

--- a/packages/vest-devtools-extension/src/panel/components/SuiteInputPanel.tsx
+++ b/packages/vest-devtools-extension/src/panel/components/SuiteInputPanel.tsx
@@ -1,0 +1,147 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { useMemo } from 'react';
+
+import { LABELS, THEME } from '../constants';
+import { formatJson, normalizeInput } from '../domain/formatters';
+
+type SuiteInputPanelProps = {
+  inputData: unknown;
+  manualInput: string;
+  error: string | null;
+  onManualInputChange: (value: string) => void;
+  onApplyInput: () => void;
+  onTriggerValidation: () => void;
+};
+
+export function SuiteInputPanel({
+  inputData,
+  manualInput,
+  error,
+  onManualInputChange,
+  onApplyInput,
+  onTriggerValidation,
+}: SuiteInputPanelProps) {
+  const formattedInput = useMemo(
+    () => formatJson(normalizeInput(inputData)),
+    [inputData],
+  );
+
+  return (
+    <div css={styles.root}>
+      <div css={styles.card}>
+        <div css={styles.headerRow}>
+          <h2 css={styles.title}>{LABELS.suiteInput}</h2>
+          <span css={styles.badge}>Read-only</span>
+        </div>
+        <pre css={styles.code}>{formattedInput}</pre>
+      </div>
+      <div css={styles.card}>
+        <div css={styles.headerRow}>
+          <h2 css={styles.title}>{LABELS.manualInput}</h2>
+        </div>
+        <textarea
+          css={styles.textarea}
+          rows={8}
+          value={manualInput}
+          onChange={event => onManualInputChange(event.target.value)}
+          placeholder="{ \"username\": \"\" }"
+        />
+        {error ? <div css={styles.errorText}>{error}</div> : null}
+        <div css={styles.actionRow}>
+          <button type="button" css={styles.secondaryButton} onClick={onApplyInput}>
+            {LABELS.applyInput}
+          </button>
+          <button type="button" css={styles.primaryButton} onClick={onTriggerValidation}>
+            {LABELS.triggerValidation}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  root: css`
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  `,
+  card: css`
+    background: ${THEME.panelElevated};
+    border: 1px solid ${THEME.panelBorder};
+    border-radius: 14px;
+    padding: 16px;
+    box-shadow: 0 14px 24px rgba(7, 10, 20, 0.45);
+  `,
+  headerRow: css`
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 12px;
+  `,
+  title: css`
+    margin: 0;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: ${THEME.textMuted};
+  `,
+  badge: css`
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: ${THEME.panel};
+    border: 1px solid ${THEME.panelBorder};
+    font-size: 11px;
+    color: ${THEME.textSecondary};
+  `,
+  code: css`
+    margin: 0;
+    background: rgba(10, 12, 24, 0.9);
+    border-radius: 10px;
+    padding: 12px;
+    color: ${THEME.textPrimary};
+    font-size: 12px;
+    overflow: auto;
+  `,
+  textarea: css`
+    width: 100%;
+    border-radius: 10px;
+    border: 1px solid ${THEME.panelBorder};
+    background: rgba(10, 12, 24, 0.9);
+    color: ${THEME.textPrimary};
+    padding: 12px;
+    font-family: ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, Monaco,
+      Consolas, 'Liberation Mono', 'Courier New', monospace;
+    font-size: 12px;
+  `,
+  actionRow: css`
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 12px;
+  `,
+  primaryButton: css`
+    border: none;
+    border-radius: 10px;
+    padding: 8px 14px;
+    font-weight: 600;
+    cursor: pointer;
+    color: ${THEME.textPrimary};
+    background: linear-gradient(135deg, ${THEME.accent}, ${THEME.accentStrong});
+  `,
+  secondaryButton: css`
+    border: 1px solid ${THEME.panelBorder};
+    border-radius: 10px;
+    padding: 8px 14px;
+    font-weight: 600;
+    cursor: pointer;
+    color: ${THEME.textPrimary};
+    background: ${THEME.panel};
+  `,
+  errorText: css`
+    color: ${THEME.status.error};
+    font-size: 12px;
+    margin-top: 6px;
+  `,
+};

--- a/packages/vest-devtools-extension/src/panel/constants.ts
+++ b/packages/vest-devtools-extension/src/panel/constants.ts
@@ -1,0 +1,52 @@
+export const THEME = {
+  background:
+    'radial-gradient(circle at 40% 35%, rgba(120, 132, 255, 0.25), transparent 55%), linear-gradient(180deg, #0c1020 0%, #0b0e1a 85%)',
+  panel: 'rgba(15, 19, 35, 0.92)',
+  panelElevated: 'rgba(20, 24, 44, 0.92)',
+  panelBorder: 'rgba(255, 255, 255, 0.08)',
+  textPrimary: '#f8fafc',
+  textSecondary: '#cbd5e1',
+  textMuted: '#9aa5d6',
+  accent: '#6366f1',
+  accentStrong: '#4f46e5',
+  accentSoft: 'rgba(99, 102, 241, 0.18)',
+  status: {
+    error: '#ff5c7c',
+    warning: '#f6a648',
+    passing: '#4ade80',
+    pending: '#e879f9',
+  },
+  suiteStatus: {
+    valid: '#7c9bff',
+    invalid: '#7c9bff',
+  },
+};
+
+export const LABELS = {
+  appTitle: 'Vest Validations',
+  connected: 'Connected',
+  disconnected: 'Disconnected',
+  history: 'History',
+  rerun: 'Re-run Suite',
+  suiteResult: 'Suite Result',
+  suiteInput: 'Suite Input Data',
+  manualInput: 'Manual Input',
+  applyInput: 'Apply Input',
+  triggerValidation: 'Trigger Validation',
+  fieldFilterPlaceholder: 'Filter fields by name...',
+};
+
+export const STATUS_LABELS = {
+  passing: 'passing',
+  failing: 'error',
+  pending: 'pending',
+  warning: 'warning',
+  idle: 'idle',
+} as const;
+
+export const FOCUS_LABELS = {
+  only: 'Only',
+  skip: 'Skip',
+};
+
+export const HISTORY_LIMIT = 200;

--- a/packages/vest-devtools-extension/src/panel/domain/formatters.ts
+++ b/packages/vest-devtools-extension/src/panel/domain/formatters.ts
@@ -1,0 +1,23 @@
+export function formatTime(timestamp: number) {
+  return new Date(timestamp).toLocaleTimeString();
+}
+
+export function formatJson(value: unknown) {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function parseJson(input: string) {
+  try {
+    return { value: JSON.parse(input), error: null };
+  } catch (error) {
+    return { value: null, error: error as Error };
+  }
+}
+
+export function normalizeInput(value: unknown) {
+  return value == null ? {} : value;
+}

--- a/packages/vest-devtools-extension/src/panel/domain/suite.ts
+++ b/packages/vest-devtools-extension/src/panel/domain/suite.ts
@@ -1,0 +1,63 @@
+import type { FieldSnapshot, SuiteFocus, SuiteSnapshot } from '../types';
+
+export type SuiteStatus = 'valid' | 'invalid' | 'unknown';
+
+export function deriveSuiteStatus(snapshot?: SuiteSnapshot): SuiteStatus {
+  if (!snapshot) {
+    return 'unknown';
+  }
+  if (snapshot.valid === true) {
+    return 'valid';
+  }
+  if (snapshot.valid === false) {
+    return 'invalid';
+  }
+  return 'unknown';
+}
+
+export function getFieldStatusLabel(status: FieldSnapshot['status']) {
+  switch (status) {
+    case 'failing':
+      return 'error';
+    case 'warning':
+      return 'warning';
+    case 'pending':
+      return 'pending';
+    case 'passing':
+      return 'passing';
+    default:
+      return 'idle';
+  }
+}
+
+export function getFocusTag(
+  focus: SuiteFocus,
+  fieldName: string,
+): 'only' | 'skip' | null {
+  if (!focus?.mode) {
+    return null;
+  }
+
+  if (focus.matchAll) {
+    return focus.mode;
+  }
+
+  return focus.match.includes(fieldName) ? focus.mode : null;
+}
+
+export function filterFields(fields: FieldSnapshot[], query: string) {
+  const trimmed = query.trim().toLowerCase();
+
+  if (!trimmed) {
+    return fields;
+  }
+
+  return fields.filter(field => field.name.toLowerCase().includes(trimmed));
+}
+
+export function getInputFromArgs(args: unknown[]) {
+  if (!args?.length) {
+    return {};
+  }
+  return args[0] ?? {};
+}

--- a/packages/vest-devtools-extension/src/panel/hooks/useDevtoolsPort.ts
+++ b/packages/vest-devtools-extension/src/panel/hooks/useDevtoolsPort.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { DevtoolsCommand, VestEventPayload } from '../types';
+
+type PortMessage = { type?: string; payload?: VestEventPayload };
+
+export function useDevtoolsPort(onEvent: (payload: VestEventPayload) => void) {
+  const portRef = useRef<chrome.runtime.Port | null>(null);
+  const [connected, setConnected] = useState(false);
+
+  const sendCommand = useCallback((command: DevtoolsCommand) => {
+    portRef.current?.postMessage({ type: 'command', payload: command });
+  }, []);
+
+  useEffect(() => {
+    const port = chrome.runtime.connect({ name: 'devtools' });
+    const tabId = chrome.devtools.inspectedWindow.tabId;
+
+    portRef.current = port;
+    port.postMessage({ type: 'init', tabId });
+    setConnected(true);
+
+    const handler = (message: PortMessage) => {
+      if (message?.type === 'event' && message.payload) {
+        onEvent(message.payload);
+      }
+    };
+
+    port.onMessage.addListener(handler);
+
+    port.onDisconnect.addListener(() => {
+      setConnected(false);
+    });
+
+    return () => {
+      port.onMessage.removeListener(handler);
+      port.disconnect();
+      portRef.current = null;
+    };
+  }, [onEvent]);
+
+  return { connected, sendCommand };
+}

--- a/packages/vest-devtools-extension/src/panel/hooks/useEventHistory.ts
+++ b/packages/vest-devtools-extension/src/panel/hooks/useEventHistory.ts
@@ -1,0 +1,63 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { HISTORY_LIMIT } from '../constants';
+import { useDevtoolsStore } from '../store';
+import type { VestEventPayload } from '../types';
+
+const EVENTS_QUERY_KEY = ['vest-events'];
+
+export type EventRecord = VestEventPayload & { id: string };
+
+export function useEventHistory() {
+  const queryClient = useQueryClient();
+  const selectedEventId = useDevtoolsStore(state => state.selectedEventId);
+  const setSelectedEventId = useDevtoolsStore(
+    state => state.setSelectedEventId,
+  );
+  const sequenceRef = useRef(0);
+
+  const { data: events = [] } = useQuery<EventRecord[]>({
+    queryKey: EVENTS_QUERY_KEY,
+    queryFn: () => Promise.resolve([]),
+    initialData: [],
+    staleTime: Infinity,
+  });
+
+  const selectedEvent = useMemo(
+    () => events.find(event => event.id === selectedEventId) ?? events[0],
+    [events, selectedEventId],
+  );
+
+  const addEvent = useCallback(
+    (payload: VestEventPayload) => {
+      const id = `event-${sequenceRef.current++}`;
+      const record: EventRecord = { ...payload, id };
+
+      queryClient.setQueryData(EVENTS_QUERY_KEY, (current: EventRecord[] = []) =>
+        [record, ...current].slice(0, HISTORY_LIMIT),
+      );
+
+      const currentSelection = useDevtoolsStore.getState().selectedEventId;
+      if (!currentSelection) {
+        setSelectedEventId(id);
+      }
+    },
+    [queryClient, setSelectedEventId],
+  );
+
+  const selectEvent = useCallback(
+    (id: string) => {
+      setSelectedEventId(id);
+    },
+    [setSelectedEventId],
+  );
+
+  return {
+    events,
+    selectedEvent,
+    selectedEventId,
+    addEvent,
+    selectEvent,
+  };
+}

--- a/packages/vest-devtools-extension/src/panel/hooks/useSuiteActions.ts
+++ b/packages/vest-devtools-extension/src/panel/hooks/useSuiteActions.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+
+import type { DevtoolsCommand } from '../types';
+import { parseJson } from '../domain/formatters';
+
+type SendCommand = (command: DevtoolsCommand) => void;
+
+export function useSuiteActions(sendCommand: SendCommand) {
+  const runSuite = useCallback(
+    (
+      suiteId: string,
+      input?: unknown,
+      mode?: 'run' | 'runStatic' | 'validate',
+    ) => {
+      sendCommand({ type: 'RUN_SUITE', suiteId, input, mode });
+    },
+    [sendCommand],
+  );
+
+  const runSuiteFromJson = useCallback(
+    (suiteId: string, inputJson: string) => {
+      const parsed = parseJson(inputJson);
+      if (parsed.error) {
+        return parsed;
+      }
+      sendCommand({ type: 'RUN_SUITE', suiteId, input: parsed.value });
+      return parsed;
+    },
+    [sendCommand],
+  );
+
+  return { runSuite, runSuiteFromJson };
+}

--- a/packages/vest-devtools-extension/src/panel/main.tsx
+++ b/packages/vest-devtools-extension/src/panel/main.tsx
@@ -1,0 +1,19 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { App } from './App';
+
+const queryClient = new QueryClient();
+
+const container = document.getElementById('root');
+
+if (container) {
+  createRoot(container).render(
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </StrictMode>,
+  );
+}

--- a/packages/vest-devtools-extension/src/panel/store.ts
+++ b/packages/vest-devtools-extension/src/panel/store.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+type DevtoolsStore = {
+  selectedEventId: string | null;
+  setSelectedEventId: (id: string | null) => void;
+  historyOpen: boolean;
+  setHistoryOpen: (open: boolean) => void;
+  fieldFilter: string;
+  setFieldFilter: (value: string) => void;
+  manualInputs: Record<string, string>;
+  setManualInput: (suiteId: string, value: string) => void;
+};
+
+export const useDevtoolsStore = create<DevtoolsStore>(set => ({
+  selectedEventId: null,
+  setSelectedEventId: selectedEventId => set({ selectedEventId }),
+  historyOpen: false,
+  setHistoryOpen: historyOpen => set({ historyOpen }),
+  fieldFilter: '',
+  setFieldFilter: fieldFilter => set({ fieldFilter }),
+  manualInputs: {},
+  setManualInput: (suiteId, value) =>
+    set(state => ({
+      manualInputs: { ...state.manualInputs, [suiteId]: value },
+    })),
+}));

--- a/packages/vest-devtools-extension/src/panel/types.ts
+++ b/packages/vest-devtools-extension/src/panel/types.ts
@@ -1,0 +1,50 @@
+export type VestEventPayload = {
+  suiteId: string;
+  suiteName: string;
+  eventName: string;
+  timestamp: number;
+  payload: unknown;
+  lastRunArgs: unknown[];
+  state: SuiteSnapshot;
+};
+
+export type SuiteSnapshot = {
+  valid: boolean | null;
+  errorCount: number;
+  warnCount: number;
+  pendingCount: number;
+  testCount: number;
+  fields: FieldSnapshot[];
+  focus: SuiteFocus;
+};
+
+export type FieldSnapshot = {
+  name: string;
+  status: 'passing' | 'failing' | 'pending' | 'warning' | 'idle';
+  errorCount: number;
+  warnCount: number;
+  pendingCount: number;
+  testCount: number;
+  errors: unknown[];
+  warnings: unknown[];
+  valid: boolean | null;
+};
+
+export type SuiteFocus = {
+  mode: 'only' | 'skip' | null;
+  matchAll: boolean;
+  match: string[];
+};
+
+export type DevtoolsCommand =
+  | {
+      type: 'RUN_SUITE';
+      suiteId: string;
+      input?: unknown;
+      mode?: 'run' | 'runStatic' | 'validate';
+    }
+  | {
+      type: 'SET_INPUT';
+      suiteId: string;
+      input?: unknown;
+    };

--- a/packages/vest-devtools-extension/tsconfig.json
+++ b/packages/vest-devtools-extension/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["chrome"]
+  },
+  "include": ["src"]
+}

--- a/packages/vest-devtools-extension/vite.config.ts
+++ b/packages/vest-devtools-extension/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  publicDir: 'public',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        panel: 'public/panel.html',
+      },
+    },
+  },
+});


### PR DESCRIPTION
### Motivation
- Replace the prior monolithic DevTools UI with a componentized React stack to improve maintainability and enable richer interactions.  
- Provide a predictable command bridge (panel -> background -> content -> page) so the DevTools panel can trigger suite runs and set inputs on inspected pages.  
- Surface suite focus metadata (only/skip) and deterministic state snapshots from the page to the panel for clearer debugging.  
- Add automated coverage for the injected page script and its integration with the Vest runtime to prevent regressions.

### Description
- Add a new extension package `packages/vest-devtools-extension` with build config (`package.json`, `vite.config.ts`, `tsconfig.json`, `public/*`) and a Vite-based React panel entry (`src/panel/*`).  
- Implement the page-side hook and messaging in `public/page-script.js` that exposes `window.__VEST_DEVTOOLS__.registerSuite`, serializes suite state (including focus isolates), wraps `run`/`runStatic`/`validate`, and listens for `RUN_SUITE` commands.  
- Wire background/content messaging in `public/background.js` and `public/content-script.js` to forward events and `command` messages between the panel and the page.  
- Build a componentized React panel UI with components, hooks, domain helpers, types, and a small Zustand store under `src/panel/*`, and add a unit test file `packages/vest-devtools-extension/__tests__/page-script.test.ts` that mocks the window hook and also exercises a real Vest suite run.

### Testing
- No automated tests were executed in this environment (CI/local run not performed).  
- Added unit test `packages/vest-devtools-extension/__tests__/page-script.test.ts` which verifies suite registration emission and focus metadata mapping and asserts that a `RUN_SUITE` command triggers a real Vest suite run.  
- The repository-level Vitest config includes `packages/**/__tests__/*.test.ts` so the new test can be executed with the repository test runner.  
- To run tests locally, invoke the repository test task (e.g., the configured Vitest command) so the new test file can be validated in CI or locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e6dfd0a08330af64df183d3e358a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a Chrome DevTools extension for Vest that enables real-time inspection of validation suites within the browser devtools panel.
  * Inspect suite status, field-level results, errors, and warnings across validation runs.
  * Access complete event history of test executions and replay suites with custom input data.
  * Support for focus mode debugging to identify specific field validation patterns.

* **Tests**
  * Added test coverage for core extension functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->