### PR TITLE
feat: onlyGroup focus type

### DIFF
--- a/packages/vest-utils/src/__tests__/isEmptySet.test.ts
+++ b/packages/vest-utils/src/__tests__/isEmptySet.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { isEmptySet, isNotEmptySet } from '../isEmptySet';
+
+describe('isEmptySet', () => {
+  it('Should return true for an empty Set', () => {
+    expect(isEmptySet(new Set())).toBe(true);
+  });
+
+  it('Should return false for a non-empty Set', () => {
+    expect(isEmptySet(new Set([1]))).toBe(false);
+  });
+});
+
+describe('isNotEmptySet', () => {
+  it('Should return false for an empty Set', () => {
+    expect(isNotEmptySet(new Set())).toBe(false);
+  });
+
+  it('Should return true for a non-empty Set', () => {
+    expect(isNotEmptySet(new Set([1]))).toBe(true);
+  });
+});

--- a/packages/vest-utils/src/isEmptySet.ts
+++ b/packages/vest-utils/src/isEmptySet.ts
@@ -2,7 +2,7 @@
  * Checks if a given set is empty.
  * @param value value to check
  */
-export function isEmptySet(value: Set<any>): boolean {
+export function isEmptySet(value: Set<unknown>): boolean {
   return value.size === 0;
 }
 
@@ -10,6 +10,6 @@ export function isEmptySet(value: Set<any>): boolean {
  * Checks if a given set is NOT empty.
  * @param value value to check
  */
-export function isNotEmptySet(value: Set<any>): boolean {
+export function isNotEmptySet(value: Set<unknown>): boolean {
   return value.size > 0;
 }

--- a/packages/vest-utils/src/isEmptySet.ts
+++ b/packages/vest-utils/src/isEmptySet.ts
@@ -1,0 +1,15 @@
+/**
+ * Checks if a given set is empty.
+ * @param value value to check
+ */
+export function isEmptySet(value: Set<any>): boolean {
+  return value.size === 0;
+}
+
+/**
+ * Checks if a given set is NOT empty.
+ * @param value value to check
+ */
+export function isNotEmptySet(value: Set<any>): boolean {
+  return value.size > 0;
+}

--- a/packages/vest-utils/src/vest-utils.ts
+++ b/packages/vest-utils/src/vest-utils.ts
@@ -32,6 +32,7 @@ export { isNull, isNotNull } from './isNull';
 export { isUndefined, isNotUndefined } from './isUndefined';
 export { isArray, isNotArray } from './isArrayValue';
 export { isEmpty, isNotEmpty } from './isEmpty';
+export { isEmptySet, isNotEmptySet } from './isEmptySet';
 export { isPositive } from './isPositive';
 export { text } from './text';
 export { StateMachine } from './SimpleStateMachine';

--- a/packages/vest/bench/suite-focus.bench.ts
+++ b/packages/vest/bench/suite-focus.bench.ts
@@ -1,0 +1,85 @@
+import { bench, describe } from 'vitest';
+
+import { create, enforce, group, test } from '../src/vest';
+
+const focusSuite = create(() => {
+  group('groupA', () => {
+    test('field_1', () => {
+      enforce(1).equals(1);
+    });
+    test('field_2', () => {
+      enforce(2).greaterThan(1);
+    });
+  });
+
+  group('groupB', () => {
+    test('field_3', () => {
+      enforce(3).lessThan(5);
+    });
+    test('field_4', () => {
+      enforce(4).equals(4);
+    });
+  });
+
+  test('field_5', () => {
+    enforce(5).equals(5);
+  });
+});
+
+describe('suite.focus modifiers', () => {
+  bench(
+    'no focus modifiers',
+    () => {
+      focusSuite.run();
+    },
+    { time: 150, iterations: 15 },
+  );
+
+  bench(
+    'skipGroup: skip one group',
+    () => {
+      focusSuite.focus({ skipGroup: 'groupA' }).run();
+    },
+    { time: 150, iterations: 15 },
+  );
+
+  bench(
+    'onlyGroup: limit to one group',
+    () => {
+      focusSuite.focus({ onlyGroup: 'groupB' }).run();
+    },
+    { time: 150, iterations: 15 },
+  );
+
+  bench(
+    'only: single field across groups',
+    () => {
+      focusSuite.focus({ only: 'field_1' }).run();
+    },
+    { time: 150, iterations: 15 },
+  );
+
+  bench(
+    'skip: single field',
+    () => {
+      focusSuite.focus({ skip: 'field_1' }).run();
+    },
+    { time: 150, iterations: 15 },
+  );
+
+  bench(
+    'combined focus: onlyGroup and only field',
+    () => {
+      focusSuite.focus({ onlyGroup: 'groupB', only: 'field_3' }).run();
+    },
+    { time: 150, iterations: 15 },
+  );
+
+  bench(
+    'combined focus: skipGroup and skip field',
+    () => {
+      focusSuite.focus({ skipGroup: 'groupA', skip: 'field_4' }).run();
+    },
+    { time: 150, iterations: 15 },
+  );
+});

--- a/packages/vest/docs/focus.md
+++ b/packages/vest/docs/focus.md
@@ -1,0 +1,88 @@
+# Focus & Scope Modifier Architecture
+
+The `focus` API (`suite.focus({ ... })`) allows restricting validations to specific sub-graphs of the suite structure. Since a Vest suite executes linearly and declaratively, modifiers must inject themselves seamlessly into the suite resolution phase before any callback is evaluated.
+
+To ensure optimal performance and correct precedence evaluation, focus modifiers are managed through Context variables, and their conditions are checked both at the structural boundary (Groups) and at the leaf nodes (Tests).
+
+## 🏗️ Architecture
+
+The Focus mechanism is divided into two operational layers:
+
+1.  **Context Construction** (`vest/suite/useCreateSuiteRunner`): Configuration maps are transformed into high-performance `Set` abstractions before the test suite begins.
+2.  **Structural Exclusion Analysis** (`vest/isolates/group` & `vest/hooks/focused/useIsExcluded`): Runtime hooks evaluate the current execution node against the Context modifiers to determine if the node should run, jump straight to skipped, or abort an entire block.
+
+## 🏗️ Structure & Location
+
+Focus modifiers strictly exist inside the **Suite Context** during a suite run: `SuiteContext.useX().modifiers`.
+
+### State Preparation (`useTransformedModifiers`)
+
+When `suite.focus()` is called, the passed modifiers (`SuiteModifiers`) configure the subsequent run. `onlyGroup` and `skipGroup` can be explicitly provided as strings or arrays of strings. Doing validating structural array iterations over strings during the suite run for every group and test definition would introduce a massive `O(N)` cost as the codebase scales.
+
+To achieve `O(1)` amortized lookups throughout the execution tree, we wrap the original parameters inside `useTransformedModifiers`. This internal layer parses the user arguments and strictly initializes `Set<string>` structures for both group inclusion and exclusion lists prior to injecting them into the `SuiteContext` interface, represented as `TInternalModifiers`.
+
+By explicitly defaulting missing arguments to empty `Set` objects rather than `undefined`, we eliminate any downstream `undefined` type-checking, enabling us to purely rely on zero-cost `isNotEmptySet()` boolean checks.
+
+---
+
+## 🔄 Update Lifecycle
+
+Exclusion decisions must occur at the optimal branch of the isolate tree to prevent unnecessary workload processing.
+
+### Flowchart
+
+```text
+       [ Isolate Encapsulation ]
+                  |
+     +------------v------------+
+     |   Suite Context Sync    |  <-- Modifiers applied as Sets
+     +------------|------------+
+                  v
+       [ Node Execution Begins ]
+                  |
+         Is it a Group Node?
+          /                \
+        Yes                 No (It's a Test)
+        /                    \
+[shouldSkipGroup]        [useIsExcluded By Field/Group]
+      |                        |
+(Destructive /              (Ascending Fallbacks)
+ Constructive Checks)          |
+      |                        v
+   [SKIP?]                [Skip Node?]
+```
+
+### 1. Group Evaluation (`shouldSkipGroup` in `group.ts`)
+
+When a `group()` callback is executed, Vest first invokes the `shouldSkipGroup(groupName)` logic before walking into the inner suite tests.
+
+- **Destructive Block-list:** If `skipGroup` contains the group, the group immediately registers itself to inject a scoped `skip(true)` context. This completely suppresses internal testing.
+- **Constructive Allow-list (`onlyGroup`):** If `onlyGroup` has active items (`isNotEmptySet(modifiers.onlyGroup)`), only matching groups are permitted. Any group missing from the allow-list is skipped.
+
+If a group fails these checks, `skip(true)` pushes a transient `Focused` isolate into the tree for the duration of the group's callback. This prevents inner elements from executing, bypassing state registration overheads natively.
+
+### 2. Top-Level Exclusion Handling (`useIsExcludedByGroup`)
+
+A fundamental implication of using `onlyGroup` is the isolation of execution solely to targeted groups. Therefore, all "top-level" tests (tests declared without a parent group) must be reliably excluded.
+
+Inside `useIsExcluded()` (specifically `useIsExcludedByGroup`), the test node is strictly verified against the `onlyGroup` rule. If `onlyGroup` is active, and the test lacks a `groupName`, it is instantly excluded. This rule handles edge cases dynamically—even if a top-level test shares the exact name of a successfully `only`'d test inside an allowed group, the top-level test will remain isolated and excluded.
+
+### 3. Field Granularity (`useIsExcludedByField`)
+
+If structural checks pass, the focus is evaluated down to the exact field declaration instance. Exclusions cascade hierarchically:
+
+1.  **Individual Explicit Control:** `skipWhen()` boundaries.
+2.  **Explicit Exclusion:** `skip` modifier targeting the field.
+3.  **Explicit Inclusion:** `only` modifier targeting the field.
+4.  **Implicit Exclusion:** If _any_ other field is `only`'d in the file and this field is not, it gets automatically suppressed.
+
+## 🛠️ Precedence Mapping
+
+To prevent conflicting instructions between `only`, `skip`, `onlyGroup`, and `skipGroup`, Vest strictly respects a **"Destructive Constraints override Constructive Constraints"** model:
+
+1.  **Highest (`skipGroup`)**: Excluded groups skip everything inside them indiscriminately.
+2.  **High (`onlyGroup`)**: If active, prunes both non-mentioned groups and top-level loose tests.
+3.  **Medium (`skip`)**: Explicit field exclusions override even successfully retained groups.
+4.  **Low (`only`)**: Narrows execution down to specific targets within any surviving groups.
+
+This combination of `O(1)` Context transformation, transient isolate suppression, and strict precedence layering ensures that Vest remains highly responsive and precisely correct across vast suite depths.

--- a/packages/vest/src/core/context/SuiteContext.ts
+++ b/packages/vest/src/core/context/SuiteContext.ts
@@ -16,12 +16,8 @@ export const SuiteContext = createCascade<CTXType>((ctxRef, parentContext) => {
       inclusion: {},
       mode: tinyState.createTinyState<Modes>(Modes.EAGER),
       modifiers: {
-        only: undefined,
-        onlyGroup: undefined,
-        onlyGroupSet: undefined,
-        skip: undefined,
-        skipGroup: undefined,
-        skipGroupSet: undefined,
+        onlyGroup: new Set<string>(),
+        skipGroup: new Set<string>(),
       },
       schema: null,
       suiteParams: [],
@@ -38,7 +34,15 @@ type CTXType = {
   skipped?: boolean;
   omitted?: boolean;
   schema: TSchema;
-  modifiers: SuiteModifiers<TFieldName>;
+  modifiers: TInternalModifiers<TFieldName>;
+};
+
+export type TInternalModifiers<F extends TFieldName = TFieldName> = Omit<
+  SuiteModifiers<F>,
+  'onlyGroup' | 'skipGroup'
+> & {
+  onlyGroup: Set<string>;
+  skipGroup: Set<string>;
 };
 
 export function useCurrentTest(msg?: string) {

--- a/packages/vest/src/core/context/SuiteContext.ts
+++ b/packages/vest/src/core/context/SuiteContext.ts
@@ -15,7 +15,14 @@ export const SuiteContext = createCascade<CTXType>((ctxRef, parentContext) => {
     {
       inclusion: {},
       mode: tinyState.createTinyState<Modes>(Modes.EAGER),
-      modifiers: { only: undefined, skip: undefined, skipGroup: undefined },
+      modifiers: {
+        only: undefined,
+        onlyGroup: undefined,
+        onlyGroupSet: undefined,
+        skip: undefined,
+        skipGroup: undefined,
+        skipGroupSet: undefined,
+      },
       schema: null,
       suiteParams: [],
     },

--- a/packages/vest/src/hooks/focused/useIsExcluded.ts
+++ b/packages/vest/src/hooks/focused/useIsExcluded.ts
@@ -1,7 +1,7 @@
 import { Nullable, dynamicValue, makeResult, Result } from 'vest-utils';
 import { TIsolate, Walker } from 'vestjs-runtime';
 
-import { useInclusion } from '../../core/context/SuiteContext';
+import { SuiteContext, useInclusion } from '../../core/context/SuiteContext';
 import { TIsolateTest } from '../../core/isolate/IsolateTest/IsolateTest';
 import { VestTest } from '../../core/isolate/IsolateTest/VestTest';
 import { useIsExcludedIndividually } from '../../isolates/skipWhen';
@@ -25,21 +25,40 @@ function useClosestMatchingFocus(
 }
 
 export function useIsExcluded(testObject: TIsolateTest): boolean {
-  const { fieldName } = VestTest.getData(testObject);
-
   if (useIsExcludedIndividually()) return true;
-  const inclusion = useInclusion();
+
+  if (useIsExcludedByGroup(testObject)) return true;
+
+  return useIsExcludedByField(testObject);
+}
+
+function useIsExcludedByGroup(testObject: TIsolateTest): boolean {
+  const groupName = VestTest.getGroupName(testObject);
+  const { modifiers } = SuiteContext.useX();
+
+  // If `onlyGroup` is applied, ANY test outside of a group is excluded.
+  return !!modifiers.onlyGroupSet && !groupName;
+}
+
+function useIsExcludedByField(testObject: TIsolateTest): boolean {
   const focusMatch = useClosestMatchingFocus(testObject).unwrap();
+
   // if test is skipped
   // no need to proceed
   if (FocusSelectors.isSkipFocused(focusMatch).unwrap()) return true;
-  const isTestIncluded = FocusSelectors.isOnlyFocused(focusMatch).unwrap();
-  // if field is only'ed
-  if (isTestIncluded) return false;
 
+  // if field is only'ed
+  if (FocusSelectors.isOnlyFocused(focusMatch).unwrap()) return false;
+
+  return useIsExcludedByImplicitOnly(testObject);
+}
+
+function useIsExcludedByImplicitOnly(testObject: TIsolateTest): boolean {
   // If there is _ANY_ `only`ed test (and we already know this one isn't) return true
   if (useHasOnliedTests(testObject)) {
     // Check if inclusion rules for this field (`include` hook)
+    const { fieldName } = VestTest.getData(testObject);
+    const inclusion = useInclusion();
     return !dynamicValue(inclusion[fieldName], testObject);
   }
 

--- a/packages/vest/src/hooks/focused/useIsExcluded.ts
+++ b/packages/vest/src/hooks/focused/useIsExcluded.ts
@@ -14,7 +14,6 @@ import { useIsExcludedIndividually } from '../../isolates/skipWhen';
 
 import { FocusSelectors, TIsolateFocused } from './focused';
 import { useHasOnliedTests } from './useHasOnliedTests';
-//Checks whether a certain test profile excluded by any of the exclusion groups.
 
 function useClosestMatchingFocus(
   testObject: TIsolateTest,
@@ -30,6 +29,17 @@ function useClosestMatchingFocus(
   );
 }
 
+/**
+ * Checks whether a specific test profile should be excluded by any of the exclusion conditions.
+ *
+ * Evaluates in order:
+ * 1. `skipWhen` rule.
+ * 2. Group targeting (`onlyGroup` excluding top level tests).
+ * 3. Field targeting (`only` / `skip`).
+ *
+ * @param {TIsolateTest} testObject - The test node to evaluate.
+ * @returns {boolean} `true` if the test should jump straight to a skipped status.
+ */
 export function useIsExcluded(testObject: TIsolateTest): boolean {
   if (useIsExcludedIndividually()) return true;
 
@@ -38,6 +48,17 @@ export function useIsExcluded(testObject: TIsolateTest): boolean {
   return useIsExcludedByField(testObject);
 }
 
+/**
+ * Checks if a specific test should be excluded because it does not belong to a targeted group.
+ *
+ * When `suite.focus({ onlyGroup: 'groupName' })` is used, ANY test that is NOT inside
+ * the targeted group(s) must be skipped. This function specifically handles tests
+ * that have NO group at all (top-level tests). Tests inside other groups are handled
+ * collectively at the group isolate level in `group.ts`.
+ *
+ * @param {TIsolateTest} testObject - The test node to evaluate.
+ * @returns {boolean} `true` if the test is outside of `onlyGroup` targeting.
+ */
 function useIsExcludedByGroup(testObject: TIsolateTest): boolean {
   const groupName = VestTest.getGroupName(testObject);
   const { modifiers } = SuiteContext.useX();

--- a/packages/vest/src/hooks/focused/useIsExcluded.ts
+++ b/packages/vest/src/hooks/focused/useIsExcluded.ts
@@ -1,4 +1,10 @@
-import { Nullable, dynamicValue, makeResult, Result } from 'vest-utils';
+import {
+  Nullable,
+  dynamicValue,
+  makeResult,
+  Result,
+  isNotEmptySet,
+} from 'vest-utils';
 import { TIsolate, Walker } from 'vestjs-runtime';
 
 import { SuiteContext, useInclusion } from '../../core/context/SuiteContext';
@@ -37,7 +43,7 @@ function useIsExcludedByGroup(testObject: TIsolateTest): boolean {
   const { modifiers } = SuiteContext.useX();
 
   // If `onlyGroup` is applied, ANY test outside of a group is excluded.
-  return !!modifiers.onlyGroupSet && !groupName;
+  return isNotEmptySet(modifiers.onlyGroup) && !groupName;
 }
 
 function useIsExcludedByField(testObject: TIsolateTest): boolean {

--- a/packages/vest/src/isolates/group.ts
+++ b/packages/vest/src/isolates/group.ts
@@ -1,4 +1,4 @@
-import { CB, makeBrand } from 'vest-utils';
+import { CB, makeBrand, isNotEmptySet } from 'vest-utils';
 import { TIsolate } from 'vestjs-runtime';
 
 import { SuiteContext } from '../core/context/SuiteContext';
@@ -50,12 +50,18 @@ function shouldSkipGroup(groupName: string): boolean {
   const { modifiers } = SuiteContext.useX();
 
   // 1. Destructive block-list takes absolute precedence
-  if (modifiers.skipGroupSet && modifiers.skipGroupSet.has(groupName)) {
+  if (
+    isNotEmptySet(modifiers.skipGroup) &&
+    modifiers.skipGroup.has(groupName)
+  ) {
     return true;
   }
 
   // 2. Constructive allow-list pruning
-  if (modifiers.onlyGroupSet && !modifiers.onlyGroupSet.has(groupName)) {
+  if (
+    isNotEmptySet(modifiers.onlyGroup) &&
+    !modifiers.onlyGroup.has(groupName)
+  ) {
     return true;
   }
 

--- a/packages/vest/src/isolates/group.ts
+++ b/packages/vest/src/isolates/group.ts
@@ -43,8 +43,16 @@ export function group(
 }
 
 /**
- * Checks whether the given group name is targeted for skipping by the
- * current suite run's `skipGroup` modifier (set via `suite.focus()`).
+ * Evaluates whether an entire group should be skipped based on `suite.focus()` modifiers.
+ *
+ * This function enforces the precedence rules: `skipGroup` > `onlyGroup`.
+ *
+ * 1. If `skipGroup` contains the group name, it is unconditionally skipped (destructive block-list).
+ * 2. If `onlyGroup` is active (has items), and the group name is NOT in it, it is skipped (constructive allow-list).
+ * 3. Otherwise, the group is allowed to run.
+ *
+ * @param {string} groupName - The name of the group being evaluated.
+ * @returns {boolean} `true` if the group should be skipped, `false` otherwise.
  */
 function shouldSkipGroup(groupName: string): boolean {
   const { modifiers } = SuiteContext.useX();

--- a/packages/vest/src/isolates/group.ts
+++ b/packages/vest/src/isolates/group.ts
@@ -48,7 +48,18 @@ export function group(
  */
 function shouldSkipGroup(groupName: string): boolean {
   const { modifiers } = SuiteContext.useX();
-  return modifiers.skipGroupSet ? modifiers.skipGroupSet.has(groupName) : false;
+
+  // 1. Destructive block-list takes absolute precedence
+  if (modifiers.skipGroupSet && modifiers.skipGroupSet.has(groupName)) {
+    return true;
+  }
+
+  // 2. Constructive allow-list pruning
+  if (modifiers.onlyGroupSet && !modifiers.onlyGroupSet.has(groupName)) {
+    return true;
+  }
+
+  return false;
 }
 
 export type TIsolateGroup<G extends TGroupName = TGroupName> = TVestIsolate<{

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -114,14 +114,6 @@ type AfterMethods<
 export type SuiteModifiers<F extends TFieldName> = {
   only?: FieldExclusion<F> | FieldExclusion<string>;
   onlyGroup?: string | string[];
-  /**
-   * @internal
-   */
-  onlyGroupSet?: Set<string>;
   skip?: FieldExclusion<F> | FieldExclusion<string>;
   skipGroup?: string | string[];
-  /**
-   * @internal
-   */
-  skipGroupSet?: Set<string>;
 };

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -113,6 +113,11 @@ type AfterMethods<
  */
 export type SuiteModifiers<F extends TFieldName> = {
   only?: FieldExclusion<F> | FieldExclusion<string>;
+  onlyGroup?: string | string[];
+  /**
+   * @internal
+   */
+  onlyGroupSet?: Set<string>;
   skip?: FieldExclusion<F> | FieldExclusion<string>;
   skipGroup?: string | string[];
   /**

--- a/packages/vest/src/suite/__tests__/focus.test.ts
+++ b/packages/vest/src/suite/__tests__/focus.test.ts
@@ -539,6 +539,52 @@ describe('suite.focus: onlyGroup', () => {
       expect(cb3).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('extensive top-level test exclusion', () => {
+    it('should skip top-level tests even when they share the same field name as a test inside an onlyGroup', () => {
+      const topCb = vi.fn(() => false);
+      const groupCb = vi.fn(() => false);
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+
+        // Same field name outside the group
+        vest.test('shared_field', topCb);
+
+        vest.group('groupA', () => {
+          // Same field name inside the group
+          vest.test('shared_field', groupCb);
+        });
+      });
+
+      const res = suite.focus({ onlyGroup: 'groupA' }).run();
+
+      expect(res.groups.groupA.shared_field.testCount).toBe(1);
+      expect(res.tests.shared_field?.testCount ?? 0).toBe(1); // the group test gets aggregated here too, but we verify cb executions
+      expect(topCb).not.toHaveBeenCalled();
+      expect(groupCb).toHaveBeenCalledTimes(1);
+    });
+
+    it('should skip top-level tests even if `only` explicitly includes their field name', () => {
+      const topCb = vi.fn(() => false);
+      const groupCb = vi.fn(() => false);
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+
+        vest.test('explicit_field', topCb);
+
+        vest.group('groupA', () => {
+          vest.test('explicit_field', groupCb);
+        });
+      });
+
+      // field is only'd, but group restricts to 'groupA'
+      // Top level test for explicit_field should STILL not run
+      suite.focus({ only: 'explicit_field', onlyGroup: 'groupA' }).run();
+
+      expect(topCb).not.toHaveBeenCalled();
+      expect(groupCb).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe('Four-Way Scope Precedence: only, skip, onlyGroup, skipGroup', () => {

--- a/packages/vest/src/suite/__tests__/focus.test.ts
+++ b/packages/vest/src/suite/__tests__/focus.test.ts
@@ -489,3 +489,111 @@ describe('suite.focus: skipGroup', () => {
     });
   });
 });
+
+describe('suite.focus: onlyGroup', () => {
+  describe('single group & top level tests', () => {
+    it('should run only tests in the specified group, skipping other groups and top-level tests', () => {
+      const cb1 = vi.fn(() => false);
+      const cb2 = vi.fn(() => false);
+      const cb3 = vi.fn(() => false);
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+
+        vest.group('groupA', () => vest.test('field_1', cb1));
+        vest.group('groupB', () => vest.test('field_2', cb2));
+        vest.test('field_3', cb3); // Top level test
+      });
+
+      const res = suite.focus({ onlyGroup: 'groupA' }).run();
+
+      expect(res.groups.groupA.field_1.testCount).toBe(1);
+      expect((res.groups.groupB as any)?.field_2?.testCount ?? 0).toBe(0);
+      expect(res.tests.field_3?.testCount ?? 0).toBe(0); // Top level test must skip
+
+      expect(cb1).toHaveBeenCalledTimes(1);
+      expect(cb2).not.toHaveBeenCalled();
+      expect(cb3).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('multiple groups', () => {
+    it('should run tests in all specified groups when passed as array', () => {
+      const cb1 = vi.fn(() => false);
+      const cb2 = vi.fn(() => false);
+      const cb3 = vi.fn(() => false);
+      const suite = vest.create(() => {
+        vest.mode(vest.Modes.ALL);
+        vest.group('groupA', () => vest.test('field_1', cb1));
+        vest.group('groupB', () => vest.test('field_2', cb2));
+        vest.group('groupC', () => vest.test('field_3', cb3));
+      });
+
+      const res = suite.focus({ onlyGroup: ['groupA', 'groupC'] }).run();
+
+      expect(res.groups.groupA.field_1.testCount).toBe(1);
+      expect(res.groups.groupC.field_3.testCount).toBe(1);
+      expect((res.groups.groupB as any)?.field_2?.testCount ?? 0).toBe(0);
+
+      expect(cb1).toHaveBeenCalledTimes(1);
+      expect(cb2).not.toHaveBeenCalled();
+      expect(cb3).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('Four-Way Scope Precedence: only, skip, onlyGroup, skipGroup', () => {
+  it('should enforce that skip constraints (skip, skipGroup) strictly override include constraints (only, onlyGroup)', () => {
+    const cbA1 = vi.fn(() => false);
+    const cbA2 = vi.fn(() => false);
+    const cbB1 = vi.fn(() => false);
+    const cbC1 = vi.fn(() => false);
+    const cbTop = vi.fn(() => false);
+
+    const suite = vest.create(() => {
+      vest.mode(vest.Modes.ALL);
+
+      // G_A is onlyGroup'd but also skipGroup'd -> skip overrides only
+      vest.group('groupA', () => {
+        vest.test('field_1', cbA1);
+        vest.test('field_2', cbA2);
+      });
+
+      // G_B is onlyGroup'd. field_1 is only'd, field_2 is skip'd
+      vest.group('groupB', () => {
+        vest.test('field_1', cbB1);
+        vest.test('field_2', cbB1);
+      });
+
+      // G_C is not in onlyGroup -> should skip entirely
+      vest.group('groupC', () => vest.test('field_1', cbC1));
+
+      // Top level tests -> should skip because onlyGroup is active
+      vest.test('field_1', cbTop);
+    });
+
+    const res = suite
+      .focus({
+        onlyGroup: ['groupA', 'groupB'],
+        skipGroup: 'groupA',
+        only: 'field_1',
+        skip: 'field_2',
+      })
+      .run();
+
+    // groupA skipped entirely due to skipGroup > onlyGroup
+    expect(cbA1).not.toHaveBeenCalled();
+    expect(cbA2).not.toHaveBeenCalled();
+
+    // groupC skipped due to not being in onlyGroup
+    expect(cbC1).not.toHaveBeenCalled();
+
+    // top-level skipped due to onlyGroup
+    expect(cbTop).not.toHaveBeenCalled();
+
+    // groupB evaluation:
+    // field_1 runs (onlyGroup matches, only matches)
+    expect(res.groups.groupB.field_1.testCount).toBe(1);
+    // field_2 skips (onlyGroup matches, but skip > only)
+    expect((res.groups.groupB as any)?.field_2?.testCount ?? 0).toBe(0);
+  });
+});

--- a/packages/vest/src/suite/__tests__/focus.test.ts
+++ b/packages/vest/src/suite/__tests__/focus.test.ts
@@ -546,6 +546,7 @@ describe('Four-Way Scope Precedence: only, skip, onlyGroup, skipGroup', () => {
     const cbA1 = vi.fn(() => false);
     const cbA2 = vi.fn(() => false);
     const cbB1 = vi.fn(() => false);
+    const cbB2 = vi.fn(() => false); // New callback for clarity
     const cbC1 = vi.fn(() => false);
     const cbTop = vi.fn(() => false);
 
@@ -561,7 +562,7 @@ describe('Four-Way Scope Precedence: only, skip, onlyGroup, skipGroup', () => {
       // G_B is onlyGroup'd. field_1 is only'd, field_2 is skip'd
       vest.group('groupB', () => {
         vest.test('field_1', cbB1);
-        vest.test('field_2', cbB1);
+        vest.test('field_2', cbB2); // Use separate callback
       });
 
       // G_C is not in onlyGroup -> should skip entirely
@@ -593,7 +594,10 @@ describe('Four-Way Scope Precedence: only, skip, onlyGroup, skipGroup', () => {
     // groupB evaluation:
     // field_1 runs (onlyGroup matches, only matches)
     expect(res.groups.groupB.field_1.testCount).toBe(1);
+    expect(cbB1).toHaveBeenCalledTimes(1);
+
     // field_2 skips (onlyGroup matches, but skip > only)
     expect((res.groups.groupB as any)?.field_2?.testCount ?? 0).toBe(0);
+    expect(cbB2).not.toHaveBeenCalled();
   });
 });

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -48,12 +48,7 @@ function createSuite<
     function createSuiteInstance(): Result<Suite<F, G, T, S>> {
       const methods = useCreateSuiteMethods<F, G, T, S>(
         suiteCallbackResult as any,
-        {
-          only: undefined,
-          onlyGroup: undefined,
-          skip: undefined,
-          skipGroup: undefined,
-        },
+        {},
         VestBus.subscribe,
         schema,
       );

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -50,6 +50,7 @@ function createSuite<
         suiteCallbackResult as any,
         {
           only: undefined,
+          onlyGroup: undefined,
           skip: undefined,
           skipGroup: undefined,
         },

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -51,7 +51,7 @@ export function useCreateSuiteRunner<
         {
           suiteParams: args as Parameters<T>,
           schema,
-          modifiers: useEnhancedModifiers(modifiers),
+          modifiers: useTransformedModifiers(modifiers),
         },
         () => {
           useEmit('SUITE_RUN_STARTED');
@@ -77,20 +77,6 @@ export function useCreateSuiteRunner<
   };
 }
 
-function useEnhancedModifiers<F extends TFieldName>(
-  modifiers: SuiteModifiers<F>,
-): SuiteModifiers<F> {
-  return {
-    ...modifiers,
-    onlyGroupSet: modifiers.onlyGroup
-      ? new Set(asArray(modifiers.onlyGroup))
-      : undefined,
-    skipGroupSet: modifiers.skipGroup
-      ? new Set(asArray(modifiers.skipGroup))
-      : undefined,
-  };
-}
-
 function useRunSuiteCallback<
   F extends TFieldName,
   G extends TGroupName,
@@ -111,7 +97,7 @@ function useRunSuiteCallback<
     // the group's callback via the modifiers stored in SuiteContext.
     only(modifiers.only);
     skip(modifiers.skip);
-    (suiteCallback as any)(...(args as Parameters<T>));
+    (suiteCallback as any)(...args);
 
     IsolateReorderable(
       runSchemaValidation(schema, modifiers, args[0]),
@@ -122,6 +108,16 @@ function useRunSuiteCallback<
     );
     useEmit('SUITE_CALLBACK_RUN_FINISHED');
     return useCreateSuiteResult<F, G, S>(schema, args[0]);
+  };
+}
+
+function useTransformedModifiers<F extends TFieldName>(
+  modifiers: SuiteModifiers<F>,
+) {
+  return {
+    ...modifiers,
+    onlyGroup: new Set(modifiers.onlyGroup ? asArray(modifiers.onlyGroup) : []),
+    skipGroup: new Set(modifiers.skipGroup ? asArray(modifiers.skipGroup) : []),
   };
 }
 

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -44,53 +44,84 @@ export function useCreateSuiteRunner<
       : [data: InferSchemaData<S>, ...args: any[]]
   ): SuiteResult<F, G, S> {
     const { resolve, promise } = withResolvers<SuiteResult<F, G, S>>();
+
     return assign(
       promise,
       SuiteContext.run(
         {
           suiteParams: args as Parameters<T>,
           schema,
-          modifiers: {
-            ...modifiers,
-            skipGroupSet: modifiers.skipGroup
-              ? new Set(asArray(modifiers.skipGroup))
-              : undefined,
-          },
+          modifiers: useEnhancedModifiers(modifiers),
         },
         () => {
           useEmit('SUITE_RUN_STARTED');
 
-          function resolver() {
+          const useResolver = () => {
             const result = useCreateSuiteResult<F, G, S>(schema, args[0]);
             resolve(result);
             return result;
-          }
+          };
 
-          const output = IsolateSuite(() => {
-            // Apply field-level focus modifiers. These create transient Focused
-            // isolates at the suite root that affect all tests in the suite.
-            // `only` restricts the run to matching fields; `skip` excludes them.
-            // `skipGroup` is handled separately inside `group()` — when a group
-            // with a matching name is entered, it injects `skip(true)` into
-            // the group's callback via the modifiers stored in SuiteContext.
-            only(modifiers.only);
-            skip(modifiers.skip);
-            (suiteCallback as any)(...(args as Parameters<T>));
-
-            IsolateReorderable(
-              runSchemaValidation(schema, modifiers, args[0]),
-              undefined,
-              {
-                tests: [],
-              },
-            );
-            useEmit('SUITE_CALLBACK_RUN_FINISHED');
-            return useCreateSuiteResult<F, G, S>(schema, args[0]);
-          }, resolver);
-          return output;
+          return IsolateSuite(
+            useRunSuiteCallback<F, G, T, S>(
+              suiteCallback,
+              modifiers,
+              args,
+              schema,
+            ),
+            useResolver,
+          );
         },
       ).output,
     );
+  };
+}
+
+function useEnhancedModifiers<F extends TFieldName>(
+  modifiers: SuiteModifiers<F>,
+): SuiteModifiers<F> {
+  return {
+    ...modifiers,
+    onlyGroupSet: modifiers.onlyGroup
+      ? new Set(asArray(modifiers.onlyGroup))
+      : undefined,
+    skipGroupSet: modifiers.skipGroup
+      ? new Set(asArray(modifiers.skipGroup))
+      : undefined,
+  };
+}
+
+function useRunSuiteCallback<
+  F extends TFieldName,
+  G extends TGroupName,
+  T extends CB = CB,
+  S extends TSchema = undefined,
+>(
+  suiteCallback: SuiteCallbackWithSchema<S, T>,
+  modifiers: SuiteModifiers<F>,
+  args: any[],
+  schema?: S,
+) {
+  return () => {
+    // Apply field-level focus modifiers. These create transient Focused
+    // isolates at the suite root that affect all tests in the suite.
+    // `only` restricts the run to matching fields; `skip` excludes them.
+    // `skipGroup` is handled separately inside `group()` — when a group
+    // with a matching name is entered, it injects `skip(true)` into
+    // the group's callback via the modifiers stored in SuiteContext.
+    only(modifiers.only);
+    skip(modifiers.skip);
+    (suiteCallback as any)(...(args as Parameters<T>));
+
+    IsolateReorderable(
+      runSchemaValidation(schema, modifiers, args[0]),
+      undefined,
+      {
+        tests: [],
+      },
+    );
+    useEmit('SUITE_CALLBACK_RUN_FINISHED');
+    return useCreateSuiteResult<F, G, S>(schema, args[0]);
   };
 }
 

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -28,6 +28,7 @@ import { SuiteModifiers, SuiteCallbackWithSchema } from './SuiteTypes';
  * @returns {Function} - The suite runner function.
  */
 
+// eslint-disable-next-line max-lines-per-function
 export function useCreateSuiteRunner<
   F extends TFieldName,
   G extends TGroupName,
@@ -38,56 +39,58 @@ export function useCreateSuiteRunner<
   modifiers: SuiteModifiers<F>,
   schema?: S,
 ) {
+  const transformedModifiers = useTransformedModifiers(modifiers);
   return function runSuite(
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
   ): SuiteResult<F, G, S> {
     const { resolve, promise } = withResolvers<SuiteResult<F, G, S>>();
-
     return assign(
       promise,
       SuiteContext.run(
         {
           suiteParams: args as Parameters<T>,
           schema,
-          modifiers: useTransformedModifiers(modifiers),
+          modifiers: transformedModifiers,
         },
         () => {
           useEmit('SUITE_RUN_STARTED');
-
           const useResolver = () => {
             const result = useCreateSuiteResult<F, G, S>(schema, args[0]);
-            resolve(result);
+            if (!result.isPending()) {
+              resolve(result);
+            }
             return result;
           };
-
           return IsolateSuite(
-            useRunSuiteCallback<F, G, T, S>(
-              suiteCallback,
-              modifiers,
+            useRunSuiteCallback<F, T, S>({
               args,
+              modifiers: transformedModifiers,
               schema,
-            ),
+              suiteCallback,
+              useResolver,
+            }),
             useResolver,
-          );
+          ).output;
         },
-      ).output,
+      ),
     );
   };
 }
 
 function useRunSuiteCallback<
   F extends TFieldName,
-  G extends TGroupName,
   T extends CB = CB,
   S extends TSchema = undefined,
->(
-  suiteCallback: SuiteCallbackWithSchema<S, T>,
-  modifiers: SuiteModifiers<F>,
-  args: any[],
-  schema?: S,
-) {
+>(params: {
+  args: any[];
+  modifiers: ReturnType<typeof useTransformedModifiers<F>>;
+  schema: S | undefined;
+  suiteCallback: SuiteCallbackWithSchema<S, T>;
+  useResolver: () => SuiteResult<F, any, S>;
+}) {
+  const { args, modifiers, schema, suiteCallback, useResolver } = params;
   return () => {
     // Apply field-level focus modifiers. These create transient Focused
     // isolates at the suite root that affect all tests in the suite.
@@ -107,7 +110,7 @@ function useRunSuiteCallback<
       },
     );
     useEmit('SUITE_CALLBACK_RUN_FINISHED');
-    return useCreateSuiteResult<F, G, S>(schema, args[0]);
+    return useResolver();
   };
 }
 
@@ -124,7 +127,11 @@ function useTransformedModifiers<F extends TFieldName>(
 function runSchemaValidation<
   F extends TFieldName,
   S extends TSchema = undefined,
->(schema: S | undefined, modifiers: SuiteModifiers<F>, data: any) {
+>(
+  schema: S | undefined,
+  modifiers: ReturnType<typeof useTransformedModifiers<F>>,
+  data: any,
+) {
   return () => {
     if (!shouldRunSchema(schema, modifiers)) return;
 
@@ -138,6 +145,6 @@ function runSchemaValidation<
   };
 }
 
-function shouldRunSchema(schema: any, modifiers: SuiteModifiers<any>): boolean {
+function shouldRunSchema(schema: any, modifiers: any): boolean {
   return !modifiers.only && !!schema && isFunction(schema.run);
 }

--- a/packages/vestjs-runtime/src/Isolate/IsolateRegistry.ts
+++ b/packages/vestjs-runtime/src/Isolate/IsolateRegistry.ts
@@ -1,4 +1,4 @@
-import { Nullable } from 'vest-utils';
+import { Nullable, isEmptySet, isNotEmptySet } from 'vest-utils';
 
 import { useAvailableRoot } from '../VestRuntime';
 import { TIsolate } from './Isolate';
@@ -60,7 +60,7 @@ export function useGetFromRegistry(
  * Checks if the registry contains any isolates for a given category and optional key.
  */
 export function useHasFromRegistry(category: string, key?: string): boolean {
-  return useGetFromRegistry(category, key).size > 0;
+  return isNotEmptySet(useGetFromRegistry(category, key) as Set<any>);
 }
 
 /**
@@ -160,7 +160,7 @@ function useRemoveNodeFromRegistryIndex(
 
   if (entry) {
     entry.delete(isolate);
-    if (entry.size === 0) {
+    if (isEmptySet(entry)) {
       index.delete(indexKey);
     }
   }

--- a/packages/vestjs-runtime/src/Isolate/IsolateRegistry.ts
+++ b/packages/vestjs-runtime/src/Isolate/IsolateRegistry.ts
@@ -60,7 +60,7 @@ export function useGetFromRegistry(
  * Checks if the registry contains any isolates for a given category and optional key.
  */
 export function useHasFromRegistry(category: string, key?: string): boolean {
-  return isNotEmptySet(useGetFromRegistry(category, key) as Set<any>);
+  return isNotEmptySet(useGetFromRegistry(category, key));
 }
 
 /**

--- a/vx/scripts/release/packagesToRelease.ts
+++ b/vx/scripts/release/packagesToRelease.ts
@@ -1,3 +1,5 @@
+import { isNotEmptySet, isEmptySet } from 'vest-utils';
+
 import { buildDepsTree, sortDependencies, type DepTree } from './depsTree.js';
 import listAllChangedPackages from './github/listAllChangedPackages.js';
 
@@ -12,7 +14,7 @@ function packagesToRelease(): {
 } {
   const deps = buildDepsTree();
   const changedPackagesSet = listAllChangedPackages();
-  const isTopLevelChange = changedPackagesSet.size === 0;
+  const isTopLevelChange = isEmptySet(changedPackagesSet);
   const changedPackagesArray = Array.from(changedPackagesSet);
   const release = new Set<string>();
   const unchangedDependents = new Set<string>();
@@ -100,7 +102,7 @@ function processReleaseQueue(
 }
 
 function logUnchangedDependents(unchangedDependents: Set<string>): void {
-  if (unchangedDependents.size) {
+  if (isNotEmptySet(unchangedDependents)) {
     logger.info(
       `🧱 The following packages did not change, but will be released because they are indirectly impacted by changes: \n  - ${[
         ...unchangedDependents,

--- a/vx/util/pathsPerPackage.ts
+++ b/vx/util/pathsPerPackage.ts
@@ -1,5 +1,7 @@
 import { createRequire } from 'module';
-import path from 'path';
+import { basename, join } from 'path';
+
+import { isNotEmptySet } from 'vest-utils';
 
 import { dir } from 'vx/opts.js';
 import vxPath from 'vx/vxPath.js';
@@ -31,9 +33,9 @@ const matches = glob.sync(vxPath.rel(vxPath.packageSrc('*', '**/*.ts')), {
 });
 
 const groupedMatches = matches.reduce<GroupedMatches>((acc, relative) => {
-  const name = path.basename(relative, '.ts');
+  const name = basename(relative, '.ts');
   const packageName = vxPath.packageNameFromPath(relative);
-  const absolute = path.join(vxPath.ROOT_PATH, relative);
+  const absolute = join(vxPath.ROOT_PATH, relative);
 
   const moduleData = {
     absolute,
@@ -88,7 +90,7 @@ function findDuplicates(): void {
   for (const [packageName, { duplicates }] of Object.entries(
     duplicatesContainer,
   )) {
-    if (duplicates.size > 0) {
+    if (isNotEmptySet(duplicates)) {
       duplicatesPerPackage.push(
         `${packageName}: ${[...duplicates].map(dup => `\n   -${dup}`).join('')}`,
       );

--- a/website/versioned_docs/version-next/recipes/focus_skipgroup_recipes.md
+++ b/website/versioned_docs/version-next/recipes/focus_skipgroup_recipes.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 3
-title: Recipe - focus({ skip / skipGroup }) patterns
+title: Recipe - focus({ skip / skipGroup / onlyGroup }) patterns
 description: Practical patterns for combining suite.focus modifiers, with emphasis on skip vs skipGroup.
 keywords: [Recipe, focus, skip, skipGroup, only, Vest]
 ---
 
-# `focus({ skip / skipGroup })` Patterns
+# `focus({ skip / skipGroup / onlyGroup })` Patterns
 
 This recipe clarifies a common source of confusion:
 

--- a/website/versioned_docs/version-next/recipes/focus_skipgroup_recipes.md
+++ b/website/versioned_docs/version-next/recipes/focus_skipgroup_recipes.md
@@ -58,6 +58,14 @@ suite.focus({ skip: 'password', skipGroup: 'billing' }).run(formData);
 
 This skips all `password` tests globally and all tests in `billing` group.
 
+## Pattern 6: Validating a Group's Fields only (`onlyGroup`)
+
+```js
+// Validate ONLY the 'step1' group.
+// All other groups AND top-level tests are skipped.
+suite.focus({ onlyGroup: 'step1' }).run(formData);
+```
+
 ## See also
 
 - [Focused Updates](../writing_your_suite/focused_updates)

--- a/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
+++ b/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
@@ -327,4 +327,4 @@ suite.focus({ onlyGroup: 'groupA' }).run(formData); // ✅
 - [Including and Excluding Fields](./including_and_excluding/skip_and_only) - Using `only()` and `skip()` inside suites
 - [Include](./including_and_excluding/include) - Link related fields to run together
 - [Test Groups](../writing_tests/advanced_test_features/grouping_tests) - Grouping tests together
-- [focus({ skip / skipGroup }) Patterns](../recipes/focus_skipgroup_recipes) - Practical recipes for choosing and combining focus modifiers
+- [`focus({ skip / skipGroup })` Patterns](../recipes/focus_skipgroup_recipes) - Practical recipes for choosing and combining focus modifiers

--- a/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
+++ b/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
@@ -335,4 +335,4 @@ suite.focus({ onlyGroup: 'groupA' }).run(formData); // ✅
 - [Including and Excluding Fields](./including_and_excluding/skip_and_only) - Using `only()` and `skip()` inside suites
 - [Include](./including_and_excluding/include) - Link related fields to run together
 - [Test Groups](../writing_tests/advanced_test_features/grouping_tests) - Grouping tests together
-- [`focus({ skip / skipGroup })` Patterns](../recipes/focus_skipgroup_recipes) - Practical recipes for choosing and combining focus modifiers
+- [`focus({ skip / skipGroup / onlyGroup })` Patterns](../recipes/focus_skipgroup_recipes) - Practical recipes for choosing and combining focus modifiers

--- a/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
+++ b/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
@@ -49,6 +49,10 @@ suite.focus({ skip: ['promoCode', 'referralCode'] }).run(formData);
 
 Use `focus({ skipGroup: ... })` to skip all tests inside a named group. Tests outside the group run normally.
 
+### Running Only Entire Groups
+
+Use `focus({ onlyGroup: ... })` to run _only_ tests inside a named group. Tests outside the group (including top-level tests) are skipped.
+
 ### `skip` vs `skipGroup`
 
 Both modifiers exclude tests, but they target different scopes:
@@ -107,7 +111,20 @@ You can combine `only`, `skip`, and `skipGroup` in a single `focus()` call:
 ```javascript
 // Only validate 'username', and also skip the 'signUp' group
 suite.focus({ only: 'username', skipGroup: 'signUp' }).run(formData);
+// Only validate 'username', and also skip the 'signUp' group
+suite.focus({ only: 'username', skipGroup: 'signUp' }).run(formData);
 ```
+
+### Focus Modifier Precedence
+
+When multiple modifiers are used, they are evaluated in the following order of precedence (highest to lowest):
+
+1. `skipGroup` (Destructive): Explicitly skipped groups are always skipped.
+2. `onlyGroup` (Constructive): If present, restricts execution to specific groups. Top-level tests are excluded.
+3. `skip` (Destructive): Explicitly skipped fields are skipped, even if they match an allowed group.
+4. `only` (Constructive): If present, restricts execution to specific fields within the allowed groups.
+
+> **Note**: A test is run only if it passes _all_ active filters. For example, if you use `onlyGroup: 'A'` and `skip: 'field1'`, `field1` inside `Group A` will be skipped.
 
 ## Fluent Chain API
 
@@ -241,6 +258,7 @@ function useFormValidation(initialData) {
 | ----------- | -------------------- | --------------------------------------------------------- |
 | `only`      | `string \| string[]` | Run only the specified field(s). All others are excluded. |
 | `skip`      | `string \| string[]` | Skip the specified field(s). All others run as usual.     |
+| `onlyGroup` | `string \| string[]` | Run only tests inside the named group(s).                 |
 | `skipGroup` | `string \| string[]` | Skip all tests inside the named group(s).                 |
 
 ## Comparison: `suite.focus()` vs `only()`/`skip()`
@@ -303,6 +321,7 @@ suite.focus({ only: 'nonexistent' }).run(formData); // ❌ Type error
 suite.focus({ skip: 'email' }).run(formData); // ✅
 suite.focus({ skipGroup: 'myGroup' }).run(formData); // ✅
 suite.focus({ skipGroup: ['groupA', 'groupB'] }).run(formData); // ✅
+suite.focus({ onlyGroup: 'groupA' }).run(formData); // ✅
 ```
 
 ## Related

--- a/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
+++ b/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
@@ -53,6 +53,14 @@ Use `focus({ skipGroup: ... })` to skip all tests inside a named group. Tests ou
 
 Use `focus({ onlyGroup: ... })` to run _only_ tests inside a named group. Tests outside the group (including top-level tests) are skipped.
 
+```javascript
+// Run only tests declared inside group('signUp', ...)
+suite.focus({ onlyGroup: 'signUp' }).run(formData);
+
+// Run only tests inside multiple specified groups
+suite.focus({ onlyGroup: ['signIn', 'signUp'] }).run(formData);
+```
+
 ### `skip` vs `skipGroup`
 
 Both modifiers exclude tests, but they target different scopes:
@@ -252,12 +260,12 @@ function useFormValidation(initialData) {
 
 ## Focus Modifiers Reference
 
-| Modifier    | Type                 | Description                                               |
-| ----------- | -------------------- | --------------------------------------------------------- |
-| `only`      | `string \| string[]` | Run only the specified field(s). All others are excluded. |
-| `skip`      | `string \| string[]` | Skip the specified field(s). All others run as usual.     |
-| `onlyGroup` | `string \| string[]` | Run only tests inside the named group(s).                 |
-| `skipGroup` | `string \| string[]` | Skip all tests inside the named group(s).                 |
+| Modifier    | Type                 | Description                                                                         |
+| ----------- | -------------------- | ----------------------------------------------------------------------------------- |
+| `only`      | `string \| string[]` | Run only the specified field(s). All others are excluded.                           |
+| `skip`      | `string \| string[]` | Skip the specified field(s). All others run as usual.                               |
+| `onlyGroup` | `string \| string[]` | Run only tests inside the named group(s); top-level (ungrouped) tests are excluded. |
+| `skipGroup` | `string \| string[]` | Skip all tests inside the named group(s).                                           |
 
 ## Comparison: `suite.focus()` vs `only()`/`skip()`
 

--- a/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
+++ b/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
@@ -111,8 +111,6 @@ You can combine `only`, `skip`, and `skipGroup` in a single `focus()` call:
 ```javascript
 // Only validate 'username', and also skip the 'signUp' group
 suite.focus({ only: 'username', skipGroup: 'signUp' }).run(formData);
-// Only validate 'username', and also skip the 'signUp' group
-suite.focus({ only: 'username', skipGroup: 'signUp' }).run(formData);
 ```
 
 ### Focus Modifier Precedence


### PR DESCRIPTION
# `suite.focus({ onlyGroup })` Implementation Summary

## Overview

The `onlyGroup` modifier has been added to `suite.focus()`. This allows users to run tests _only_ within specified groups, treating all other groups and top-level tests as skipped.

## Changes

### Core Logic

- **`SuiteTypes`**: Added `onlyGroup` (public) to `SuiteModifiers`.
- **`SuiteContext` / `createSuite`**: Updated defaults to include `onlyGroup`.
- **`group.ts`**: Updated `shouldSkipGroup` to respect precedence: `skipGroup` (destructive) > `onlyGroup` (constructive).
- **`useIsExcluded.ts`**: Added logic to exclude top-level tests (tests without a group) when `onlyGroup` is active.

### Documentation

- Updated [Focused Updates](../website/versioned_docs/version-next/writing_your_suite/focused_updates.md) with API reference, precedence rules, and TypeScript examples.
- Updated [Recipes](../website/versioned_docs/version-next/recipes/focus_skipgroup_recipes.md) with a new pattern for `onlyGroup`.

### Tests

- Added comprehensive tests in `focus.test.ts` covering:
  - Single group inclusion.
  - Multiple group inclusion.
  - Exclusion of top-level tests.
  - Precedence rules (skip strictly overrides only).

## Precedence Rules

1. **`skipGroup`**: Strongest. If a group is skipped, it runs nothing.
2. **`onlyGroup`**: If present, limits the "universe" of runnable tests to specific groups. Top-level tests are excluded.
3. **`skip`**: Skips specific fields within allowed groups.
4. **`only`**: Runs specific fields within allowed groups.

## Verification

Tests were added to `packages/vest/src/suite/__tests__/focus.test.ts`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added onlyGroup modifier to run only tests within specified group(s); focus now honors precedence: skipGroup > onlyGroup > skip > only, including correct handling of top-level vs grouped tests.
  * Improved group/field inclusion performance via set-based modifiers.

* **Documentation**
  * Added docs, recipes, and guides showing onlyGroup usage, examples, and precedence rules.

* **Tests**
  * Added comprehensive tests for onlyGroup interactions with only, skipGroup, and skip.

* **Chores**
  * Added set-emptiness helpers and a benchmark suite for focus modifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->