### PR TITLE
Ensure context is restored even on exceptions

### DIFF
--- a/packages/context/src/__tests__/context.test.ts
+++ b/packages/context/src/__tests__/context.test.ts
@@ -100,5 +100,21 @@ describe('Context', () => {
         expect(ctx.use()).toBeUndefined();
       });
     });
+
+    describe('Context restoration when callback throws', () => {
+      it('should restore context to EMPTY_CONTEXT when callback throws', () => {
+        const valueA = { some: 'value' };
+
+        expect(() => {
+          ctx.run(valueA, () => {
+            expect(ctx.use()).toBe(valueA);
+            throw new Error('test error');
+          });
+        }).toThrow('test error');
+
+        // After the error, context should be reset to EMPTY_CONTEXT
+        expect(ctx.use()).toBeUndefined();
+      });
+    });
   });
 });

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -36,13 +36,13 @@ export function createContext<T>(defaultContextValue?: T): CtxApi<T> {
 
   function run<R>(value: T, cb: () => R): R {
     const parentContext = isInsideContext() ? use() : EMPTY_CONTEXT;
-
     contextValue = value;
-
-    const res = cb();
-
-    contextValue = parentContext;
-    return res;
+    
+    try {
+      return cb();
+    } finally {
+      contextValue = parentContext;
+    }
   }
 
   function isInsideContext(): boolean {

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -11,7 +11,17 @@ const USEX_DEFAULT_ERROR_MESSAGE = 'Not inside of a running context.';
 const EMPTY_CONTEXT = Symbol();
 
 /**
- * Base context interface.
+ * Creates a context API for temporarily setting and accessing a value of type `T`.
+ *
+ * The returned API lets callers run a function with a provided context value (restoring the previous
+ * context after the function completes, even if it throws), read the current context value with a
+ * fallback, or read the current context value and throw if none is active.
+ *
+ * @param defaultContextValue - Value returned by `use()` when no context is active
+ * @returns An object with:
+ *  - `run(value, cb)` — executes `cb` with the context set to `value` and restores the prior context after `cb` finishes (restoration occurs even if `cb` throws).
+ *  - `use()` — returns the current context value if a context is active, otherwise returns `defaultContextValue`.
+ *  - `useX(errorMessage?)` — returns the current context value if a context is active; throws an error with `errorMessage` (or a default message) when no context is active.
  */
 export function createContext<T>(defaultContextValue?: T): CtxApi<T> {
   let contextValue: T | symbol = EMPTY_CONTEXT;
@@ -34,6 +44,13 @@ export function createContext<T>(defaultContextValue?: T): CtxApi<T> {
     return contextValue as T;
   }
 
+  /**
+   * Executes a callback with the context set to the provided value and restores the previous context when the callback completes or throws.
+   *
+   * @param value - Context value to set for the duration of `cb`
+   * @param cb - Function to execute while the given context is active
+   * @returns The value returned by `cb`
+   */
   function run<R>(value: T, cb: () => R): R {
     const parentContext = isInsideContext() ? use() : EMPTY_CONTEXT;
     contextValue = value;
@@ -44,6 +61,11 @@ export function createContext<T>(defaultContextValue?: T): CtxApi<T> {
     }
   }
 
+  /**
+   * Determines whether a context is currently active.
+   *
+   * @returns `true` if a context is active, `false` otherwise.
+   */
   function isInsideContext(): boolean {
     return contextValue !== EMPTY_CONTEXT;
   }

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -37,7 +37,6 @@ export function createContext<T>(defaultContextValue?: T): CtxApi<T> {
   function run<R>(value: T, cb: () => R): R {
     const parentContext = isInsideContext() ? use() : EMPTY_CONTEXT;
     contextValue = value;
-    
     try {
       return cb();
     } finally {


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Please fill the following form (leave what's relevant)
-->

<!-- Describe your changes below in detail. -->

| Q                | A |
| ---------------- | - |
| Bug fix?         | ✔ |
| New feature?     | ✖ |
| Breaking change? | ✖ |
| Deprecations?    | ✖ |
| Documentation?   | ✖ |
| Tests added?     | ✖ |
| Types added?     | ✖ |
| Related issues   |     |

### Summary
Fix context restoration when `run()` throws.

### Details
Wraps `run()` logic in `try/finally` to prevent context leakage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Context state is now reliably restored in all scenarios, including when operations throw, preventing unexpected state leakage.

* **Tests**
  * Added tests verifying context restoration after errors to ensure stability and prevent regressions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->