### PR TITLE
Focus skip skip group

### DIFF
--- a/packages/vest/src/core/context/SuiteContext.ts
+++ b/packages/vest/src/core/context/SuiteContext.ts
@@ -15,7 +15,7 @@ export const SuiteContext = createCascade<CTXType>((ctxRef, parentContext) => {
     {
       inclusion: {},
       mode: tinyState.createTinyState<Modes>(Modes.EAGER),
-      modifiers: { only: undefined },
+      modifiers: { only: undefined, skip: undefined, skipGroup: undefined },
       schema: null,
       suiteParams: [],
     },

--- a/packages/vest/src/isolates/group.ts
+++ b/packages/vest/src/isolates/group.ts
@@ -1,11 +1,13 @@
-import { CB, makeBrand } from 'vest-utils';
+import { CB, asArray, makeBrand } from 'vest-utils';
 import { TIsolate } from 'vestjs-runtime';
 
+import { SuiteContext } from '../core/context/SuiteContext';
 import {
   createVestIsolate,
   TVestIsolate,
   VestIsolateType,
 } from '../core/isolate/VestIsolateType';
+import { skip } from '../hooks/focused/focused';
 import { TGroupName } from '../suiteResult/SuiteResultTypes';
 
 export function group(groupName: string, callback: CB<void>): TIsolate;
@@ -20,9 +22,34 @@ export function group(
   const safeGroupName =
     groupName === undefined ? undefined : makeBrand<TGroupName>(groupName);
 
-  return createVestIsolate(VestIsolateType.Group, callback, {
-    groupName: safeGroupName as TGroupName,
-  });
+  return createVestIsolate(
+    VestIsolateType.Group,
+    () => {
+      // When `skipGroup` is set via `suite.focus({ skipGroup: ... })`, inject
+      // a `skip(true)` call at the top of the matching group's callback.
+      // This creates a transient Focused isolate inside the group scope with
+      // `matchAll: true`, causing all tests in this group to be excluded.
+      // Because the isolate is transient, it is not persisted in the suite
+      // state and adds zero overhead between runs.
+      if (groupName && shouldSkipGroup(groupName)) {
+        skip(true);
+      }
+      callback();
+    },
+    {
+      groupName: safeGroupName as TGroupName,
+    },
+  );
+}
+
+/**
+ * Checks whether the given group name is targeted for skipping by the
+ * current suite run's `skipGroup` modifier (set via `suite.focus()`).
+ */
+function shouldSkipGroup(groupName: string): boolean {
+  const { modifiers } = SuiteContext.useX();
+  if (!modifiers.skipGroup) return false;
+  return asArray(modifiers.skipGroup).includes(groupName);
 }
 
 export type TIsolateGroup<G extends TGroupName = TGroupName> = TVestIsolate<{

--- a/packages/vest/src/isolates/group.ts
+++ b/packages/vest/src/isolates/group.ts
@@ -1,4 +1,4 @@
-import { CB, asArray, makeBrand } from 'vest-utils';
+import { CB, makeBrand } from 'vest-utils';
 import { TIsolate } from 'vestjs-runtime';
 
 import { SuiteContext } from '../core/context/SuiteContext';
@@ -48,8 +48,7 @@ export function group(
  */
 function shouldSkipGroup(groupName: string): boolean {
   const { modifiers } = SuiteContext.useX();
-  if (!modifiers.skipGroup) return false;
-  return asArray(modifiers.skipGroup).includes(groupName);
+  return modifiers.skipGroupSet ? modifiers.skipGroupSet.has(groupName) : false;
 }
 
 export type TIsolateGroup<G extends TGroupName = TGroupName> = TVestIsolate<{

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -112,6 +112,10 @@ type AfterMethods<
  *   matched groups are unaffected. Internally, a `skip(true)` call is injected
  *   at the start of the matching group's callback, producing a transient
  *   Focused isolate that adds zero overhead to stored state.
+ *
+ * Modifiers are composable. For example, `{ skip: 'email', skipGroup: 'signUp' }`
+ * skips the `email` field everywhere while also skipping every test that runs
+ * inside `group('signUp', ...)`.
  */
 export type SuiteModifiers<F extends TFieldName> = {
   only?: FieldExclusion<F> | FieldExclusion<string>;

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -109,16 +109,14 @@ type AfterMethods<
  *   explicitly included via `include()`.
  * - `skip` — Skip the specified field(s). All others run as usual.
  * - `skipGroup` — Skip all tests inside the named group(s). Tests outside the
- *   matched groups are unaffected. Internally, a `skip(true)` call is injected
- *   at the start of the matching group's callback, producing a transient
- *   Focused isolate that adds zero overhead to stored state.
- *
- * Modifiers are composable. For example, `{ skip: 'email', skipGroup: 'signUp' }`
- * skips the `email` field everywhere while also skipping every test that runs
- * inside `group('signUp', ...)`.
+ *   matched groups are unaffected.
  */
 export type SuiteModifiers<F extends TFieldName> = {
   only?: FieldExclusion<F> | FieldExclusion<string>;
   skip?: FieldExclusion<F> | FieldExclusion<string>;
   skipGroup?: string | string[];
+  /**
+   * @internal
+   */
+  skipGroupSet?: Set<string>;
 };

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -101,6 +101,20 @@ type AfterMethods<
   ) => SuiteResult<F, G>;
 };
 
+/**
+ * Modifiers that control which fields and groups are included or excluded
+ * during a focused suite run. These are passed via `suite.focus(modifiers)`.
+ *
+ * - `only` — Run only the specified field(s). All others are excluded unless
+ *   explicitly included via `include()`.
+ * - `skip` — Skip the specified field(s). All others run as usual.
+ * - `skipGroup` — Skip all tests inside the named group(s). Tests outside the
+ *   matched groups are unaffected. Internally, a `skip(true)` call is injected
+ *   at the start of the matching group's callback, producing a transient
+ *   Focused isolate that adds zero overhead to stored state.
+ */
 export type SuiteModifiers<F extends TFieldName> = {
   only?: FieldExclusion<F> | FieldExclusion<string>;
+  skip?: FieldExclusion<F> | FieldExclusion<string>;
+  skipGroup?: string | string[];
 };

--- a/packages/vest/src/suite/__tests__/focus.test.ts
+++ b/packages/vest/src/suite/__tests__/focus.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import { dummyTest } from '../../testUtils/testDummy';
 import * as vest from '../../vest';
@@ -117,6 +117,375 @@ describe('suite.focus: only', () => {
         expect(validResult.hasErrors('f2')).toBe(false);
         expect(validResult.isValid()).toBe(true);
       });
+    });
+  });
+});
+
+describe('suite.focus: skip', () => {
+  describe('single field', () => {
+    it('should skip the specified field', () => {
+      const suite = vest.create(() => {
+        dummyTest.failing('field_1');
+        dummyTest.failing('field_2');
+        dummyTest.failing('field_3');
+      });
+
+      const res = suite.focus({ skip: 'field_1' }).run();
+
+      expect(res.hasErrors('field_1')).toBe(false);
+      expect(res.hasErrors('field_2')).toBe(true);
+      expect(res.hasErrors('field_3')).toBe(true);
+
+      expect(res.tests.field_1.testCount).toBe(0);
+      expect(res.tests.field_2.testCount).toBe(1);
+      expect(res.tests.field_3.testCount).toBe(1);
+    });
+  });
+
+  describe('multiple fields', () => {
+    it('should skip all specified fields', () => {
+      const suite = vest.create(() => {
+        dummyTest.failing('field_1');
+        dummyTest.failing('field_2');
+        dummyTest.failing('field_3');
+      });
+
+      const res = suite.focus({ skip: ['field_1', 'field_2'] }).run();
+
+      expect(res.hasErrors('field_1')).toBe(false);
+      expect(res.hasErrors('field_2')).toBe(false);
+      expect(res.hasErrors('field_3')).toBe(true);
+
+      expect(res.tests.field_1.testCount).toBe(0);
+      expect(res.tests.field_2.testCount).toBe(0);
+      expect(res.tests.field_3.testCount).toBe(1);
+    });
+  });
+
+  describe('combined with only', () => {
+    it('should apply both only and skip modifiers', () => {
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+        vest.test('field_1', 'f1 error', () => false);
+        vest.test('field_2', 'f2 error', () => false);
+        vest.test('field_3', 'f3 error', () => false);
+      });
+
+      // only field_1 should run - skip is redundant here but should not interfere
+      const res = suite.focus({ only: 'field_1', skip: 'field_3' }).run();
+
+      expect(res.hasErrors('field_1')).toBe(true);
+      expect(res.hasErrors('field_2')).toBe(false);
+      expect(res.hasErrors('field_3')).toBe(false);
+
+      expect(res.tests.field_1.testCount).toBe(1);
+      expect(res.tests.field_2.testCount).toBe(0);
+      expect(res.tests.field_3.testCount).toBe(0);
+    });
+  });
+
+  describe('multiple runs', () => {
+    it('should not persist skip focus from one run to the next', () => {
+      const suite = vest.create(() => {
+        dummyTest.failing('field_1');
+        dummyTest.failing('field_2');
+        dummyTest.failing('field_3');
+      });
+
+      // 1. Focused skip run
+      const skippedResult = suite.focus({ skip: 'field_1' }).run();
+      expect(skippedResult.hasErrors('field_1')).toBe(false);
+      expect(skippedResult.hasErrors('field_2')).toBe(true);
+      expect(skippedResult.hasErrors('field_3')).toBe(true);
+
+      // 2. Normal run - field_1 should now run
+      const fullResult = suite.run();
+      expect(fullResult.hasErrors('field_1')).toBe(true);
+      expect(fullResult.hasErrors('field_2')).toBe(true);
+      expect(fullResult.hasErrors('field_3')).toBe(true);
+    });
+  });
+});
+
+describe('suite.focus: skipGroup', () => {
+  describe('single group', () => {
+    it('should skip all tests in the specified group', () => {
+      const cb1 = vi.fn(() => false);
+      const cb2 = vi.fn(() => false);
+      const cb3 = vi.fn(() => false);
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+
+        vest.group('groupA', () => {
+          vest.test('field_1', cb1);
+          vest.test('field_2', cb1);
+        });
+
+        vest.group('groupB', () => {
+          vest.test('field_2', cb2);
+          vest.test('field_3', cb2);
+        });
+
+        vest.test('field_1', cb3);
+      });
+
+      const res = suite.focus({ skipGroup: 'groupA' }).run();
+
+      // groupA tests should be skipped
+      expect(res.groups.groupA.field_1.testCount).toBe(0);
+      expect(res.groups.groupA.field_2.testCount).toBe(0);
+
+      // groupB tests should run normally
+      expect(res.groups.groupB.field_2.testCount).toBe(1);
+      expect(res.groups.groupB.field_3.testCount).toBe(1);
+
+      // Top-level tests should run normally
+      expect(res.tests.field_1.testCount).toBe(1);
+
+      // cb1 (groupA) should not have been called
+      expect(cb1).not.toHaveBeenCalled();
+      // cb2 (groupB) should have been called
+      expect(cb2).toHaveBeenCalledTimes(2);
+      // cb3 (top-level) should have been called
+      expect(cb3).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('multiple groups', () => {
+    it('should skip all tests in all specified groups when passed as array', () => {
+      const cb1 = vi.fn(() => false);
+      const cb2 = vi.fn(() => false);
+      const cb3 = vi.fn(() => false);
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+
+        vest.group('groupA', () => {
+          vest.test('field_1', cb1);
+        });
+
+        vest.group('groupB', () => {
+          vest.test('field_2', cb2);
+        });
+
+        vest.test('field_3', cb3);
+      });
+
+      const res = suite.focus({ skipGroup: ['groupA', 'groupB'] }).run();
+
+      expect(res.groups.groupA.field_1.testCount).toBe(0);
+      expect(res.groups.groupB.field_2.testCount).toBe(0);
+      expect(res.tests.field_3.testCount).toBe(1);
+
+      expect(cb1).not.toHaveBeenCalled();
+      expect(cb2).not.toHaveBeenCalled();
+      expect(cb3).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('nonexistent group', () => {
+    it('should have no effect when skipGroup references a group that does not exist', () => {
+      const cb1 = vi.fn(() => false);
+      const cb2 = vi.fn(() => false);
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+
+        vest.group('groupA', () => {
+          vest.test('field_1', cb1);
+        });
+
+        vest.test('field_2', cb2);
+      });
+
+      const res = suite.focus({ skipGroup: 'nonexistent' }).run();
+
+      expect(res.groups.groupA.field_1.testCount).toBe(1);
+      expect(res.tests.field_2.testCount).toBe(1);
+      expect(cb1).toHaveBeenCalledTimes(1);
+      expect(cb2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('combined with only', () => {
+    it('should focus only on the specified field and skip the specified group', () => {
+      const cb1 = vi.fn(() => false);
+      const cb2 = vi.fn(() => false);
+      const cb3 = vi.fn(() => false);
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+
+        vest.group('groupA', () => {
+          vest.test('field_1', cb1);
+          vest.test('field_2', cb1);
+        });
+
+        vest.group('groupB', () => {
+          vest.test('field_1', cb2);
+          vest.test('field_2', cb2);
+        });
+
+        vest.test('field_1', cb3);
+        vest.test('field_2', cb3);
+      });
+
+      const res = suite.focus({ only: 'field_1', skipGroup: 'groupA' }).run();
+
+      // field_1 is only'd, so field_2 is excluded everywhere
+      // groupA is skipped entirely (even field_1 in groupA is skipped)
+      expect(res.groups.groupA.field_1.testCount).toBe(0);
+      expect(res.groups.groupA.field_2.testCount).toBe(0);
+
+      // field_1 in groupB should run (it's only'd and groupB is not skipped)
+      expect(res.groups.groupB.field_1.testCount).toBe(1);
+      expect(res.groups.groupB.field_2.testCount).toBe(0);
+
+      // Top-level field_1 should run
+      expect(res.tests.field_1.testCount).toBe(2);
+      expect(res.tests.field_2.testCount).toBe(0);
+    });
+  });
+
+  describe('combined with skip', () => {
+    it('should skip both the specified field and the specified group', () => {
+      const cb1 = vi.fn(() => false);
+      const cb2 = vi.fn(() => false);
+      const cb3 = vi.fn(() => false);
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+
+        vest.group('groupA', () => {
+          vest.test('field_1', cb1);
+          vest.test('field_2', cb1);
+        });
+
+        vest.group('groupB', () => {
+          vest.test('field_1', cb2);
+          vest.test('field_2', cb2);
+        });
+
+        vest.test('field_1', cb3);
+        vest.test('field_2', cb3);
+      });
+
+      const res = suite.focus({ skip: 'field_1', skipGroup: 'groupA' }).run();
+
+      // groupA is entirely skipped
+      expect(res.groups.groupA.field_1.testCount).toBe(0);
+      expect(res.groups.groupA.field_2.testCount).toBe(0);
+
+      // field_1 is skipped everywhere (including groupB)
+      expect(res.groups.groupB.field_1.testCount).toBe(0);
+      // field_2 in groupB should run
+      expect(res.groups.groupB.field_2.testCount).toBe(1);
+
+      // Top-level: field_1 skipped, field_2 runs
+      expect(res.tests.field_1.testCount).toBe(0);
+      expect(res.tests.field_2.testCount).toBe(2);
+    });
+  });
+
+  describe('multiple runs', () => {
+    it('should not persist skipGroup focus from one run to the next', () => {
+      const cb1 = vi.fn(() => false);
+      const cb2 = vi.fn(() => false);
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+
+        vest.group('groupA', () => {
+          vest.test('field_1', cb1);
+        });
+
+        vest.test('field_2', cb2);
+      });
+
+      // 1. Focused run - skip groupA
+      const focusedResult = suite.focus({ skipGroup: 'groupA' }).run();
+      expect(focusedResult.groups.groupA.field_1.testCount).toBe(0);
+      expect(focusedResult.tests.field_2.testCount).toBe(1);
+
+      // 2. Normal run - groupA should now run
+      cb1.mockClear();
+      cb2.mockClear();
+      const fullResult = suite.run();
+      expect(fullResult.groups.groupA.field_1.testCount).toBe(1);
+      expect(fullResult.tests.field_2.testCount).toBe(1);
+      expect(cb1).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow changing skipGroup between focused runs', () => {
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+
+        vest.group('groupA', () => {
+          vest.test('field_1', () => false);
+        });
+
+        vest.group('groupB', () => {
+          vest.test('field_2', () => false);
+        });
+      });
+
+      // Skip groupA - groupB runs
+      const res1 = suite.focus({ skipGroup: 'groupA' }).run();
+      expect(res1.groups.groupA.field_1.testCount).toBe(0);
+      expect(res1.groups.groupB.field_2.testCount).toBe(1);
+
+      // Now skip groupB instead - groupA now runs, groupB preserves previous result
+      const res2 = suite.focus({ skipGroup: 'groupB' }).run();
+      expect(res2.groups.groupA.field_1.testCount).toBe(1);
+      // groupB.field_2 keeps its result from the previous run (state is cumulative)
+      expect(res2.groups.groupB.field_2.testCount).toBe(1);
+    });
+  });
+
+  describe('chaining with focus', () => {
+    it('should support combining only and skipGroup in a single focus call', () => {
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+
+        vest.group('groupA', () => {
+          vest.test('field_1', () => false);
+        });
+
+        vest.group('groupB', () => {
+          vest.test('field_2', () => false);
+        });
+
+        vest.test('field_3', () => false);
+      });
+
+      const res = suite.focus({ only: 'field_1', skipGroup: 'groupA' }).run();
+
+      // field_1 is only'd, but groupA is skipped
+      expect(res.groups.groupA.field_1.testCount).toBe(0);
+      expect(res.groups.groupB.field_2.testCount).toBe(0);
+      expect(res.tests.field_3.testCount).toBe(0);
+    });
+  });
+
+  describe('with tests inside and outside the skipped group', () => {
+    it('should only skip tests inside the group, not outside', () => {
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+
+        vest.test('field_1', 'top level field_1', () => false);
+
+        vest.group('groupA', () => {
+          vest.test('field_1', 'groupA field_1', () => false);
+          vest.test('field_2', 'groupA field_2', () => false);
+        });
+
+        vest.test('field_2', 'top level field_2', () => false);
+      });
+
+      const res = suite.focus({ skipGroup: 'groupA' }).run();
+
+      // Top-level tests should run
+      expect(res.tests.field_1.testCount).toBe(1);
+      expect(res.tests.field_2.testCount).toBe(1);
+
+      // Tests inside groupA should be skipped
+      expect(res.groups.groupA.field_1.testCount).toBe(0);
+      expect(res.groups.groupA.field_2.testCount).toBe(0);
     });
   });
 });

