### PR TITLE
Type custom enforce matchers in parse tests

### DIFF
--- a/packages/n4s/docs/schema.md
+++ b/packages/n4s/docs/schema.md
@@ -1,0 +1,59 @@
+# n4s schema parsing architecture
+
+## Goals
+
+1. **Single-pass validation and transformation** for schema rules (`shape`, `loose`, `partial`).
+2. **Predictable parse API** available across plain rules and chains.
+3. **Security-first object traversal**, with explicit protection against dangerous keys used in prototype-pollution attacks.
+4. **O(1) lookup behavior** by relying on native object property checks and set membership checks.
+
+## Pipeline design
+
+Schema execution is now modeled as a parse pipeline:
+
+1. Validate the input container (must be object-like).
+2. Reject dangerous own keys (`__proto__`, `prototype`, `constructor`) on both schema and user input.
+3. Iterate schema keys using own-key iteration only (`Object.keys`).
+4. Run each field rule and collect the transformed output (`RuleRunReturn.type`).
+5. Return a parsed object with validated/coerced values.
+
+This keeps validation and transformation in one pass over the relevant keys.
+
+## Security decisions
+
+Schema object utilities centralize safety behavior:
+
+- `ownKeys` avoids prototype chain traversal.
+- `safeHasOwn` avoids `in` checks that include inherited keys.
+- `findDangerousOwnKey` short-circuits when dangerous keys are detected.
+- `safeShallowCopy` creates a sanitized shallow clone and omits dangerous keys.
+
+These utilities are used by `shape`, `loose`, and `partial` to ensure consistent behavior.
+
+## Parse API semantics
+
+Every `RuleInstance` now exposes:
+
+- `test(value)` → boolean
+- `validate(value)` → standard-schema result (`value` or `issues`)
+- `parse(value)` → transformed output or throws on validation failure
+- `run(value)` → internal `RuleRunReturn`
+
+Chains propagate transformed values through each step, so rules can compose coercions predictably.
+
+## Vest integration
+
+When a suite is created with a schema:
+
+- The schema parsing path is executed before the suite callback.
+- If `schema.parse` exists, it is used first.
+- On parse throw, Vest falls back to `schema.run` for rich path/message reporting.
+- The suite callback receives parsed data.
+- `SuiteResult.value` and `types.output` are parsed output.
+- `types.input` remains the original input.
+
+## Complexity notes
+
+- Key checks are O(1) average-case (`Set.has`, own-property checks).
+- Rule execution remains linear in the number of relevant keys: O(n).
+- No recursive cloning is performed in schema wrappers; copying is shallow by design.

--- a/packages/n4s/src/__tests__/parse.test.ts
+++ b/packages/n4s/src/__tests__/parse.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { enforce } from '../n4s';
+
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      toNumber: (value: unknown) => { pass: boolean; type: unknown };
+    }
+  }
+}
+
+describe('parse()', () => {
+  it('should expose parse on lazy rules', () => {
+    const validator = enforce.isString();
+    expect(typeof validator.parse).toBe('function');
+    expect(validator.parse('hello')).toBe('hello');
+  });
+
+  it('should throw on failed parse', () => {
+    const validator = enforce.isString().message('Must be string');
+    expect(() => validator.parse(100 as any)).toThrow('Must be string');
+  });
+
+  it('should return transformed output for schema rules', () => {
+    enforce.extend({
+      toNumber: (value: unknown) => {
+        const parsed = Number(value);
+        return Number.isNaN(parsed)
+          ? { pass: false, type: value }
+          : { pass: true, type: parsed };
+      },
+    });
+
+    const schema = enforce.shape({
+      age: enforce.toNumber(),
+    });
+
+    expect(schema.parse({ age: '42' })).toEqual({ age: 42 });
+  });
+});

--- a/packages/n4s/src/__tests__/standardSchema.test.ts
+++ b/packages/n4s/src/__tests__/standardSchema.test.ts
@@ -62,6 +62,22 @@ describe('n4s StandardSchema Support', () => {
     });
   });
 
