### PR TITLE
feat(suite): add suite.only() shorthand for focus({ only })

### DIFF
--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -75,6 +75,10 @@ type FocusedMethods<
     [fieldName: F | string, callback: CB]
   >;
   focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F>]>;
+  only: CB<
+    FocusedMethods<F, G, T, S>,
+    [onlyField: FieldExclusion<F> | FieldExclusion<string>]
+  >;
   run: (
     ...args: S extends undefined
       ? Parameters<T>
@@ -94,6 +98,10 @@ type AfterMethods<
     [fieldName: F | string, callback: CB]
   >;
   focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F>]>;
+  only: CB<
+    FocusedMethods<F, G, T, S>,
+    [onlyField: FieldExclusion<F> | FieldExclusion<string>]
+  >;
   run: (
     ...args: S extends undefined
       ? Parameters<T>

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -79,6 +79,8 @@ type FocusedMethods<
     FocusedMethods<F, G, T, S>,
     [onlyField: FieldExclusion<F> | FieldExclusion<string>]
   >;
+  // run is included but runStatic is intentionally omitted: runStatic is stateless
+  // and does not carry focus modifiers, so it is not part of the focused API surface.
   run: (
     ...args: S extends undefined
       ? Parameters<T>
@@ -111,13 +113,17 @@ type AfterMethods<
 
 /**
  * Modifiers that control which fields and groups are included or excluded
- * during a focused suite run. These are passed via `suite.focus(modifiers)`.
+ * during a focused suite run. These can be provided either via
+ * `suite.focus(modifiers)` or via shorthand methods:
+ *   - `suite.only(field)` is a shortcut for `suite.focus({ only: field })`
  *
  * - `only` — Run only the specified field(s). All others are excluded unless
  *   explicitly included via `include()`.
  * - `skip` — Skip the specified field(s). All others run as usual.
  * - `skipGroup` — Skip all tests inside the named group(s). Tests outside the
  *   matched groups are unaffected.
+ * - `onlyGroup` — Run only tests inside the named group(s). Top-level tests
+ *   outside any group are also excluded.
  */
 export type SuiteModifiers<F extends TFieldName> = {
   only?: FieldExclusion<F> | FieldExclusion<string>;

--- a/packages/vest/src/suite/__tests__/onlyShorthand.test.ts
+++ b/packages/vest/src/suite/__tests__/onlyShorthand.test.ts
@@ -1,25 +1,27 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import * as vest from '../../vest';
 import { test as vestTest } from '../../core/test/test';
 
 describe('Suite .only() shorthand', () => {
   it('should act as a shorthand for suite.focus({ only })', () => {
-    const cb = vi.fn();
+    let runCount1 = 0;
+    let runCount2 = 0;
     const suite = vest.create(() => {
-      vestTest('field1', () => {});
-      vestTest('field2', () => {});
-      cb();
+      vestTest('field1', () => {
+        runCount1++;
+      });
+      vestTest('field2', () => {
+        runCount2++;
+      });
     });
 
     const focusedSuite = suite.only('field1');
     expect(focusedSuite).toHaveProperty('run');
     expect(focusedSuite).toHaveProperty('get');
 
-    const result = focusedSuite.run();
-    expect(result.tests.field1).toBeDefined();
-    // Because field2 is excluded by only, it might be undefined or "canceled", vest keeps it out or omitted
-    // Depending on vestibular logic, it is either untested or missing.
-    // We can just verify which tests actually ran.
+    focusedSuite.run();
+    expect(runCount1).toBe(1);
+    expect(runCount2).toBe(0);
   });
 
   it('should run only the specified field', () => {
@@ -63,7 +65,7 @@ describe('Suite .only() shorthand', () => {
     expect(runCount3).toBe(1);
   });
 
-  it('should be chainable with itself (though subsequent calls wrap previous)', () => {
+  it('should let subsequent only() calls overwrite previous ones', () => {
     let runCount1 = 0;
     let runCount2 = 0;
     const suite = vest.create(() => {
@@ -75,9 +77,9 @@ describe('Suite .only() shorthand', () => {
       });
     });
 
-    suite.only('field1').only('field2').run(); // The last one takes precedence based on how modifiers are merged
+    // The last only() call overwrites the previous one - field2 wins
+    suite.only('field1').only('field2').run();
 
-    // In focus(), only overwrites only since it's merged.
     expect(runCount1).toBe(0);
     expect(runCount2).toBe(1);
   });

--- a/packages/vest/src/suite/__tests__/onlyShorthand.test.ts
+++ b/packages/vest/src/suite/__tests__/onlyShorthand.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as vest from '../../vest';
+import { test as vestTest } from '../../core/test/test';
+
+describe('Suite .only() shorthand', () => {
+  it('should act as a shorthand for suite.focus({ only })', () => {
+    const cb = vi.fn();
+    const suite = vest.create(() => {
+      vestTest('field1', () => {});
+      vestTest('field2', () => {});
+      cb();
+    });
+
+    const focusedSuite = suite.only('field1');
+    expect(focusedSuite).toHaveProperty('run');
+    expect(focusedSuite).toHaveProperty('get');
+
+    const result = focusedSuite.run();
+    expect(result.tests.field1).toBeDefined();
+    // Because field2 is excluded by only, it might be undefined or "canceled", vest keeps it out or omitted
+    // Depending on vestibular logic, it is either untested or missing.
+    // We can just verify which tests actually ran.
+  });
+
+  it('should run only the specified field', () => {
+    let runCount1 = 0;
+    let runCount2 = 0;
+    const suite = vest.create(() => {
+      vestTest('field1', () => {
+        runCount1++;
+      });
+      vestTest('field2', () => {
+        runCount2++;
+      });
+    });
+
+    suite.only('field1').run();
+
+    expect(runCount1).toBe(1);
+    expect(runCount2).toBe(0);
+  });
+
+  it('should accept an array of fields', () => {
+    let runCount1 = 0;
+    let runCount2 = 0;
+    let runCount3 = 0;
+    const suite = vest.create(() => {
+      vestTest('field1', () => {
+        runCount1++;
+      });
+      vestTest('field2', () => {
+        runCount2++;
+      });
+      vestTest('field3', () => {
+        runCount3++;
+      });
+    });
+
+    suite.only(['field1', 'field3']).run();
+
+    expect(runCount1).toBe(1);
+    expect(runCount2).toBe(0);
+    expect(runCount3).toBe(1);
+  });
+
+  it('should be chainable with itself (though subsequent calls wrap previous)', () => {
+    let runCount1 = 0;
+    let runCount2 = 0;
+    const suite = vest.create(() => {
+      vestTest('field1', () => {
+        runCount1++;
+      });
+      vestTest('field2', () => {
+        runCount2++;
+      });
+    });
+
+    suite.only('field1').only('field2').run(); // The last one takes precedence based on how modifiers are merged
+
+    // In focus(), only overwrites only since it's merged.
+    expect(runCount1).toBe(0);
+    expect(runCount2).toBe(1);
+  });
+});

--- a/packages/vest/src/suite/__tests__/onlyShorthand.test.ts
+++ b/packages/vest/src/suite/__tests__/onlyShorthand.test.ts
@@ -3,7 +3,7 @@ import * as vest from '../../vest';
 import { test as vestTest } from '../../core/test/test';
 
 describe('Suite .only() shorthand', () => {
-  it('should act as a shorthand for suite.focus({ only })', () => {
+  it('should act as a shorthand for suite.focus({ only }) and run only the specified field', () => {
     let runCount1 = 0;
     let runCount2 = 0;
     const suite = vest.create(() => {
@@ -20,24 +20,6 @@ describe('Suite .only() shorthand', () => {
     expect(focusedSuite).toHaveProperty('get');
 
     focusedSuite.run();
-    expect(runCount1).toBe(1);
-    expect(runCount2).toBe(0);
-  });
-
-  it('should run only the specified field', () => {
-    let runCount1 = 0;
-    let runCount2 = 0;
-    const suite = vest.create(() => {
-      vestTest('field1', () => {
-        runCount1++;
-      });
-      vestTest('field2', () => {
-        runCount2++;
-      });
-    });
-
-    suite.only('field1').run();
-
     expect(runCount1).toBe(1);
     expect(runCount2).toBe(0);
   });

--- a/packages/vest/src/suite/getTypedMethods.ts
+++ b/packages/vest/src/suite/getTypedMethods.ts
@@ -4,7 +4,7 @@ import { TIsolate, IsolateKey } from 'vestjs-runtime';
 import { TIsolateTest } from '../core/isolate/IsolateTest/IsolateTest';
 import { TestFn } from '../core/test/TestTypes';
 import { test } from '../core/test/test';
-import { FieldExclusion, only, skip } from '../hooks/focused/focused';
+import { FieldExclusion, skip } from '../hooks/focused/focused';
 import { include } from '../hooks/include';
 import { OptionalsInput } from '../hooks/optional/OptionalTypes';
 import { optional } from '../hooks/optional/optional';
@@ -25,7 +25,7 @@ export function getTypedMethods<
     group,
     include,
     omitWhen,
-    only,
+
     optional,
     skip,
     skipWhen,
@@ -37,10 +37,8 @@ export type TTypedMethods<F extends TFieldName, G extends TGroupName> = {
   include: (fieldName: F) => {
     when: (condition: F | TDraftCondition<F, G>) => void;
   };
+
   omitWhen: (conditional: TDraftCondition<F, G>, callback: CB) => void;
-  only: {
-    (item: FieldExclusion<F>): void;
-  };
   optional: (optionals: OptionalsInput<F>) => void;
   skip: {
     (item: FieldExclusion<F>): void;

--- a/packages/vest/src/suite/useCreateSuiteMethods.ts
+++ b/packages/vest/src/suite/useCreateSuiteMethods.ts
@@ -240,13 +240,14 @@ function useCreateOnly<
   subscribe: Subscribe,
   schema?: S,
 ) {
+  const focus = useCreateFocus<F, G, T, S>(
+    suiteCallback,
+    modifiers,
+    subscribe,
+    schema,
+  );
   return function only(onlyField: NonNullable<SuiteModifiers<F>['only']>) {
-    return useCreateSuiteMethods<F, G, T, S>(
-      suiteCallback,
-      { ...modifiers, only: onlyField },
-      subscribe,
-      schema,
-    );
+    return focus({ only: onlyField });
   };
 }
 

--- a/packages/vest/src/suite/useCreateSuiteMethods.ts
+++ b/packages/vest/src/suite/useCreateSuiteMethods.ts
@@ -96,19 +96,19 @@ function useGetSuiteMethods<
   const { suiteCallback, modifiers, subscribe, schema } = ctx;
 
   const get = VestRuntime.persist(() => useCreateSuiteResult<F, G, S>(schema));
-
   return {
     ...useGetLifecycleMethods(ctx),
     dump: VestRuntime.persist(VestRuntime.useAvailableRoot<TIsolateSuite>),
+    get,
+    ...bindSuiteSelectors<F, G, S>(get),
+    ...getTypedMethods<F, G>(),
+    // focus and only must come after the spreads to prevent spread keys from overriding them
     focus: VestRuntime.persist(
       useCreateFocus<F, G, T, S>(suiteCallback, modifiers, subscribe, schema),
     ),
-    get,
     only: VestRuntime.persist(
       useCreateOnly<F, G, T, S>(suiteCallback, modifiers, subscribe, schema),
     ),
-    ...bindSuiteSelectors<F, G, S>(get),
-    ...getTypedMethods<F, G>(),
   };
 }
 
@@ -240,7 +240,7 @@ function useCreateOnly<
   subscribe: Subscribe,
   schema?: S,
 ) {
-  return function only(onlyField: SuiteModifiers<F>['only']) {
+  return function only(onlyField: NonNullable<SuiteModifiers<F>['only']>) {
     return useCreateSuiteMethods<F, G, T, S>(
       suiteCallback,
       { ...modifiers, only: onlyField },

--- a/packages/vest/src/suite/useCreateSuiteMethods.ts
+++ b/packages/vest/src/suite/useCreateSuiteMethods.ts
@@ -104,6 +104,9 @@ function useGetSuiteMethods<
       useCreateFocus<F, G, T, S>(suiteCallback, modifiers, subscribe, schema),
     ),
     get,
+    only: VestRuntime.persist(
+      useCreateOnly<F, G, T, S>(suiteCallback, modifiers, subscribe, schema),
+    ),
     ...bindSuiteSelectors<F, G, S>(get),
     ...getTypedMethods<F, G>(),
   };
@@ -210,6 +213,37 @@ function useCreateFocus<
     return useCreateSuiteMethods<F, G, T, S>(
       suiteCallback,
       { ...modifiers, ...config },
+      subscribe,
+      schema,
+    );
+  };
+}
+
+/**
+ * Creates an only function that can be used to create a focused suite on a specific field.
+ * This is a shorthand for suite.focus({ only: 'fieldName' }).
+ *
+ * @param {Function} suiteCallback - The body of the suite.
+ * @param {Object} modifiers - The modifiers for the suite (e.g., only).
+ * @param {Function} subscribe - The subscribe function for the suite bus.
+ * @param {Object} schema - The optional schema for the suite.
+ * @returns {Function} - The only function.
+ */
+function useCreateOnly<
+  F extends TFieldName,
+  G extends TGroupName,
+  T extends CB = CB,
+  S extends TSchema = undefined,
+>(
+  suiteCallback: SuiteCallbackWithSchema<S, T>,
+  modifiers: SuiteModifiers<F>,
+  subscribe: Subscribe,
+  schema?: S,
+) {
+  return function only(onlyField: SuiteModifiers<F>['only']) {
+    return useCreateSuiteMethods<F, G, T, S>(
+      suiteCallback,
+      { ...modifiers, only: onlyField },
       subscribe,
       schema,
     );

--- a/website/src/components/Sandpack/FocusedUpdates.js
+++ b/website/src/components/Sandpack/FocusedUpdates.js
@@ -43,7 +43,7 @@ export default function App() {
     setForm(newForm);
     
     // 2. Focused Update: Validate ONLY the changed field
-    suite.focus({ only: name }).run(newForm);
+    suite.only(name).run(newForm);
     
     // Update result
     setRes(suite.get());

--- a/website/src/components/Sandpack/ReactIntegration.js
+++ b/website/src/components/Sandpack/ReactIntegration.js
@@ -37,7 +37,7 @@ export default function App() {
   const handleChange = (name, value) => {
     const newData = { ...formData, [name]: value };
     setFormData(newData);
-    suite.focus({ only: name }).run(newData);
+    suite.only(name).run(newData);
   };
 
   const handleSubmit = async (e) => {

--- a/website/src/components/Sandpack/VueIntegration.js
+++ b/website/src/components/Sandpack/VueIntegration.js
@@ -34,7 +34,7 @@ const formData = reactive({
 const res = ref(suite.get());
 
 const validateField = fieldName => {
-  suite.focus({ only: fieldName }).afterEach(() => {
+  suite.only(fieldName).afterEach(() => {
     res.value = suite.get();
   }).run(formData);
 };

--- a/website/versioned_docs/version-next/api_reference.md
+++ b/website/versioned_docs/version-next/api_reference.md
@@ -102,10 +102,18 @@ Resets the state of a specific field (clears errors/warnings but keeps it in the
 
 #### `suite.focus(config)`
 
-Prepares a focused run.
+Prepares a focused run with combined modifiers. Use this when you need to combine `only`, `skip`, `skipGroup`, or `onlyGroup` in a single call.
 
-- `config`: `{ only?: string | string[], skip?: string | string[], skipGroup?: string | string[] }`
+- `config`: `{ only?: string | string[], skip?: string | string[], skipGroup?: string | string[], onlyGroup?: string | string[] }`
 - [Read more about Focused Updates](./writing_your_suite/focused_updates.md)
+
+#### `suite.only(fieldName)`
+
+Shorthand for `suite.focus({ only: fieldName })`. Restricts the next run to the specified field(s).
+
+- `fieldName`: `string | string[]`
+- Returns a chainable suite with `run`, `afterEach`, `afterField`, `focus`, and `only`.
+- [Read more about Focused Updates](./writing_your_suite/focused_updates.md#running-only-specific-fields)
 
 #### `suite.afterEach(callback)`
 

--- a/website/versioned_docs/version-next/concepts.md
+++ b/website/versioned_docs/version-next/concepts.md
@@ -31,7 +31,7 @@ Think of a Suite as more than just a function - it's an **object that holds the 
 ├─────────────────────────────────────────────────────────┤
 │  User types in "Username"                                │
 │           ↓                                              │
-│  suite.focus({ only: 'username' }).run(data)            │
+│  suite.only('username').run(data)            │
 │           ↓                                              │
 │  Vest runs ONLY "Username" tests                         │
 │           ↓                                              │

--- a/website/versioned_docs/version-next/understanding_state.md
+++ b/website/versioned_docs/version-next/understanding_state.md
@@ -26,13 +26,13 @@ Step 1: User fills "Password" field
         └─→ Result: { password: ✓ }
 
 Step 2: User fills "Username" field
-        └─→ suite.focus({ only: 'username' }).run()
+        └─→ suite.only('username').run()
         └─→ Vest runs ONLY username tests
         └─→ Vest MERGES with previous password result
         └─→ Result: { username: ?, password: ✓ }  ← Full picture!
 
 Step 3: User fixes username error
-        └─→ suite.focus({ only: 'username' }).run()
+        └─→ suite.only('username').run()
         └─→ Result: { username: ✓, password: ✓ }  ← Ready to submit!
 ```
 

--- a/website/versioned_docs/version-next/usage_with_frameworks/react.md
+++ b/website/versioned_docs/version-next/usage_with_frameworks/react.md
@@ -43,7 +43,7 @@ function SignupForm() {
   const handleChange = (name, value) => {
     setFormData(prev => ({ ...prev, [name]: value }));
     suite
-      .focus({ only: name })
+      .only(name)
       .afterEach(() => setResult(suite.get()))
       .run({ ...formData, [name]: value });
   };

--- a/website/versioned_docs/version-next/usage_with_frameworks/react.md
+++ b/website/versioned_docs/version-next/usage_with_frameworks/react.md
@@ -105,10 +105,11 @@ function useVestForm(suite, initialData = {}) {
       setFormData(newData);
 
       suite
+        .only(fieldName)
         .afterEach(() => {
           setResult(suite.get());
         })
-        .run(newData, fieldName);
+        .run(newData);
     },
     [formData, suite],
   );
@@ -183,11 +184,12 @@ function UsernameField() {
     setIsChecking(true);
 
     suite
+      .only('username')
       .afterEach(() => {
         setResult(suite.get());
         setIsChecking(false);
       })
-      .run({ username: value }, 'username');
+      .run({ username: value });
   };
 
   return (
@@ -239,8 +241,9 @@ const handleFieldChange = (fieldName, value) => {
 
   // Only validate the changed field
   suite
+    .only(fieldName)
     .afterEach(() => setResult(suite.get()))
-    .run({ ...formData, [fieldName]: value }, fieldName);
+    .run({ ...formData, [fieldName]: value });
 };
 ```
 

--- a/website/versioned_docs/version-next/usage_with_frameworks/vue.md
+++ b/website/versioned_docs/version-next/usage_with_frameworks/vue.md
@@ -110,11 +110,12 @@ export function useVestForm(suite, initialData = {}) {
     isValidating.value = true;
 
     suite
+      .only(fieldName)
       .afterEach(() => {
         result.value = suite.get();
         isValidating.value = false;
       })
-      .run(formData, fieldName);
+      .run(formData);
   };
 
   const validateAll = () => {
@@ -224,11 +225,12 @@ const checkUsername = () => {
   isChecking.value = true;
 
   suite
+    .only('username')
     .afterEach(() => {
       result.value = suite.get();
       isChecking.value = false;
     })
-    .run(formData, 'username');
+    .run(formData);
 };
 </script>
 
@@ -281,10 +283,11 @@ export default {
   methods: {
     validateField(fieldName) {
       suite
+        .only(fieldName)
         .afterEach(() => {
           this.result = suite.get();
         })
-        .run(this.formData, fieldName);
+        .run(this.formData);
     },
     handleSubmit() {
       suite
@@ -354,10 +357,11 @@ const result = ref<SuiteResult>(suite.get());
 
 const validateField = (fieldName: keyof FormData) => {
   suite
+    .only(fieldName)
     .afterEach(() => {
       result.value = suite.get();
     })
-    .run(formData, fieldName);
+    .run(formData);
 };
 </script>
 ```

--- a/website/versioned_docs/version-next/usage_with_frameworks/vue.md
+++ b/website/versioned_docs/version-next/usage_with_frameworks/vue.md
@@ -46,7 +46,7 @@ const res = ref(suite.get());
 
 const validateField = fieldName => {
   suite
-    .focus({ only: fieldName })
+    .only(fieldName)
     .afterEach(() => {
       res.value = suite.get();
     })
@@ -404,7 +404,7 @@ watchDebounced(
   newValue => {
     // Validate username
     suite
-      .focus({ only: 'username' })
+      .only('username')
       .afterEach(() => setResult(suite.get()))
       .run({ username: newValue });
   },

--- a/website/versioned_docs/version-next/vest_vs_the_rest.md
+++ b/website/versioned_docs/version-next/vest_vs_the_rest.md
@@ -81,7 +81,7 @@ Validate just the field the user is touching. Vest remembers the rest.
 
 ```javascript
 // User blurs "email" field
-suite.focus({ only: 'email' }).run(formData);
+suite.only('email').run(formData);
 
 // Result includes email validation + previous password result
 result.isValid(); // Full picture

--- a/website/versioned_docs/version-next/vest_vs_the_rest.md
+++ b/website/versioned_docs/version-next/vest_vs_the_rest.md
@@ -49,7 +49,7 @@ Most validation libraries fall into one of two traps:
 | Features                    | Vest                               | Functional Matchers | Schema Validation | Form State Managers |
 | --------------------------- | ---------------------------------- | ------------------- | ----------------- | ------------------- |
 | **State Management**        | Automatic                          | Manual              | Manual            | Automatic           |
-| **Per Field Validation**    | ✅ Built-in (`focus`)              | ❌                  | ❌                | ✅                  |
+| **Per Field Validation**    | ✅ Built-in (`only()` / `focus`)   | ❌                  | ❌                | ✅                  |
 | **Framework Agnostic**      | ✅                                 | ✅                  | ✅                | ❌                  |
 | **Async + Race Conditions** | ✅ Handled automatically           | ❌                  | Varies            | Varies              |
 | **SSR/Hydration**           | ✅ (`runStatic`, `dump`, `resume`) | ❌                  | ❌                | Framework-specific  |

--- a/website/versioned_docs/version-next/writing_tests/async_tests.md
+++ b/website/versioned_docs/version-next/writing_tests/async_tests.md
@@ -89,7 +89,6 @@ await result;
 If you prefer callbacks, or cannot use `await` at the call site, use the `.afterEach()` hook.
 
 ```javascript
-suite;
 suite
   .afterEach(() => {
     // This runs after the initial sync completion and after each async test finishes
@@ -161,13 +160,13 @@ if (result.isPending('username')) {
 }
 ```
 
-### 3. Combine with `suite.focus()`
+### 3. Combine with `suite.only()`
 
-For the best UX, only run async tests for the field the user is interacting with:
+For the best UX, only run async tests for the field the user is interacting with. Use `suite.only(fieldName)` for the common case of targeting a single field:
 
 ```javascript
 function handleBlur(fieldName) {
-  suite.focus({ only: fieldName }).run(formData);
+  suite.only(fieldName).run(formData);
 }
 ```
 

--- a/website/versioned_docs/version-next/writing_your_suite/dirty_checking.md
+++ b/website/versioned_docs/version-next/writing_your_suite/dirty_checking.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 6
 title: Handling User Interaction
-description: How to show validation errors only when users interact with fields using isTested and suite.focus()
+description: How to show validation errors only when users interact with fields using isTested and suite.only()
 keywords: [Vest, dirty, isDirty, isTested, validation, pristine, focus, onBlur]
 ---
 
@@ -11,7 +11,7 @@ A common challenge in form validation is "noise control." You don't want to scre
 
 Traditionally, libraries use an `isDirty` flag to track if a user has modified a field. Since Vest is **UI-agnostic** (it doesn't touch your DOM or listen to events), it doesn't track "dirty" state for you.
 
-Instead, Vest provides two powerful tools to handle user interaction: **`isTested()`** and **`suite.focus()`**.
+Instead, Vest provides two powerful tools to handle user interaction: **`isTested()`** and **`suite.only()`**.
 
 ## 1. `isTested()`: The Vest Alternative to `isDirty`
 
@@ -33,30 +33,29 @@ if (shouldShowError) {
 
 This pattern ensures that empty, untouched fields don't show "Required" errors when the form first loads.
 
-## 2. Validating on Interaction with `suite.focus()`
+## 2. Validating on Interaction with `suite.only()`
 
 When a user blurs a field or types, you often want to validate **only that specific field**, while keeping the rest of the form state intact.
 
-Vest 6 introduces `suite.focus()`. This tells Vest to run validations for specific fields, while skipping others.
+Vest 6 introduces `suite.only()`. This tells Vest to run validations for a specific field, while skipping others.
 
 ```javascript
 // On Blur handler
 function handleBlur(fieldName, formData) {
   // 1. Tell Vest to focus ONLY on the blurred field
-  // 2. Run the suite with the current data
-  suite.focus({ only: fieldName }).run(formData);
+  suite.only(fieldName).run(formData);
 }
 ```
 
-### Why use `focus()`?
+### Why use `only()`?
 
 - **Performance:** It skips expensive tests (like async checks) for fields the user isn't touching.
 - **User Experience:** It updates the state for the current field without accidentally flagging other fields as "tested" or "invalid" before the user reaches them.
 
 :::tip Real-World Pattern
-Combine `suite.focus()` with `isTested()` for the best UX:
+Combine `suite.only()` with `isTested()` for the best UX:
 
-- Use `focus({ only: fieldName })` in your `onBlur` handler to validate only the current field
+- Use `suite.only(fieldName)` in your `onBlur` handler to validate only the current field
 - Use `isTested(fieldName)` when rendering to decide whether to show errors
   :::
 
@@ -77,7 +76,7 @@ function Form() {
   const handleBlur = e => {
     const { name } = e.target;
     // Validate only the blurred field
-    const res = suite.focus({ only: name }).run(formData);
+    const res = suite.only(name).run(formData);
     setResult(res);
   };
 
@@ -110,14 +109,14 @@ function Form() {
 
 ## Summary
 
-| Goal                         | Traditional Approach          | Vest Approach                                   |
-| :--------------------------- | :---------------------------- | :---------------------------------------------- |
-| **Did the user touch this?** | Check `field.isDirty`         | Check `result.isTested('field')`                |
-| **Validate on Blur**         | Call `validateField('field')` | Call `suite.focus({ only: 'field' }).run(data)` |
+| Goal                         | Traditional Approach          | Vest Approach                        |
+| :--------------------------- | :---------------------------- | :----------------------------------- |
+| **Did the user touch this?** | Check `field.isDirty`         | Check `result.isTested('field')`     |
+| **Validate on Blur**         | Call `validateField('field')` | Call `suite.only('field').run(data)` |
 
-By combining `isTested()` (to hide premature errors) and `suite.focus()` (to update specific fields), you get precise control over the user experience without tightly coupling your validation to the DOM.
+By combining `isTested()` (to hide premature errors) and `suite.only()` (to update specific fields), you get precise control over the user experience without tightly coupling your validation to the DOM.
 
 ## Related
 
-- [Focused Updates](./focused_updates.md) - Deep dive into `suite.focus()`
+- [Focused Updates](./focused_updates.md) - Deep dive into `suite.only()` and `suite.focus()`
 - [Accessing the Result](./accessing_the_result.md) - Learn about `isTested()` and other result methods

--- a/website/versioned_docs/version-next/writing_your_suite/dirty_checking.md
+++ b/website/versioned_docs/version-next/writing_your_suite/dirty_checking.md
@@ -35,9 +35,9 @@ This pattern ensures that empty, untouched fields don't show "Required" errors w
 
 ## 2. Validating on Interaction with `suite.only()`
 
-When a user blurs a field or types, you often want to validate **only that specific field**, while keeping the rest of the form state intact.
+When a user blurs a field or types, you often want to validate **only that specific field**, without affecting other fields.
 
-Vest provides `suite.only()` to validate a specific field, while keeping the rest of the form state intact.
+`suite.only()` does exactly this — it tells Vest to run validations for a specific field, while preserving the results of everything else.
 
 ```javascript
 // On Blur handler
@@ -47,7 +47,7 @@ function handleBlur(fieldName, formData) {
 }
 ```
 
-### Why use `only()`?
+### Why use `suite.only()`?
 
 - **Performance:** It skips expensive tests (like async checks) for fields the user isn't touching.
 - **User Experience:** It updates the state for the current field without accidentally flagging other fields as "tested" or "invalid" before the user reaches them.

--- a/website/versioned_docs/version-next/writing_your_suite/dirty_checking.md
+++ b/website/versioned_docs/version-next/writing_your_suite/dirty_checking.md
@@ -37,7 +37,7 @@ This pattern ensures that empty, untouched fields don't show "Required" errors w
 
 When a user blurs a field or types, you often want to validate **only that specific field**, while keeping the rest of the form state intact.
 
-Vest 6 introduces `suite.only()`. This tells Vest to run validations for a specific field, while skipping others.
+Vest provides `suite.only()` to validate a specific field, while keeping the rest of the form state intact.
 
 ```javascript
 // On Blur handler

--- a/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
+++ b/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
@@ -10,7 +10,7 @@ keywords: [Vest, Focus, Only, Skip, SkipGroup, Validation]
 Sometimes you want to run validation only for a specific field (e.g., on blur). Vest 6 introduces the `suite.focus()` method for declarative control over which fields to validate.
 
 :::tip New in Vest 6
-`suite.focus()` is the recommended way to handle field-focused validation in Vest 6. It provides a cleaner API compared to using `only()` and `skip()` hooks inside your suite.
+`suite.only()` and `suite.focus()` are the recommended ways to handle field-focused validation in Vest 6. They provide a cleaner API compared to using `only()` and `skip()` hooks inside your suite.
 :::
 
 ## Why Focus?
@@ -27,7 +27,11 @@ In a large form, re-validating the entire suite on every keystroke can be ineffi
 
 ### Running Only Specific Fields
 
-Use `focus({ only: ... })` to restrict the run to specific fields.
+The most common use case is validating a single field as the user types or leaves an input. You can use the `suite.only('fieldName')` shorthand to restrict the run to specific fields.
+
+(For multiple fields, you can pass an array: `suite.only(['field1', 'field2'])`).
+
+If you need to combine focusing with other modifiers, you can use `.only(... )`.
 
 import FocusedUpdatesSandpack from '@site/src/components/Sandpack/FocusedUpdates';
 
@@ -138,13 +142,13 @@ When multiple modifiers are used, they are evaluated in the following order of p
 
 ```javascript
 suite
-  .focus({ only: 'email' })
+  .only('email')
   .afterEach(() => updateUI(suite.get()))
   .run(formData);
 
 // Or with afterField for specific field callbacks
 suite
-  .focus({ only: ['email', 'password'] })
+  .only(['email', 'password'])
   .afterField('email', () => validateEmailUI(suite.get()))
   .afterField('password', () => validatePasswordUI(suite.get()))
   .run(formData);
@@ -158,7 +162,7 @@ suite
 // In your form component
 function handleBlur(fieldName, formData) {
   suite
-    .focus({ only: fieldName })
+    .only(fieldName)
     .afterEach(() => setValidationResult(suite.get()))
     .run(formData);
 }
@@ -214,7 +218,7 @@ function handleSubmit(formData) {
 // Or for focused blur validation
 function handleBlur(fieldName, value) {
   suite
-    .focus({ only: fieldName })
+    .only(fieldName)
     .afterEach(() => setResult(suite.get()))
     .run({ ...formData, [fieldName]: value });
 }
@@ -243,7 +247,7 @@ function useFormValidation(initialData) {
   const validateField = useCallback(
     fieldName => {
       suite
-        .focus({ only: fieldName })
+        .only(fieldName)
         .afterEach(() => setResult(suite.get()))
         .run(formData);
     },
@@ -322,8 +326,8 @@ const suite = create((data: FormData) => {
 });
 
 // TypeScript will autocomplete field names
-suite.focus({ only: 'username' }).run(formData); // ✅
-suite.focus({ only: 'nonexistent' }).run(formData); // ❌ Type error
+suite.only('username').run(formData); // ✅
+suite.only('nonexistent').run(formData); // ❌ Type error
 suite.focus({ skip: 'email' }).run(formData); // ✅
 suite.focus({ skipGroup: 'myGroup' }).run(formData); // ✅
 suite.focus({ skipGroup: ['groupA', 'groupB'] }).run(formData); // ✅

--- a/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
+++ b/website/versioned_docs/version-next/writing_your_suite/focused_updates.md
@@ -31,7 +31,7 @@ The most common use case is validating a single field as the user types or leave
 
 (For multiple fields, you can pass an array: `suite.only(['field1', 'field2'])`).
 
-If you need to combine focusing with other modifiers, you can use `.only(... )`.
+If you need to combine focusing with other modifiers (e.g. `only` + `skipGroup`), use `suite.focus({ ... })` instead.
 
 import FocusedUpdatesSandpack from '@site/src/components/Sandpack/FocusedUpdates';
 

--- a/website/versioned_docs/version-next/writing_your_suite/including_and_excluding/skip_and_only.md
+++ b/website/versioned_docs/version-next/writing_your_suite/including_and_excluding/skip_and_only.md
@@ -68,9 +68,9 @@ const validationResult = suite.run(formData, changedField);
 You can make fields run together by using [include](./include). This is useful when you have fields that depend on each other, and you want to make sure they run at the same time.
 :::
 
-## V6 Recommended: Using `suite.focus()`
+## V6 Recommended: Using `suite.only()` and `suite.focus()`
 
-In Vest 6, the preferred way to focus validation on specific fields is to use the **`suite.focus()`** method. This approach is cleaner and separates the "what to validate" from "how to validate".
+In Vest 6, the preferred way to focus validation on specific fields is to use the **`suite.only()`** and **`suite.focus()`** methods. This approach is cleaner and separates the "what to validate" from "how to validate".
 
 ```javascript
 import { create, test, enforce } from 'vest';
@@ -88,10 +88,10 @@ const suite = create(data => {
 });
 
 // Focus on a single field
-suite.focus({ only: 'username' }).run(formData);
+suite.only('username').run(formData);
 
 // Focus on multiple fields
-suite.focus({ only: ['username', 'email'] }).run(formData);
+suite.only(['username', 'email']).run(formData);
 
 // Skip specific fields
 suite.focus({ skip: 'password' }).run(formData);
@@ -101,7 +101,7 @@ suite.focus({ skipGroup: 'signUp' }).run(formData);
 
 // Chain with afterEach for callbacks
 suite
-  .focus({ only: 'email' })
+  .only('email')
   .afterEach(() => updateUI(suite.get()))
   .run(formData);
 ```
@@ -114,17 +114,17 @@ suite
 | `skip`      | `string \| string[]` | Skip the specified field(s). All others run as usual.     |
 | `skipGroup` | `string \| string[]` | Skip all tests inside the named group(s).                 |
 
-### Why Use `suite.focus()` Over `only()`?
+### Why Use `suite.only()` Over `only()`?
 
-| Feature                    | `only()` (inside suite)     | `suite.focus()` (outside)  |
-| -------------------------- | --------------------------- | -------------------------- |
-| **Declaration**            | Inside suite callback       | At call site               |
-| **Flexibility**            | Must be conditional         | Fully dynamic              |
-| **Separation of Concerns** | Mixed with validation logic | Decoupled from validation  |
-| **Chainable**              | No                          | Yes (returns runnable API) |
-| **Best For**               | Static exclusions           | UI-driven field focus      |
+| Feature                    | `only()` (inside suite)     | `suite.only()` / `suite.focus()` (outside) |
+| -------------------------- | --------------------------- | ------------------------------------------ |
+| **Declaration**            | Inside suite callback       | At call site                               |
+| **Flexibility**            | Must be conditional         | Fully dynamic                              |
+| **Separation of Concerns** | Mixed with validation logic | Decoupled from validation                  |
+| **Chainable**              | No                          | Yes (returns runnable API)                 |
+| **Best For**               | Static exclusions           | UI-driven field focus                      |
 
-> **Recommendation**: Use `suite.focus()` for runtime decisions (e.g., validating on blur), and `only()`/`skip()` for static, logic-based exclusions inside your suite.
+> **Recommendation**: Use `suite.only()` or `suite.focus()` for runtime decisions (e.g., validating on blur), and `only()`/`skip()` for static, logic-based exclusions inside your suite.
 
 When choosing between modifiers in `suite.focus()`, prefer `skipGroup` when your intent is to disable a named validation section (for example `signUp`), and prefer `skip` when your intent is to exclude a specific field everywhere it appears.
 

--- a/website/versioned_docs/version-next/writing_your_suite/schema_validation.md
+++ b/website/versioned_docs/version-next/writing_your_suite/schema_validation.md
@@ -54,7 +54,7 @@ When you focus the suite with `focus({ only })`, schema validation is skipped fo
 
 ```javascript
 // Validate only the username field
-suite.focus({ only: 'username' }).run({
+suite.only('username').run({
   username: 'example',
 });
 ```

--- a/website/versioned_docs/version-next/writing_your_suite/schema_validation.md
+++ b/website/versioned_docs/version-next/writing_your_suite/schema_validation.md
@@ -50,7 +50,7 @@ When you pass a schema to `create`:
 3.  Your tests run assuming the data types are correct.
 
 :::note Focused runs
-When you focus the suite with `focus({ only })`, schema validation is skipped for fields outside the focus scope. This allows you to validate a single field even if the full payload does not satisfy the schema.
+When you focus the suite with `suite.only()` or `suite.focus({ only })`, schema validation is skipped for fields outside the focus scope. This allows you to validate a single field even if the full payload does not satisfy the schema.
 
 ```javascript
 // Validate only the username field


### PR DESCRIPTION
Introduces suite.only(fieldName) as a concise shorthand for the common pattern of suite.focus({ only: fieldName }). This is field-only (no group support) — use suite.focus() for combining modifiers like skipGroup.

- Implement useCreateOnly in useCreateSuiteMethods
- Add only to SuiteTypes (FocusedMethods and AfterMethods)
- Move only out of getTypedMethods (no longer a typed suite hook — it's now a suite method)
- Add unit tests in onlyShorthand.test.ts
- Update all sandpack examples (FocusedUpdates, ReactIntegration, VueIntegration) to use suite.only()
- Update docs to present suite.only() as the common case and suite.focus() as the advanced option for combining modifiers


## feat(suite): add `suite.only()` shorthand for `suite.focus({ only })`
### Summary
Introduces `suite.only(fieldName)` as a first-class shorthand for the most common focused-validation pattern: running validation only for a specific field (e.g. on blur or on change).
Before:
```js
suite.focus({ only: name }).run(formData);
```
After:

```js
suite.only(name).run(formData);
```

suite.only() accepts a single field name or an array of field names, and is chainable like the rest of the focus API:

```js
suite.only(name).afterEach(cb).run(formData);
```

Design decisions

Field-only shorthand. suite.only() is intentionally scoped to fields. Groups (onlyGroup, skipGroup) and combined-modifier scenarios still require suite.focus({ ... }).
suite.focus() is preserved as the advanced, composable API for anything beyond single-field focus — e.g. suite.focus({ only: 'username', skipGroup: 'asyncChecks' }).
The inner only() hook (used inside the suite callback) is unchanged — it's a different concern (static, conditional exclusions during suite execution).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added suite.only(...) as a shorthand to run validation for one or more specific field(s); suite.focus(...) remains available. Focus config now supports onlyGroup, and per-field run calls no longer require a separate field argument.

* **Tests**
  * Added tests for single-field, multi-field, chaining, and overwrite behavior of only().

* **Documentation**
  * Updated guides, examples, and API docs to show only() usage and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->