--- a/packages/vest/src/suite/__tests__/focus.test.ts
+++ b/packages/vest/src/suite/__tests__/focus.test.ts
@@ -437,7 +437,7 @@ describe('suite.focus: skipGroup', () => {
     });
   });
 
-  describe('chaining with focus', () => {
+  describe('focus with combined options', () => {
     it('should support combining only and skipGroup in a single focus call', () => {
       const suite = vest.create(() => {
         vest.mode(vest.Modes.ALL);

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -50,6 +50,8 @@ function createSuite<
         suiteCallbackResult as any,
         {
           only: undefined,
+          skip: undefined,
+          skipGroup: undefined,
         },
         VestBus.subscribe,
         schema,

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -1,4 +1,4 @@
-import { assign, CB, isFunction, withResolvers } from 'vest-utils';
+import { assign, asArray, CB, isFunction, withResolvers } from 'vest-utils';
 
 import { useEmit } from '../core/VestBus/VestBus';
 
@@ -50,7 +50,12 @@ export function useCreateSuiteRunner<
         {
           suiteParams: args as Parameters<T>,
           schema,
-          modifiers,
+          modifiers: {
+            ...modifiers,
+            skipGroupSet: modifiers.skipGroup
+              ? new Set(asArray(modifiers.skipGroup))
+              : undefined,
+          },
         },
         () => {
           useEmit('SUITE_RUN_STARTED');

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -6,7 +6,7 @@ import { SuiteContext } from '../core/context/SuiteContext';
 import { IsolateReorderable } from 'vestjs-runtime';
 import { IsolateSuite } from '../core/isolate/IsolateSuite/IsolateSuite';
 import { test } from '../core/test/test';
-import { only } from '../hooks/focused/focused';
+import { only, skip } from '../hooks/focused/focused';
 import {
   SuiteResult,
   TFieldName,
@@ -50,6 +50,7 @@ export function useCreateSuiteRunner<
         {
           suiteParams: args as Parameters<T>,
           schema,
+          modifiers,
         },
         () => {
           useEmit('SUITE_RUN_STARTED');
@@ -61,7 +62,14 @@ export function useCreateSuiteRunner<
           }
 
           const output = IsolateSuite(() => {
+            // Apply field-level focus modifiers. These create transient Focused
+            // isolates at the suite root that affect all tests in the suite.
+            // `only` restricts the run to matching fields; `skip` excludes them.
+            // `skipGroup` is handled separately inside `group()` — when a group
+            // with a matching name is entered, it injects `skip(true)` into
+            // the group's callback via the modifiers stored in SuiteContext.
             only(modifiers.only);
+            skip(modifiers.skip);
             (suiteCallback as any)(...(args as Parameters<T>));
 
             IsolateReorderable(

--- a/website/versioned_docs/version-next/api_reference.md
+++ b/website/versioned_docs/version-next/api_reference.md
@@ -104,7 +104,7 @@ Resets the state of a specific field (clears errors/warnings but keeps it in the
 
 Prepares a focused run.
 
-- `config`: `{ only?: string | string[], skip?: string | string[] }`
+- `config`: `{ only?: string | string[], skip?: string | string[], skipGroup?: string | string[] }`
 - [Read more about Focused Updates](./writing_your_suite/focused_updates.md)
 
 #### `suite.afterEach(callback)`

--- a/website/versioned_docs/version-next/recipes/focus_skipgroup_recipes.md
+++ b/website/versioned_docs/version-next/recipes/focus_skipgroup_recipes.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 3
+title: Recipe - focus({ skip / skipGroup }) patterns
+description: Practical patterns for combining suite.focus modifiers, with emphasis on skip vs skipGroup.
+keywords: [Recipe, focus, skip, skipGroup, only, Vest]
+---
+
+# `focus({ skip / skipGroup })` Patterns
+
+This recipe clarifies a common source of confusion:
+
+- `skip` excludes by **field name**.
+- `skipGroup` excludes by **group name**.
+
+## Mental model
+
+Use `skip` when the question is **"which field(s) should not run?"**.
+Use `skipGroup` when the question is **"which validation section should not run?"**.
+
+## Pattern 1: Skip one field everywhere
+
+```js
+suite.focus({ skip: 'email' }).run(formData);
+```
+
+This skips every `test('email', ...)`, regardless of whether it is top-level or nested in groups.
+
+## Pattern 2: Skip one entire section
+
+```js
+suite.focus({ skipGroup: 'signUp' }).run(formData);
+```
+
+This skips all tests declared inside `group('signUp', ...)`, regardless of field names.
+
+## Pattern 3: Validate one field and skip heavy checks
+
+```js
+suite
+  .focus({ only: 'username', skipGroup: 'availabilityChecks' })
+  .run(formData);
+```
+
+Useful for blur validation in forms where async checks are expensive.
+
+## Pattern 4: Wizard step validation
+
+```js
+// run only step2 validations by skipping other groups
+suite.focus({ skipGroup: ['step1', 'step3'] }).run(formData);
+```
+
+## Pattern 5: Combine both scopes
+
+```js
+suite.focus({ skip: 'password', skipGroup: 'billing' }).run(formData);
+```
+
+This skips all `password` tests globally and all tests in `billing` group.
+
+## See also
+
+- [Focused Updates](../writing_your_suite/focused_updates)
+- [Including and Excluding Fields](../writing_your_suite/including_and_excluding/skip_and_only)

--- a/website/versioned_docs/version-next/writing_tests/advanced_test_features/grouping_tests.md
+++ b/website/versioned_docs/version-next/writing_tests/advanced_test_features/grouping_tests.md
@@ -100,7 +100,7 @@ const suite = create(data => {
 
   group('pricing_tab', () => {
     test('price', '5$ or more.', () => {
-      enforce(data.price).lte(5);
+      enforce(data.price).gte(5);
     });
     test('productExtras', "Can't be empty.", () => {
       enforce(data.extras).isNotEmpty();
@@ -123,8 +123,6 @@ suite.run(data);
 `skipGroup` internally injects a `skip(true)` call at the start of each matching group's callback. Because it creates a transient isolate, it adds zero overhead to the suite state.
 
 For more details, see [Focused Updates](../../writing_your_suite/focused_updates).
-
-### 2. Multi-stage form with `skip()` inside the suite
 
 ### 2. Multi-stage form with `skip()` inside the suite
 

--- a/website/versioned_docs/version-next/writing_tests/advanced_test_features/grouping_tests.md
+++ b/website/versioned_docs/version-next/writing_tests/advanced_test_features/grouping_tests.md
@@ -81,7 +81,52 @@ create(data => {
 
 ## Use cases
 
-### 1. Multi-stage form
+### 1. Skipping groups with `suite.focus()`
+
+The simplest way to skip groups is using `suite.focus({ skipGroup })` from outside the suite. This keeps your suite definition clean and moves the skip logic to the call site:
+
+```js
+import { create, test, group, enforce } from 'vest';
+
+const suite = create(data => {
+  group('overview_tab', () => {
+    test('productTitle', 'Must be at least 5 chars.', () => {
+      enforce(data.productTitle).longerThanOrEquals(5);
+    });
+    test('productDescription', "Can't be longer than 2500 chars.", () => {
+      enforce(data.productDescription).shorterThanOrEquals(2500);
+    });
+  });
+
+  group('pricing_tab', () => {
+    test('price', '5$ or more.', () => {
+      enforce(data.price).lte(5);
+    });
+    test('productExtras', "Can't be empty.", () => {
+      enforce(data.extras).isNotEmpty();
+    });
+  });
+});
+```
+
+```js
+// Only validate the overview tab - skip pricing
+suite.focus({ skipGroup: 'pricing_tab' }).run(data);
+
+// Only validate the pricing tab - skip overview
+suite.focus({ skipGroup: 'overview_tab' }).run(data);
+
+// Validate everything on submit (no focus)
+suite.run(data);
+```
+
+`skipGroup` internally injects a `skip(true)` call at the start of each matching group's callback. Because it creates a transient isolate, it adds zero overhead to the suite state.
+
+For more details, see [Focused Updates](../../writing_your_suite/focused_updates).
+
+### 2. Multi-stage form with `skip()` inside the suite
+
+### 2. Multi-stage form with `skip()` inside the suite
 
 You may have in your application a multi-screen form in which you want to validate each screen individually but submit it all at once.
 
@@ -129,7 +174,7 @@ suite.run(data, 'overview_tab'); // will only validate 'overview_tab' group
 suite.run(data, 'pricing_tab'); // will only validate 'pricing_tab' group
 ```
 
-### 2. Skipping only some of the tests of a given field
+### 3. Skipping only some of the tests of a given field
 
 If we want to conditionally skip a portion of our suite, we can use `skip()` within a group.
 

--- a/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
+++ b/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
@@ -1,8 +1,8 @@
 ---
 sidebar_position: 4
 title: Focused Updates
-description: Run validation only for specific fields using suite.focus()
-keywords: [Vest, Focus, Only, Validation]
+description: Run validation only for specific fields or skip groups using suite.focus()
+keywords: [Vest, Focus, Only, Skip, SkipGroup, Validation]
 ---
 
 # Focused Updates
@@ -19,6 +19,7 @@ In a large form, re-validating the entire suite on every keystroke can be ineffi
 
 - **Validate on Blur**: Run checks only for the field the user just left.
 - **Skip Expensive Tests**: Temporarily bypass heavy async validations when they aren't needed.
+- **Skip Entire Groups**: Bypass whole sections of validation (e.g., skip "sign-up" validations when signing in).
 - **Improve Performance**: Run only what's necessary.
 - **Better UX**: Avoid showing errors for untouched fields.
 
@@ -31,6 +32,67 @@ Use `focus({ only: ... })` to restrict the run to specific fields.
 import FocusedUpdatesSandpack from '@site/src/components/Sandpack/FocusedUpdates';
 
 <FocusedUpdatesSandpack />
+
+### Skipping Specific Fields
+
+Use `focus({ skip: ... })` to exclude specific fields from the run while running everything else.
+
+```javascript
+// Skip the 'promoCode' field during this run
+suite.focus({ skip: 'promoCode' }).run(formData);
+
+// Skip multiple fields
+suite.focus({ skip: ['promoCode', 'referralCode'] }).run(formData);
+```
+
+### Skipping Entire Groups
+
+Use `focus({ skipGroup: ... })` to skip all tests inside a named group. Tests outside the group run normally.
+
+```javascript
+import { create, test, group, enforce } from 'vest';
+
+const suite = create(data => {
+  test('username', 'Username is required', () => {
+    enforce(data.username).isNotBlank();
+  });
+
+  group('signIn', () => {
+    test('password', 'Password is required', () => {
+      enforce(data.password).isNotBlank();
+    });
+  });
+
+  group('signUp', () => {
+    test('email', 'Email is required', () => {
+      enforce(data.email).isEmail();
+    });
+    test('tos', 'You must accept the terms', () => {
+      enforce(data.tos).equals(true);
+    });
+  });
+});
+
+// When signing in, skip the signUp group entirely
+suite.focus({ skipGroup: 'signUp' }).run(formData);
+
+// When signing up, skip the signIn group entirely
+suite.focus({ skipGroup: 'signIn' }).run(formData);
+
+// Skip multiple groups at once
+suite.focus({ skipGroup: ['signIn', 'signUp'] }).run(formData);
+```
+
+`skipGroup` works by injecting a `skip(true)` call at the beginning of each matching group's callback. Since `skip(true)` creates a transient isolate, it adds zero overhead to the stored suite state between runs.
+
+### Combining Modifiers
+
+You can combine `only`, `skip`, and `skipGroup` in a single `focus()` call:
+
+```javascript
+// Only validate 'username', and also skip the 'signUp' group
+suite.focus({ only: 'username', skipGroup: 'signUp' }).run(formData);
+```
 
 ## Fluent Chain API
 
@@ -69,6 +131,36 @@ function handleBlur(fieldName, formData) {
   onBlur={() => handleBlur('email', formData)}
   onChange={handleChange}
 />;
+```
+
+### Multi-Step Form with Group Skipping
+
+```javascript
+const suite = create(data => {
+  group('step1', () => {
+    test('name', 'Name is required', () => {
+      enforce(data.name).isNotBlank();
+    });
+  });
+
+  group('step2', () => {
+    test('address', 'Address is required', () => {
+      enforce(data.address).isNotBlank();
+    });
+  });
+
+  group('step3', () => {
+    test('payment', 'Payment method is required', () => {
+      enforce(data.payment).isNotBlank();
+    });
+  });
+});
+
+// Validate only step 2 by skipping the other steps
+suite
+  .focus({ skipGroup: ['step1', 'step3'] })
+  .afterEach(() => setResult(suite.get()))
+  .run(formData);
 ```
 
 ### Validating All Fields Without Focus
@@ -128,6 +220,14 @@ function useFormValidation(initialData) {
 }
 ```
 
+## Focus Modifiers Reference
+
+| Modifier    | Type                 | Description                                               |
+| ----------- | -------------------- | --------------------------------------------------------- |
+| `only`      | `string \| string[]` | Run only the specified field(s). All others are excluded. |
+| `skip`      | `string \| string[]` | Skip the specified field(s). All others run as usual.     |
+| `skipGroup` | `string \| string[]` | Skip all tests inside the named group(s).                 |
+
 ## Comparison: `suite.focus()` vs `only()`/`skip()`
 
 | Feature                    | `only()`/`skip()`              | `suite.focus()`                        |
@@ -135,6 +235,7 @@ function useFormValidation(initialData) {
 | **Location**               | Inside suite callback          | Outside, at call site                  |
 | **Flexibility**            | Requires conditional logic     | Fully dynamic                          |
 | **Separation of Concerns** | Mixed with validation          | Decoupled from validation              |
+| **Group Skipping**         | `skip(true)` inside group      | `skipGroup` modifier                   |
 | **Chainable**              | No                             | Yes (`afterEach`, `afterField`, `run`) |
 | **Best For**               | Static, logic-based exclusions | UI-driven field focus                  |
 
@@ -144,6 +245,7 @@ function useFormValidation(initialData) {
 
 - Validating on blur or focus events
 - The decision of what to validate comes from UI interactions
+- You want to skip entire groups from outside the suite
 - You want to chain callbacks
 
 **Use `only()`/`skip()`** when:
@@ -159,6 +261,7 @@ function useFormValidation(initialData) {
 - **Non-persistent**: Focused runs do not persist between calls. Each `focus` call applies only to the immediately following `run()`.
 - **Schema Validation**: When focusing specific fields, schema validation is skipped for fields outside the focus scope, allowing targeted validation even if the full payload is invalid.
 - **State Preservation**: Previous validation results for non-focused fields are preserved.
+- **skipGroup is transient**: The `skip(true)` isolate injected by `skipGroup` is transient — it is not stored in the suite state tree and adds zero overhead between runs.
   :::
 
 ## TypeScript Support
@@ -182,9 +285,13 @@ const suite = create((data: FormData) => {
 // TypeScript will autocomplete field names
 suite.focus({ only: 'username' }).run(formData); // ✅
 suite.focus({ only: 'nonexistent' }).run(formData); // ❌ Type error
+suite.focus({ skip: 'email' }).run(formData); // ✅
+suite.focus({ skipGroup: 'myGroup' }).run(formData); // ✅
+suite.focus({ skipGroup: ['groupA', 'groupB'] }).run(formData); // ✅
 ```
 
 ## Related
 
 - [Including and Excluding Fields](./including_and_excluding/skip_and_only) - Using `only()` and `skip()` inside suites
 - [Include](./including_and_excluding/include) - Link related fields to run together
+- [Test Groups](../writing_tests/advanced_test_features/grouping_tests) - Grouping tests together

--- a/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
+++ b/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
@@ -49,6 +49,21 @@ suite.focus({ skip: ['promoCode', 'referralCode'] }).run(formData);
 
 Use `focus({ skipGroup: ... })` to skip all tests inside a named group. Tests outside the group run normally.
 
+### `skip` vs `skipGroup`
+
+Both modifiers exclude tests, but they target different scopes:
+
+- `skip`: skips by **field name**, no matter where that field is declared.
+- `skipGroup`: skips by **group name**, regardless of field names inside that group.
+
+```javascript
+// Skip every `email` test across the suite (top-level and inside groups)
+suite.focus({ skip: 'email' }).run(formData);
+
+// Skip only tests declared inside group('signUp', ...)
+suite.focus({ skipGroup: 'signUp' }).run(formData);
+```
+
 ```javascript
 import { create, test, group, enforce } from 'vest';
 
@@ -295,3 +310,4 @@ suite.focus({ skipGroup: ['groupA', 'groupB'] }).run(formData); // ✅
 - [Including and Excluding Fields](./including_and_excluding/skip_and_only) - Using `only()` and `skip()` inside suites
 - [Include](./including_and_excluding/include) - Link related fields to run together
 - [Test Groups](../writing_tests/advanced_test_features/grouping_tests) - Grouping tests together
+- [focus({ skip / skipGroup }) Patterns](../recipes/focus_skipgroup_recipes) - Practical recipes for choosing and combining focus modifiers

--- a/website/versioned_docs/version-next/writing_your_suite/including_and_excluding/skip_and_only.md
+++ b/website/versioned_docs/version-next/writing_your_suite/including_and_excluding/skip_and_only.md
@@ -126,6 +126,8 @@ suite
 
 > **Recommendation**: Use `suite.focus()` for runtime decisions (e.g., validating on blur), and `only()`/`skip()` for static, logic-based exclusions inside your suite.
 
+When choosing between modifiers in `suite.focus()`, prefer `skipGroup` when your intent is to disable a named validation section (for example `signUp`), and prefer `skip` when your intent is to exclude a specific field everywhere it appears.
+
 For more details, see [Focused Updates](../focused_updates).
 
 ## Skipping fields

--- a/website/versioned_docs/version-next/writing_your_suite/including_and_excluding/skip_and_only.md
+++ b/website/versioned_docs/version-next/writing_your_suite/including_and_excluding/skip_and_only.md
@@ -93,12 +93,26 @@ suite.focus({ only: 'username' }).run(formData);
 // Focus on multiple fields
 suite.focus({ only: ['username', 'email'] }).run(formData);
 
+// Skip specific fields
+suite.focus({ skip: 'password' }).run(formData);
+
+// Skip entire groups
+suite.focus({ skipGroup: 'signUp' }).run(formData);
+
 // Chain with afterEach for callbacks
 suite
   .focus({ only: 'email' })
   .afterEach(() => updateUI(suite.get()))
   .run(formData);
 ```
+
+### `suite.focus()` Modifiers
+
+| Modifier    | Type                 | Description                                               |
+| ----------- | -------------------- | --------------------------------------------------------- |
+| `only`      | `string \| string[]` | Run only the specified field(s). All others are excluded. |
+| `skip`      | `string \| string[]` | Skip the specified field(s). All others run as usual.     |
+| `skipGroup` | `string \| string[]` | Skip all tests inside the named group(s).                 |
 
 ### Why Use `suite.focus()` Over `only()`?
 


### PR DESCRIPTION
Add focus({skip}), focus({skipGroup})

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * suite.focus() now supports skip modifier to exclude specific fields from focused runs
  * suite.focus() now supports skipGroup modifier to skip entire test groups at runtime
  * Both modifiers can be combined for flexible test control strategies

* **Documentation**
  * Added comprehensive guides and recipes demonstrating skip and skipGroup patterns with real-world examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->