+  it('should expose .parse() and return transformed value when valid', async () => {
+    const { enforce } = await import('../n4s');
+    enforce.extend({
+      toNumberForParse: (value: any) => {
+        const parsed = Number(value);
+        return {
+          pass: !Number.isNaN(parsed),
+          type: parsed,
+          message: 'not numeric',
+        };
+      },
+    });
+
+    expect((enforce as any).toNumberForParse().parse('12')).toBe(12);
+  });
+
   describe('Direct validate() method usage', () => {
     it('should expose .validate() as a direct method', () => {
       const validator = enforce.equals(5);

--- a/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
+++ b/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
@@ -14,7 +14,7 @@ import { executeChain, type Predicate } from './chainExecutor';
 import { createChainProxyHandlers } from './proxyHandlers';
 
 export type RuleFunctions<T extends RuleInstance<any, any>> = Record<
-  keyof Omit<T, 'infer' | 'test' | 'validate' | '~standard'>,
+  keyof Omit<T, 'infer' | 'test' | 'validate' | 'parse' | '~standard'>,
   (...args: any[]) => boolean
 >;
 
@@ -72,6 +72,17 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
   }) as T['test'];
 
   // Internal compatibility method - converts StandardSchema Result to RuleRunReturn
+
+  const parse: T['parse'] = ((...args: any[]) => {
+    const result = validate(...args);
+    if (!result.issues) {
+      return result.value;
+    }
+
+    const [firstIssue] = result.issues;
+    throw new TypeError(firstIssue?.message || 'Validation failed');
+  }) as T['parse'];
+
   const run: T['run'] = ((...args: any[]) => {
     const result = executeChain(chain, args[0]);
     if (!result.pass && lazyMessage) {
@@ -105,6 +116,7 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
       } as StandardSchemaV1.Props<any, any>,
       add,
       message,
+      parse,
       run,
       test,
       validate,

--- a/packages/n4s/src/rules/chainBuilder/chainExecutor.ts
+++ b/packages/n4s/src/rules/chainBuilder/chainExecutor.ts
@@ -12,15 +12,18 @@ export function executeChain(
   chain: Predicate[],
   value: any,
 ): RuleRunReturn<any> {
+  let currentValue = value;
+
   for (const predicate of chain) {
-    const result = predicate(value);
+    const result = predicate(currentValue);
 
     if (isRuleRunReturn(result)) {
       if (!result.pass) return result as RuleRunReturn<any>;
+      currentValue = result.type;
     } else if (!result) {
-      return RuleRunReturn.Failing(value);
+      return RuleRunReturn.Failing(currentValue);
     }
   }
 
-  return RuleRunReturn.Passing(value);
+  return RuleRunReturn.Passing(currentValue);
 }

--- a/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
+++ b/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
@@ -8,7 +8,7 @@ import { getLazyRule } from './lazyRegistry';
 
 export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
   rules: Record<
-    keyof Omit<T, 'infer' | 'test' | 'validate' | '~standard'>,
+    keyof Omit<T, 'infer' | 'test' | 'validate' | 'parse' | '~standard'>,
     (...args: any[]) => boolean
   >,
   {
@@ -16,6 +16,7 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
     test,
     validate,
     run,
+    parse,
     message,
     '~standard': standard,
   }: {
@@ -23,16 +24,25 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
     test: T['test'];
     validate: T['validate'];
     run: T['run'];
+    parse: T['parse'];
     message: (msg: any) => T;
     '~standard': StandardSchemaV1.Props<any, any>;
   },
 ) {
-  const methods = { '~standard': standard, message, run, test, validate };
+  const methods = {
+    '~standard': standard,
+    message,
+    parse,
+    run,
+    test,
+    validate,
+  };
   const methodKeys = new Set([
     'infer',
     'test',
     'validate',
     'run',
+    'parse',
     'message',
     '~standard',
   ]);

--- a/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { enforce } from '../../../n4s';
+
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      toNumber: (value: unknown) => { pass: boolean; type: unknown };
+      trimString: (value: unknown) => { pass: boolean; type: unknown };
+    }
+  }
+}
+
+enforce.extend({
+  toNumber: (value: unknown) => {
+    const parsed = Number(value);
+    return Number.isNaN(parsed)
+      ? { pass: false, type: value }
+      : { pass: true, type: parsed };
+  },
+  trimString: (value: unknown) => {
+    if (typeof value !== 'string') {
+      return { pass: false, type: value };
+    }
+
+    return { pass: true, type: value.trim() };
+  },
+});
+
+describe('schema parse integration', () => {
+  it('shape parses nested values with custom coercions', () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        name: enforce.trimString(),
+        age: enforce.toNumber(),
+      }),
+    });
+
+    const result = schema.parse({
+      profile: { name: '  Jane  ', age: '34' },
+    });
+
+    expect(result).toEqual({
+      profile: { name: 'Jane', age: 34 },
+    });
+  });
+
+  it('loose parses known keys while keeping extra payload fields', () => {
+    const schema = enforce.loose({
+      amount: enforce.toNumber(),
+      title: enforce.trimString(),
+    });
+
+    const result = schema.parse({
+      amount: '49',
+      title: '  invoice ',
+      metadata: { source: 'api' },
+    });
+
+    expect(result).toEqual({
+      amount: 49,
+      title: 'invoice',
+      metadata: { source: 'api' },
+    });
+  });
+
+  it('partial parses only provided keys', () => {
+    const schema = enforce.partial({
+      page: enforce.toNumber(),
+      search: enforce.trimString(),
+    });
+
+    expect(schema.parse({ page: '2' })).toEqual({ page: 2 });
+    expect(schema.parse({ search: '  vest  ' })).toEqual({ search: 'vest' });
+  });
+
+  it('rejects dangerous own keys to prevent prototype pollution', () => {
+    const schema = enforce.loose({
+      safe: enforce.isString(),
+    });
+
+    const payload = JSON.parse('{"safe":"ok","__proto__":{"polluted":true}}');
+    const result = schema.run(payload);
+
+    expect(result.pass).toBe(false);
+    expect(result.path).toEqual(['__proto__']);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('rejects dangerous schema keys', () => {
+    const schema = enforce.shape(
+      JSON.parse('{"__proto__":true}') as Record<string, unknown> as any,
+    );
+
+    const result = schema.run({});
+
+    expect(result.pass).toBe(false);
+    expect(result.path).toEqual(['__proto__']);
+  });
+});

--- a/packages/n4s/src/rules/schemaRules/loose.ts
+++ b/packages/n4s/src/rules/schemaRules/loose.ts
@@ -4,6 +4,12 @@ import { ctx } from '../../enforceContext';
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
+import {
+  findDangerousOwnKey,
+  ownKeys,
+  safeHasOwn,
+  safeShallowCopy,
+} from './schemaObjectUtils';
 import type { ShapeType } from './shape';
 
 /**
@@ -45,8 +51,26 @@ export function loose<T extends Record<string, any>>(
     return RuleRunReturn.Failing(value);
   }
 
-  for (const key in schema) {
-    const fieldValue = key in value ? value[key] : undefined;
+  const dangerousSchemaKey = findDangerousOwnKey(schema);
+  if (dangerousSchemaKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [dangerousSchemaKey],
+    };
+  }
+
+  const dangerousValueKey = findDangerousOwnKey(value);
+  if (dangerousValueKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [dangerousValueKey],
+    };
+  }
+
+  const parsedValue: Record<string, any> = safeShallowCopy(value);
+
+  for (const key of ownKeys(schema)) {
+    const fieldValue = safeHasOwn(value, key) ? value[key] : undefined;
     const res = ctx.run({ value: fieldValue, set: true, meta: { key } }, () =>
       schema[key].run(fieldValue),
     );
@@ -55,8 +79,11 @@ export function loose<T extends Record<string, any>>(
       const newRes = { ...res, path: [key, ...currentPath] };
       return newRes as RuleRunReturn<T>;
     }
+
+    parsedValue[key] = res.type;
   }
-  return RuleRunReturn.Passing(value);
+
+  return RuleRunReturn.Passing(parsedValue as T);
 }
 
 // Types colocated with loose rule

--- a/packages/n4s/src/rules/schemaRules/partial.ts
+++ b/packages/n4s/src/rules/schemaRules/partial.ts
@@ -4,21 +4,28 @@ import { ctx } from '../../enforceContext';
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
+import {
+  findDangerousOwnKey,
+  ownKeys,
+  safeHasOwn,
+  safeShallowCopy,
+} from './schemaObjectUtils';
 import type { ShapeType } from './shape';
 
 /**
  * Checks if value has any keys not present in schema.
  */
-function hasExtraKeys<T extends Record<string, any>>(
+function getFirstExtraKey<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
-): boolean {
-  for (const key in value) {
-    if (!(key in schema)) {
-      return true;
+): string | null {
+  for (const key of ownKeys(value)) {
+    if (!safeHasOwn(schema, key)) {
+      return key;
     }
   }
-  return false;
+
+  return null;
 }
 
 /**
@@ -28,16 +35,23 @@ function hasExtraKeys<T extends Record<string, any>>(
 function validateProvidedKeys<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
+  parsedValue: Record<string, any>,
 ): RuleRunReturn<T> | null {
-  for (const key in schema) {
-    if (key in value) {
+  for (const key of ownKeys(schema)) {
+    if (safeHasOwn(value, key)) {
       const fieldValue = value[key];
       const res = ctx.run({ value: fieldValue, set: true, meta: { key } }, () =>
         schema[key].run(fieldValue),
       );
       if (!res.pass) {
-        return res as RuleRunReturn<T>;
+        const currentPath = res.path || [];
+        return {
+          ...res,
+          path: [key, ...currentPath],
+        } as RuleRunReturn<T>;
       }
+
+      parsedValue[key] = res.type;
     }
   }
   return null;
@@ -82,6 +96,7 @@ function validateProvidedKeys<T extends Record<string, any>>(
  * updateSchema.test({ name: 'Jane', extra: 'x' }); // false (extra key not in schema)
  * ```
  */
+// eslint-disable-next-line complexity
 export function partial<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
@@ -90,16 +105,37 @@ export function partial<T extends Record<string, any>>(
     return RuleRunReturn.Failing(value);
   }
 
-  if (hasExtraKeys(value, schema)) {
-    return RuleRunReturn.Failing(value);
+  const dangerousSchemaKey = findDangerousOwnKey(schema);
+  if (dangerousSchemaKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [dangerousSchemaKey],
+    };
   }
 
-  const validationResult = validateProvidedKeys(value, schema);
+  const dangerousValueKey = findDangerousOwnKey(value);
+  if (dangerousValueKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [dangerousValueKey],
+    };
+  }
+
+  const extraKey = getFirstExtraKey(value, schema);
+  if (extraKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [extraKey],
+    };
+  }
+
+  const parsedValue = safeShallowCopy(value);
+  const validationResult = validateProvidedKeys(value, schema, parsedValue);
   if (validationResult) {
     return validationResult;
   }
 
-  return RuleRunReturn.Passing(value);
+  return RuleRunReturn.Passing(parsedValue as T);
 }
 
 // Types colocated with partial rule

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -1,0 +1,68 @@
+import { hasOwnProperty, isObject } from 'vest-utils';
+
+/**
+ * Keys that can mutate object prototypes when assigned.
+ *
+ * This set is intentionally tiny and lookup is O(1).
+ */
+const DANGEROUS_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+/**
+ * Returns only own enumerable keys for object-like values.
+ *
+ * Prototype keys are never traversed which prevents inherited-key surprises.
+ */
+export function ownKeys(value: unknown): string[] {
+  if (!isObject(value)) {
+    return [];
+  }
+
+  return Object.keys(value as Record<string, unknown>);
+}
+
+/**
+ * Checks whether a key is known to be unsafe for object assignment/traversal.
+ */
+export function isDangerousKey(key: string): boolean {
+  return DANGEROUS_KEYS.has(key);
+}
+
+/**
+ * Safe own-property check that does not rely on user-provided prototypes.
+ */
+export function safeHasOwn(value: unknown, key: string): boolean {
+  return hasOwnProperty(value, key);
+}
+
+/**
+ * Returns the first dangerous own key if present; otherwise null.
+ */
+export function findDangerousOwnKey(value: unknown): string | null {
+  for (const key of ownKeys(value)) {
+    if (isDangerousKey(key)) {
+      return key;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Produces a shallow sanitized copy that excludes dangerous keys.
+ *
+ * Shallow copy is intentional for performance; nested rules are responsible
+ * for validating nested payloads.
+ */
+export function safeShallowCopy<T extends Record<string, any>>(value: T): T {
+  const output: Record<string, any> = {};
+
+  for (const key of ownKeys(value)) {
+    if (isDangerousKey(key)) {
+      continue;
+    }
+
+    output[key] = value[key];
+  }
+
+  return output as T;
+}

--- a/packages/n4s/src/rules/schemaRules/shape.ts
+++ b/packages/n4s/src/rules/schemaRules/shape.ts
@@ -1,9 +1,8 @@
-import { hasOwnProperty } from 'vest-utils';
-
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
 import { loose } from './loose';
+import { ownKeys, safeHasOwn } from './schemaObjectUtils';
 
 /**
  * Validates that an object matches a schema exactly - all keys required, no extra keys allowed.
@@ -44,15 +43,15 @@ export function shape<T extends Record<string, any>>(
     return baseRes;
   }
 
-  for (const key in value) {
-    if (!hasOwnProperty(schema, key)) {
+  for (const key of ownKeys(value)) {
+    if (!safeHasOwn(schema, key)) {
       const res = RuleRunReturn.Failing(value);
       const newRes = { ...res, path: [key] };
       return newRes;
     }
   }
 
-  return RuleRunReturn.Passing(value);
+  return RuleRunReturn.Passing(baseRes.type);
 }
 
 // Types colocated with shape rule

--- a/packages/n4s/src/utils/RuleInstance.ts
+++ b/packages/n4s/src/utils/RuleInstance.ts
@@ -41,6 +41,9 @@ export class RuleInstance<T, Args extends any[] = any[]> {
   // Type-only declaration for the StandardSchema validate method
   validate!: (...args: Args) => StandardSchemaV1.Result<T>;
 
+  // Type-only declaration for parse helper that throws on issues
+  parse!: (...args: Args) => T;
+
   // Type-only declaration for StandardSchema property
   '~standard'!: StandardSchemaV1.Props<Args[0], T>;
 
@@ -77,6 +80,16 @@ export class RuleInstance<T, Args extends any[] = any[]> {
       return rule(...args);
     };
 
+    const parse = (...args: Args): T => {
+      const result = validate(...args);
+      if (!result.issues) {
+        return result.value;
+      }
+
+      const [firstIssue] = result.issues;
+      throw new TypeError(firstIssue?.message || 'Validation failed');
+    };
+
     return {
       '~standard': {
         types: {
@@ -89,6 +102,7 @@ export class RuleInstance<T, Args extends any[] = any[]> {
       },
       infer: {} as T,
       run,
+      parse,
       test: (...args: Args) => {
         const result = validate(...args);
         return !result.issues;

--- a/packages/n4s/src/utils/RuleRunReturn.ts
+++ b/packages/n4s/src/utils/RuleRunReturn.ts
@@ -52,6 +52,7 @@ export class RuleRunReturn<T> {
     return RuleRunReturn.fromObject(pass, type, message);
   }
 
+  // eslint-disable-next-line complexity
   private static fromObject<T>(
     pass: any,
     type: T,
@@ -63,9 +64,14 @@ export class RuleRunReturn<T> {
       return new RuleRunReturn(false, type, dynamicValue(message, type));
     }
 
+    const resolvedPass = !!pass.pass;
+    const resolvedType = resolvedPass
+      ? (pass.type ?? type)
+      : (type ?? pass.type);
+
     const res = new RuleRunReturn(
-      !!pass.pass,
-      type ?? pass.type,
+      resolvedPass,
+      resolvedType,
       dynamicValue(message ?? pass.message, type),
     );
 

--- a/packages/n4s/src/utils/__tests__/RuleInstance.test.ts
+++ b/packages/n4s/src/utils/__tests__/RuleInstance.test.ts
@@ -62,4 +62,34 @@ describe('RuleInstance.create', () => {
       ],
     });
   });
+
+  it('parse() returns transformed output for valid input', () => {
+    type R = RuleInstance<number, [string]>;
+
+    const toNumber = (value: string) => {
+      const parsed = Number(value);
+      return Number.isNaN(parsed)
+        ? RuleRunReturn.Failing(value as any, 'not a number')
+        : RuleRunReturn.Passing(parsed);
+    };
+
+    const rule = RuleInstance.create<R, number, [string]>(toNumber as any);
+
+    expect(rule.parse('15')).toBe(15);
+  });
+
+  it('parse() throws when validation fails', () => {
+    type R = RuleInstance<number, [string]>;
+
+    const toNumber = (value: string) => {
+      const parsed = Number(value);
+      return Number.isNaN(parsed)
+        ? RuleRunReturn.Failing(value as any, 'not a number')
+        : RuleRunReturn.Passing(parsed);
+    };
+
+    const rule = RuleInstance.create<R, number, [string]>(toNumber as any);
+
+    expect(() => rule.parse('bad')).toThrow('not a number');
+  });
 });

--- a/packages/n4s/src/utils/__tests__/RuleRunReturn.test.ts
+++ b/packages/n4s/src/utils/__tests__/RuleRunReturn.test.ts
@@ -67,8 +67,8 @@ describe('RuleRunReturn', () => {
       const msgFn = vi.fn((t: string) => `outer:${t}`);
       const res = RuleRunReturn.create(inner, 'OUTER', msgFn);
 
-      // final type prefers explicit type
-      expect(res.type).toBe('OUTER');
+      // final type preserves inner transformed type on pass
+      expect(res.type).toBe('INNER');
       // message function receives the second arg to create (OUTER)
       expect(res.message).toBe('outer:OUTER');
       expect(msgFn).toHaveBeenCalledTimes(1);

--- a/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import { create, enforce, test } from '../../vest';
+
+describe('suite schema parse integration', () => {
+  it('passes parsed output to callback and result.value', () => {
+    const schema = {
+      parse: (value: any) => ({
+        quantity: Number(value.quantity),
+        label: String(value.label).trim(),
+      }),
+      run: (value: any) => {
+        const quantity = Number(value.quantity);
+        if (Number.isNaN(quantity)) {
+          return {
+            message: 'quantity must be numeric',
+            pass: false,
+            path: ['quantity'],
+            type: value,
+          };
+        }
+
+        return {
+          pass: true,
+          type: {
+            quantity,
+            label: String(value.label).trim(),
+          },
+        };
+      },
+    };
+
+    let callbackData: any;
+
+    const suite = create((data: any) => {
+      callbackData = data;
+
+      test('quantity', () => {
+        enforce(data.quantity).isNumber();
+      });
+    }, schema as any);
+
+    const result = suite.run({ quantity: '10', label: '  item  ' } as any);
+
+    expect(callbackData).toEqual({ quantity: 10, label: 'item' });
+    expect(result.value).toEqual({ quantity: 10, label: 'item' });
+    expect((result.types as any)?.output).toEqual({
+      quantity: 10,
+      label: 'item',
+    });
+  });
+
+  it('uses parsed data with extra payload keys', () => {
+    const schema = {
+      parse: (value: any) => ({
+        amount: Number(value.amount),
+        extra: value.extra,
+      }),
+      run: (value: any) => ({
+        pass: !Number.isNaN(Number(value.amount)),
+        path: ['amount'],
+        type: { amount: Number(value.amount), extra: value.extra },
+      }),
+    };
+
+    let callbackAmount: unknown;
+
+    const suite = create((data: any) => {
+      callbackAmount = data.amount;
+      test('amount', () => {
+        enforce(data.amount).isNumber();
+      });
+    }, schema as any);
+
+    const result = suite.run({ amount: '7', extra: 'keep' } as any);
+
+    expect(callbackAmount).toBe(7);
+    expect(result.value).toEqual({ amount: 7, extra: 'keep' });
+  });
+
+  it('falls back to original input when parse fails', () => {
+    const schema = {
+      parse: (value: any) => {
+        const quantity = Number(value.quantity);
+        if (Number.isNaN(quantity)) {
+          throw new Error('parse failed');
+        }
+
+        return { quantity };
+      },
+      run: (value: any) => ({
+        message: 'quantity must be numeric',
+        pass: !Number.isNaN(Number(value.quantity)),
+        path: ['quantity'],
+        type: { quantity: Number(value.quantity) },
+      }),
+    };
+
+    let callbackData: any;
+
+    const suite = create((data: any) => {
+      callbackData = data;
+      test('quantity', () => {
+        enforce(data.quantity).isNotEmpty();
+      });
+    }, schema as any);
+
+    const result = suite.run({ quantity: 'not-a-number' } as any);
+
+    expect(callbackData).toEqual({ quantity: 'not-a-number' });
+    expect(result.hasErrors('quantity')).toBe(true);
+    expect(result.value).toBeUndefined();
+  });
+
+  it('maps security-related schema run paths into suite errors', () => {
+    const schema = {
+      parse: (value: any) => value,
+      run: () => ({
+        message: 'dangerous key',
+        pass: false,
+        path: ['security'],
+        type: {},
+      }),
+    };
+
+    const suite = create(() => {}, schema as any);
+
+    const result = suite.run({ name: 'safe' } as any);
+
+    expect(result.hasErrors()).toBe(true);
+    expect(result.hasErrors('security')).toBe(true);
+  });
+});

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -4,6 +4,14 @@ import { describe, it, expect } from 'vitest';
 import { create, test } from '../../vest';
 
 describe('Schema Runtime Validation', () => {
+  enforce.extend({
+    toNumber: (value: unknown) => {
+      const parsed = Number(value);
+      return Number.isNaN(parsed)
+        ? { pass: false, type: value }
+        : { pass: true, type: parsed };
+    },
+  });
   const schema = enforce.shape({
     name: enforce.isString(),
     age: enforce.isNumber(),
@@ -261,6 +269,28 @@ describe('Schema Runtime Validation', () => {
       expect(res.pass).toBe(false);
       expect(res.path).toEqual(['users', '1', 'age']);
     });
+  });
+
+  it('should pass parsed schema output into the suite callback', () => {
+    const schemaWithParsing = {
+      parse: (value: any) => ({ age: Number(value.age) }),
+      run: (value: any) => ({ pass: true, type: { age: Number(value.age) } }),
+    } as any;
+
+    let receivedAge: unknown;
+    const parsedSuite = create((data: any) => {
+      receivedAge = data.age;
+      test('age', () => {
+        enforce(data.age).isNumber();
+      });
+    }, schemaWithParsing);
+
+    const result = parsedSuite.run({ age: '32' } as any);
+
+    expect(receivedAge).toBe(32);
+    expect(result.value).toEqual({ age: 32 });
+    expect((result.types as any)?.output).toEqual({ age: 32 });
+    expect(result.isValid()).toBe(true);
   });
 
   describe('Stateful behavior', () => {

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -1,4 +1,12 @@
-import { assign, asArray, CB, isFunction, withResolvers } from 'vest-utils';
+import {
+  assign,
+  asArray,
+  CB,
+  isArray,
+  isFunction,
+  isObject,
+  withResolvers,
+} from 'vest-utils';
 
 import { useEmit } from '../core/VestBus/VestBus';
 
@@ -18,16 +26,19 @@ import { useCreateSuiteResult } from '../suiteResult/suiteResult';
 
 import { SuiteModifiers, SuiteCallbackWithSchema } from './SuiteTypes';
 
-/**
- * Creates the actual suite runner function.
- * This function is responsible for initializing the suite context,
- * running the suite callback, and returning the result.
- *
- * @param {Function} suiteCallback - The body of the suite.
- * @param {Object} modifiers - The modifiers for the suite (e.g., only).
- * @returns {Function} - The suite runner function.
- */
+type SchemaRunResult = {
+  message?: string;
+  pass: boolean;
+  path?: string[];
+  type: unknown;
+};
 
+/**
+ * Creates the suite runner bound to a callback, modifiers and (optional) schema.
+ *
+ * The runner performs schema preprocessing once per run, stores the original input
+ * and parsed output, and then executes the suite callback within SuiteContext.
+ */
 // eslint-disable-next-line max-lines-per-function
 export function useCreateSuiteRunner<
   F extends TFieldName,
@@ -40,34 +51,56 @@ export function useCreateSuiteRunner<
   schema?: S,
 ) {
   const transformedModifiers = useTransformedModifiers(modifiers);
+
   return function runSuite(
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
   ): SuiteResult<F, G, S> {
     const { resolve, promise } = withResolvers<SuiteResult<F, G, S>>();
+
+    const schemaInput = args[0];
+    const schemaRunResult = shouldRunSchema(schema, transformedModifiers)
+      ? runSchemaWithParse(schema, schemaInput)
+      : undefined;
+
+    // Only expose parsed output to the callback when schema processing succeeded.
+    const callbackInput = schemaRunResult?.pass
+      ? schemaRunResult.type
+      : schemaInput;
+    const callbackArgs = [callbackInput, ...args.slice(1)] as Parameters<T>;
+
     return assign(
       promise,
       SuiteContext.run(
         {
-          suiteParams: args as Parameters<T>,
+          suiteParams: callbackArgs,
           schema,
           modifiers: transformedModifiers,
         },
         () => {
           useEmit('SUITE_RUN_STARTED');
+
           const useResolver = () => {
-            const result = useCreateSuiteResult<F, G, S>(schema, args[0]);
+            const result = useCreateSuiteResult<F, G, S>(
+              schema,
+              callbackInput,
+              schemaInput,
+            );
+
             if (!result.isPending()) {
               resolve(result);
             }
+
             return result;
           };
+
           return IsolateSuite(
             useRunSuiteCallback<F, T, S>({
-              args,
+              args: callbackArgs,
               modifiers: transformedModifiers,
               schema,
+              schemaRunResult,
               suiteCallback,
               useResolver,
             }),
@@ -79,6 +112,9 @@ export function useCreateSuiteRunner<
   };
 }
 
+/**
+ * Wraps suite callback execution and schema failure emission into an isolate callback.
+ */
 function useRunSuiteCallback<
   F extends TFieldName,
   T extends CB = CB,
@@ -87,33 +123,42 @@ function useRunSuiteCallback<
   args: any[];
   modifiers: ReturnType<typeof useTransformedModifiers<F>>;
   schema: S | undefined;
+  schemaRunResult?: SchemaRunResult;
   suiteCallback: SuiteCallbackWithSchema<S, T>;
   useResolver: () => SuiteResult<F, any, S>;
 }) {
-  const { args, modifiers, schema, suiteCallback, useResolver } = params;
+  const {
+    args,
+    modifiers,
+    schema,
+    schemaRunResult,
+    suiteCallback,
+    useResolver,
+  } = params;
+
   return () => {
-    // Apply field-level focus modifiers. These create transient Focused
-    // isolates at the suite root that affect all tests in the suite.
-    // `only` restricts the run to matching fields; `skip` excludes them.
-    // `skipGroup` is handled separately inside `group()` — when a group
-    // with a matching name is entered, it injects `skip(true)` into
-    // the group's callback via the modifiers stored in SuiteContext.
+    // Focused modifiers are applied before user callback so every test in this run
+    // observes the same focus context.
     only(modifiers.only);
     skip(modifiers.skip);
     (suiteCallback as any)(...args);
 
     IsolateReorderable(
-      runSchemaValidation(schema, modifiers, args[0]),
+      runSchemaValidation(schema, modifiers, schemaRunResult),
       undefined,
       {
         tests: [],
       },
     );
+
     useEmit('SUITE_CALLBACK_RUN_FINISHED');
     return useResolver();
   };
 }
 
+/**
+ * Normalizes user-provided modifiers into deterministic sets for O(1) membership checks.
+ */
 function useTransformedModifiers<F extends TFieldName>(
   modifiers: SuiteModifiers<F>,
 ) {
@@ -124,27 +169,127 @@ function useTransformedModifiers<F extends TFieldName>(
   };
 }
 
+/**
+ * Emits schema failure into vest test tree when schema processing failed.
+ */
+
 function runSchemaValidation<
   F extends TFieldName,
   S extends TSchema = undefined,
 >(
   schema: S | undefined,
   modifiers: ReturnType<typeof useTransformedModifiers<F>>,
-  data: any,
+  schemaRunResult?: SchemaRunResult,
 ) {
+  // eslint-disable-next-line complexity
   return () => {
-    if (!shouldRunSchema(schema, modifiers)) return;
-
-    const runResult = (schema as any).run(data);
-
-    if (!runResult.pass && runResult.path) {
-      // Use the top-level field name (first segment) for error reporting
-      const fieldName = runResult.path[0];
-      test(fieldName, runResult.message, () => false, fieldName);
+    if (
+      !shouldRunSchema(schema, modifiers) ||
+      !schemaRunResult ||
+      schemaRunResult.pass
+    ) {
+      return;
     }
+
+    const fieldName = schemaRunResult.path?.[0];
+    if (!fieldName) {
+      return;
+    }
+
+    test(
+      fieldName,
+      schemaRunResult.message ?? 'Validation failed',
+      () => false,
+      fieldName,
+    );
   };
 }
 
-function shouldRunSchema(schema: any, modifiers: any): boolean {
-  return !modifiers.only && !!schema && isFunction(schema.run);
+/**
+ * Runs schema parsing/validation in a safe order:
+ * 1) try parse
+ * 2) if parse succeeds and run exists, validate parsed value with run
+ * 3) on parse failure, fallback to run(raw)
+ *
+ * Returned payload is normalized so downstream consumers can rely on shape.
+ */
+function runSchemaWithParse(schema: any, data: unknown): SchemaRunResult {
+  if (isFunction(schema.parse)) {
+    try {
+      const parsedValue = schema.parse(data);
+
+      if (isFunction(schema.run)) {
+        return normalizeSchemaRunResult(schema.run(parsedValue), parsedValue);
+      }
+
+      return {
+        pass: true,
+        type: parsedValue,
+      };
+    } catch (_error) {
+      // parse may throw intentionally; fallback to run(raw) for path/message details.
+    }
+  }
+
+  if (isFunction(schema.run)) {
+    return normalizeSchemaRunResult(schema.run(data), data);
+  }
+
+  return {
+    pass: true,
+    type: data,
+  };
+}
+
+/**
+ * Converts unknown schema.run return value into a stable internal representation.
+ *
+ * This avoids runtime crashes when a custom schema returns malformed payloads.
+ */
+function normalizeSchemaRunResult(
+  candidate: unknown,
+  fallbackType: unknown,
+): SchemaRunResult {
+  if (!isSchemaRunResult(candidate)) {
+    return {
+      pass: false,
+      type: fallbackType,
+    };
+  }
+
+  return {
+    message: candidate.message,
+    pass: candidate.pass,
+    path: candidate.path,
+    type: candidate.type,
+  };
+}
+
+/**
+ * Runtime type guard for schema run payloads.
+ */
+
+function isSchemaRunResult(candidate: unknown): candidate is SchemaRunResult {
+  if (!isObject(candidate)) {
+    return false;
+  }
+
+  const value = candidate as Partial<SchemaRunResult>;
+
+  const hasPass = typeof value.pass === 'boolean';
+  const hasPath =
+    value.path === undefined ||
+    (isArray(value.path) && value.path.every(item => typeof item === 'string'));
+
+  return hasPass && hasPath;
+}
+
+/**
+ * Schema should run only when schema exists and the run is not field-focused.
+ */
+function shouldRunSchema(
+  schema: unknown,
+  modifiers: { only?: unknown },
+): boolean {
+  return !modifiers.only && !!schema;
 }

--- a/packages/vest/src/suiteResult/SuiteResultTypes.ts
+++ b/packages/vest/src/suiteResult/SuiteResultTypes.ts
@@ -55,9 +55,21 @@ export type GetFailuresResponse = FailureMessages | string[];
 export type FailureMessages = Record<string, string[]>;
 export type TSchema = any;
 
-export type InferSchemaData<S> = S extends { infer: infer T }
-  ? { [K in keyof T]: T[K] } & NonNullable<unknown>
-  : any;
+export type InferSchemaData<S> = S extends {
+  '~standard': { types: { input: infer I } };
+}
+  ? I
+  : S extends { infer: infer T }
+    ? { [K in keyof T]: T[K] } & NonNullable<unknown>
+    : any;
+
+export type InferSchemaOutput<S> = S extends {
+  '~standard': { types: { output: infer O } };
+}
+  ? O
+  : S extends { infer: infer T }
+    ? { [K in keyof T]: T[K] } & NonNullable<unknown>
+    : any;
 
 type SuiteResultData<
   F extends TFieldName,
@@ -67,7 +79,7 @@ type SuiteResultData<
   | (Omit<SuiteSummary<F, G>, 'valid'> &
       SuiteSelectors<F, G> & {
         valid: true;
-        value: InferSchemaData<S>;
+        value: InferSchemaOutput<S>;
         issues?: undefined;
       })
   | (Omit<SuiteSummary<F, G>, 'valid'> &
@@ -94,7 +106,7 @@ export type SuiteResult<
   dump: CB<TIsolateSuite>;
   types: S extends undefined
     ? undefined
-    : { input: InferSchemaData<S>; output: InferSchemaData<S> };
+    : { input: InferSchemaData<S>; output: InferSchemaOutput<S> };
 };
 
 // Public-facing aliases remain plain strings; internals can still brand via FieldName/GroupName.

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -20,15 +20,15 @@ export function useCreateSuiteResult<
   F extends TFieldName,
   G extends TGroupName,
   S extends TSchema = undefined,
->(schema?: S, data?: any): SuiteResult<F, G, S> {
+>(schema?: S, outputData?: any, inputData?: any): SuiteResult<F, G, S> {
   return useSuiteResultCache<F, G, S>(() => {
     // @vx-allow use-use
     const summary = useProduceSuiteSummary<F, G>();
-    const resultBody = constructSuiteResultObject<F, G, S>(summary, data);
+    const resultBody = constructSuiteResultObject<F, G, S>(summary, outputData);
     return freezeAssign(resultBody as SuiteResult<F, G, S>, {
       dump: VestRuntime.persist(VestRuntime.useAvailableRoot<TIsolateSuite>),
       types: (schema
-        ? { input: data, output: data }
+        ? { input: inputData, output: outputData }
         : undefined) as SuiteResult<F, G, S>['types'],
     }) as SuiteResult<F, G, S>;
   });


### PR DESCRIPTION
## Summary
Added a hardened schema-object utility layer (ownKeys, dangerous-key detection, safe own checks, safe shallow copy) and applied it across schema rules to prevent prototype-chain traversal and dangerous keys while returning parsed/coerced objects from schema validation flows. 

Added parse() support to rule instances and chain proxies, and updated chain execution to propagate transformed values through each predicate (currentValue = result.type) so composed rules can coerce deterministically. 
Updated Vest suite schema handling to pre-run parsing (with safe fallback), pass parsed data into suite callbacks, and carry separate input/output typing and runtime values in suite result metadata. 

Added architecture documentation for schema parsing, security decisions, parse semantics, and complexity tradeoffs in n4s/docs/schema.md.

Added integration/unit coverage for parse coercion, dangerous key rejection, RuleInstance parse behavior, and Vest callback/result propagation. 

