### PR TITLE
Expose parse() on rules, secure schema parsing, and propagate parsed output into suites

### DIFF
--- a/packages/n4s/docs/schema.md
+++ b/packages/n4s/docs/schema.md
@@ -1,0 +1,59 @@
+# n4s schema parsing architecture
+
+## Goals
+
+1. **Single-pass validation and transformation** for schema rules (`shape`, `loose`, `partial`).
+2. **Predictable parse API** available across plain rules and chains.
+3. **Security-first object traversal**, with explicit protection against dangerous keys used in prototype-pollution attacks.
+4. **O(1) lookup behavior** by relying on native object property checks and set membership checks.
+
+## Pipeline design
+
+Schema execution is now modeled as a parse pipeline:
+
+1. Validate the input container (must be object-like).
+2. Reject dangerous own keys (`__proto__`, `prototype`, `constructor`) on both schema and user input.
+3. Iterate schema keys using own-key iteration only (`Object.keys`).
+4. Run each field rule and collect the transformed output (`RuleRunReturn.type`).
+5. Return a parsed object with validated/coerced values.
+
+This keeps validation and transformation in one pass over the relevant keys.
+
+## Security decisions
+
+Schema object utilities centralize safety behavior:
+
+- `ownKeys` avoids prototype chain traversal.
+- `safeHasOwn` avoids `in` checks that include inherited keys.
+- `findDangerousOwnKey` short-circuits when dangerous keys are detected.
+- `safeShallowCopy` creates a sanitized shallow clone and omits dangerous keys.
+
+These utilities are used by `shape`, `loose`, and `partial` to ensure consistent behavior.
+
+## Parse API semantics
+
+Every `RuleInstance` now exposes:
+
+- `test(value)` → boolean
+- `validate(value)` → standard-schema result (`value` or `issues`)
+- `parse(value)` → transformed output or throws on validation failure
+- `run(value)` → internal `RuleRunReturn`
+
+Chains propagate transformed values through each step, so rules can compose coercions predictably.
+
+## Vest integration
+
+When a suite is created with a schema:
+
+- The schema parsing path is executed before the suite callback.
+- If `schema.parse` exists, it is used first.
+- On parse throw, Vest falls back to `schema.run` for rich path/message reporting.
+- The suite callback receives parsed data.
+- `SuiteResult.value` and `types.output` are parsed output.
+- `types.input` remains the original input.
+
+## Complexity notes
+
+- Key checks are O(1) average-case (`Set.has`, own-property checks).
+- Rule execution remains linear in the number of relevant keys: O(n).
+- No recursive cloning is performed in schema wrappers; copying is shallow by design.

--- a/packages/n4s/src/__tests__/parse.test.ts
+++ b/packages/n4s/src/__tests__/parse.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { enforce } from '../n4s';
+
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      toNumber: (value: unknown) => { pass: boolean; type: unknown };
+    }
+  }
+}
+
+describe('parse()', () => {
+  it('should expose parse on lazy rules', () => {
+    const validator = enforce.isString();
+    expect(typeof validator.parse).toBe('function');
+    expect(validator.parse('hello')).toBe('hello');
+  });
+
+  it('should throw on failed parse', () => {
+    const validator = enforce.isString().message('Must be string');
+    expect(() => validator.parse(100 as any)).toThrow('Must be string');
+  });
+
+  it('should return transformed output for schema rules', () => {
+    enforce.extend({
+      toNumber: (value: unknown) => {
+        const parsed = Number(value);
+        return Number.isNaN(parsed)
+          ? { pass: false, type: value }
+          : { pass: true, type: parsed };
+      },
+    });
+
+    const schema = enforce.shape({
+      age: enforce.toNumber(),
+    });
+
+    expect(schema.parse({ age: '42' })).toEqual({ age: 42 });
+  });
+});

--- a/packages/n4s/src/__tests__/parse.test.ts
+++ b/packages/n4s/src/__tests__/parse.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { enforce } from '../n4s';
 
@@ -11,6 +11,30 @@ declare global {
 }
 
 describe('parse()', () => {
+  let originalToNumber: unknown;
+
+  beforeEach(() => {
+    originalToNumber = (enforce as unknown as Record<string, unknown>).toNumber;
+
+    enforce.extend({
+      toNumber: (value: unknown) => {
+        const parsed = Number(value);
+        return Number.isNaN(parsed)
+          ? { pass: false, type: value }
+          : { pass: true, type: parsed };
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (originalToNumber === undefined) {
+      delete (enforce as unknown as Record<string, unknown>).toNumber;
+      return;
+    }
+
+    (enforce as unknown as Record<string, unknown>).toNumber = originalToNumber;
+  });
+
   it('should expose parse on lazy rules', () => {
     const validator = enforce.isString();
     expect(typeof validator.parse).toBe('function');
@@ -23,15 +47,6 @@ describe('parse()', () => {
   });
 
   it('should return transformed output for schema rules', () => {
-    enforce.extend({
-      toNumber: (value: unknown) => {
-        const parsed = Number(value);
-        return Number.isNaN(parsed)
-          ? { pass: false, type: value }
-          : { pass: true, type: parsed };
-      },
-    });
-
     const schema = enforce.shape({
       age: enforce.toNumber(),
     });

--- a/packages/n4s/src/__tests__/standardSchema.test.ts
+++ b/packages/n4s/src/__tests__/standardSchema.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from 'vitest';
 
 import { enforce } from '../n4s';
 
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      toNumberForParse: (value: unknown) => {
+        message: string;
+        pass: boolean;
+        type: number;
+      };
+    }
+  }
+}
+
 describe('n4s StandardSchema Support', () => {
   describe('Lazy Interface', () => {
     it('Should have the "~standard" property', () => {
@@ -60,6 +72,22 @@ describe('n4s StandardSchema Support', () => {
       expect((invalidResult as any).issues?.[0]).toHaveProperty('path');
       expect(Array.isArray((invalidResult as any).issues?.[0].path)).toBe(true);
     });
+  });
+
+  it('should expose .parse() and return transformed value when valid', async () => {
+    const { enforce } = await import('../n4s');
+    enforce.extend({
+      toNumberForParse: (value: any) => {
+        const parsed = Number(value);
+        return {
+          pass: !Number.isNaN(parsed),
+          type: parsed,
+          message: 'not numeric',
+        };
+      },
+    });
+
+    expect(enforce.toNumberForParse().parse('12')).toBe(12);
   });
 
   describe('Direct validate() method usage', () => {

--- a/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
+++ b/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
@@ -14,7 +14,7 @@ import { executeChain, type Predicate } from './chainExecutor';
 import { createChainProxyHandlers } from './proxyHandlers';
 
 export type RuleFunctions<T extends RuleInstance<any, any>> = Record<
-  keyof Omit<T, 'infer' | 'test' | 'validate' | '~standard'>,
+  keyof Omit<T, 'infer' | 'test' | 'validate' | 'parse' | '~standard'>,
   (...args: any[]) => boolean
 >;
 
@@ -72,6 +72,17 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
   }) as T['test'];
 
   // Internal compatibility method - converts StandardSchema Result to RuleRunReturn
+
+  const parse: T['parse'] = ((...args: any[]) => {
+    const result = validate(...args);
+    if (!result.issues) {
+      return result.value;
+    }
+
+    const [firstIssue] = result.issues;
+    throw new TypeError(firstIssue?.message || 'Validation failed');
+  }) as T['parse'];
+
   const run: T['run'] = ((...args: any[]) => {
     const result = executeChain(chain, args[0]);
     if (!result.pass && lazyMessage) {
@@ -105,6 +116,7 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
       } as StandardSchemaV1.Props<any, any>,
       add,
       message,
+      parse,
       run,
       test,
       validate,

--- a/packages/n4s/src/rules/chainBuilder/chainExecutor.ts
+++ b/packages/n4s/src/rules/chainBuilder/chainExecutor.ts
@@ -12,15 +12,18 @@ export function executeChain(
   chain: Predicate[],
   value: any,
 ): RuleRunReturn<any> {
+  let currentValue = value;
+
   for (const predicate of chain) {
-    const result = predicate(value);
+    const result = predicate(currentValue);
 
     if (isRuleRunReturn(result)) {
       if (!result.pass) return result as RuleRunReturn<any>;
+      currentValue = result.type;
     } else if (!result) {
-      return RuleRunReturn.Failing(value);
+      return RuleRunReturn.Failing(currentValue);
     }
   }
 
-  return RuleRunReturn.Passing(value);
+  return RuleRunReturn.Passing(currentValue);
 }

--- a/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
+++ b/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
@@ -8,7 +8,7 @@ import { getLazyRule } from './lazyRegistry';
 
 export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
   rules: Record<
-    keyof Omit<T, 'infer' | 'test' | 'validate' | '~standard'>,
+    keyof Omit<T, 'infer' | 'test' | 'validate' | 'parse' | '~standard'>,
     (...args: any[]) => boolean
   >,
   {
@@ -16,6 +16,7 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
     test,
     validate,
     run,
+    parse,
     message,
     '~standard': standard,
   }: {
@@ -23,16 +24,25 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
     test: T['test'];
     validate: T['validate'];
     run: T['run'];
+    parse: T['parse'];
     message: (msg: any) => T;
     '~standard': StandardSchemaV1.Props<any, any>;
   },
 ) {
-  const methods = { '~standard': standard, message, run, test, validate };
+  const methods = {
+    '~standard': standard,
+    message,
+    parse,
+    run,
+    test,
+    validate,
+  };
   const methodKeys = new Set([
     'infer',
     'test',
     'validate',
     'run',
+    'parse',
     'message',
     '~standard',
   ]);

--- a/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { enforce } from '../../../n4s';
+
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      toNumber: (value: unknown) => { pass: boolean; type: unknown };
+      trimString: (value: unknown) => { pass: boolean; type: unknown };
+    }
+  }
+}
+
+enforce.extend({
+  toNumber: (value: unknown) => {
+    const parsed = Number(value);
+    return Number.isNaN(parsed)
+      ? { pass: false, type: value }
+      : { pass: true, type: parsed };
+  },
+  trimString: (value: unknown) => {
+    if (typeof value !== 'string') {
+      return { pass: false, type: value };
+    }
+
+    return { pass: true, type: value.trim() };
+  },
+});
+
+describe('schema parse integration', () => {
+  it('shape parses nested values with custom coercions', () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        name: enforce.trimString(),
+        age: enforce.toNumber(),
+      }),
+    });
+
+    const result = schema.parse({
+      profile: { name: '  Jane  ', age: '34' },
+    });
+
+    expect(result).toEqual({
+      profile: { name: 'Jane', age: 34 },
+    });
+  });
+
+  it('loose parses known keys while keeping extra payload fields', () => {
+    const schema = enforce.loose({
+      amount: enforce.toNumber(),
+      title: enforce.trimString(),
+    });
+
+    const result = schema.parse({
+      amount: '49',
+      title: '  invoice ',
+      metadata: { source: 'api' },
+    });
+
+    expect(result).toEqual({
+      amount: 49,
+      title: 'invoice',
+      metadata: { source: 'api' },
+    });
+  });
+
+  it('partial parses only provided keys', () => {
+    const schema = enforce.partial({
+      page: enforce.toNumber(),
+      search: enforce.trimString(),
+    });
+
+    expect(schema.parse({ page: '2' })).toEqual({ page: 2 });
+    expect(schema.parse({ search: '  vest  ' })).toEqual({ search: 'vest' });
+  });
+
+  it('rejects dangerous own keys to prevent prototype pollution', () => {
+    const schema = enforce.loose({
+      safe: enforce.isString(),
+    });
+
+    const payload = JSON.parse('{"safe":"ok","__proto__":{"polluted":true}}');
+    const result = schema.run(payload);
+
+    expect(result.pass).toBe(false);
+    expect(result.path).toEqual(['__proto__']);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('rejects dangerous schema keys', () => {
+    const schema = enforce.shape(
+      JSON.parse('{"__proto__":true}') as Record<string, unknown> as any,
+    );
+
+    const result = schema.run({});
+
+    expect(result.pass).toBe(false);
+    expect(result.path).toEqual(['__proto__']);
+  });
+});

--- a/packages/n4s/src/rules/schemaRules/loose.ts
+++ b/packages/n4s/src/rules/schemaRules/loose.ts
@@ -4,6 +4,12 @@ import { ctx } from '../../enforceContext';
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
+import {
+  findDangerousOwnKey,
+  ownKeys,
+  safeHasOwn,
+  safeShallowCopy,
+} from './schemaObjectUtils';
 import type { ShapeType } from './shape';
 
 /**
@@ -45,8 +51,26 @@ export function loose<T extends Record<string, any>>(
     return RuleRunReturn.Failing(value);
   }
 
-  for (const key in schema) {
-    const fieldValue = key in value ? value[key] : undefined;
+  const dangerousSchemaKey = findDangerousOwnKey(schema);
+  if (dangerousSchemaKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [dangerousSchemaKey],
+    };
+  }
+
+  const dangerousValueKey = findDangerousOwnKey(value);
+  if (dangerousValueKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [dangerousValueKey],
+    };
+  }
+
+  const parsedValue: Record<string, any> = safeShallowCopy(value);
+
+  for (const key of ownKeys(schema)) {
+    const fieldValue = safeHasOwn(value, key) ? value[key] : undefined;
     const res = ctx.run({ value: fieldValue, set: true, meta: { key } }, () =>
       schema[key].run(fieldValue),
     );
@@ -55,8 +79,11 @@ export function loose<T extends Record<string, any>>(
       const newRes = { ...res, path: [key, ...currentPath] };
       return newRes as RuleRunReturn<T>;
     }
+
+    parsedValue[key] = res.type;
   }
-  return RuleRunReturn.Passing(value);
+
+  return RuleRunReturn.Passing(parsedValue as T);
 }
 
 // Types colocated with loose rule

--- a/packages/n4s/src/rules/schemaRules/loose.ts
+++ b/packages/n4s/src/rules/schemaRules/loose.ts
@@ -5,8 +5,8 @@ import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
 import {
-  findDangerousOwnKey,
   ownKeys,
+  rejectDangerousKeys,
   safeShallowCopy,
 } from './schemaObjectUtils';
 import type { ShapeType } from './shape';
@@ -50,20 +50,9 @@ export function loose<T extends Record<string, any>>(
     return RuleRunReturn.Failing(value);
   }
 
-  const dangerousSchemaKey = findDangerousOwnKey(schema);
-  if (dangerousSchemaKey) {
-    return {
-      ...RuleRunReturn.Failing(value),
-      path: [dangerousSchemaKey],
-    };
-  }
-
-  const dangerousValueKey = findDangerousOwnKey(value);
-  if (dangerousValueKey) {
-    return {
-      ...RuleRunReturn.Failing(value),
-      path: [dangerousValueKey],
-    };
+  const rejected = rejectDangerousKeys(value, schema);
+  if (rejected) {
+    return rejected;
   }
 
   const parsedValue: Record<string, any> = safeShallowCopy(value);

--- a/packages/n4s/src/rules/schemaRules/loose.ts
+++ b/packages/n4s/src/rules/schemaRules/loose.ts
@@ -1,4 +1,4 @@
-import { isObject } from 'vest-utils';
+import { hasOwnProperty, isObject } from 'vest-utils';
 
 import { ctx } from '../../enforceContext';
 import type { RuleInstance } from '../../utils/RuleInstance';
@@ -7,7 +7,6 @@ import { RuleRunReturn } from '../../utils/RuleRunReturn';
 import {
   findDangerousOwnKey,
   ownKeys,
-  safeHasOwn,
   safeShallowCopy,
 } from './schemaObjectUtils';
 import type { ShapeType } from './shape';
@@ -70,7 +69,7 @@ export function loose<T extends Record<string, any>>(
   const parsedValue: Record<string, any> = safeShallowCopy(value);
 
   for (const key of ownKeys(schema)) {
-    const fieldValue = safeHasOwn(value, key) ? value[key] : undefined;
+    const fieldValue = hasOwnProperty(value, key) ? value[key] : undefined;
     const res = ctx.run({ value: fieldValue, set: true, meta: { key } }, () =>
       schema[key].run(fieldValue),
     );

--- a/packages/n4s/src/rules/schemaRules/partial.ts
+++ b/packages/n4s/src/rules/schemaRules/partial.ts
@@ -53,7 +53,6 @@ function validateProvidedKeys<T extends Record<string, any>>(
         const result = RuleRunReturn.Failing(value);
         result.message = res.message;
         result.path = [key, ...currentPath];
-        result.type = res.type as T;
 
         return { ok: false, result };
       }
@@ -125,11 +124,12 @@ export function partial<T extends Record<string, any>>(
     return result;
   }
 
-  const parsedValue = safeShallowCopy(value);
   const parsedEntriesResult = validateProvidedKeys(value, schema);
   if (!parsedEntriesResult.ok) {
     return parsedEntriesResult.result;
   }
+
+  const parsedValue = safeShallowCopy(value);
 
   return RuleRunReturn.Passing({
     ...parsedValue,

--- a/packages/n4s/src/rules/schemaRules/partial.ts
+++ b/packages/n4s/src/rules/schemaRules/partial.ts
@@ -5,8 +5,8 @@ import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
 import {
-  findDangerousOwnKey,
   ownKeys,
+  rejectDangerousKeys,
   safeShallowCopy,
 } from './schemaObjectUtils';
 import type { ShapeType } from './shape';
@@ -27,6 +27,10 @@ function getFirstExtraKey<T extends Record<string, any>>(
   return null;
 }
 
+type ParsedKeysResult<T extends Record<string, any>> =
+  | { ok: true; parsedEntries: Record<string, any> }
+  | { ok: false; result: RuleRunReturn<T> };
+
 /**
  * Validates provided keys against their schema rules and returns parsed entries.
  *
@@ -35,7 +39,7 @@ function getFirstExtraKey<T extends Record<string, any>>(
 function validateProvidedKeys<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
-): RuleRunReturn<T> | { parsedEntries: Record<string, any> } {
+): ParsedKeysResult<T> {
   const parsedEntries: Record<string, any> = {};
 
   for (const key of ownKeys(schema)) {
@@ -46,17 +50,19 @@ function validateProvidedKeys<T extends Record<string, any>>(
       );
       if (!res.pass) {
         const currentPath = res.path || [];
-        return {
-          ...res,
-          path: [key, ...currentPath],
-        } as RuleRunReturn<T>;
+        const result = RuleRunReturn.Failing(value);
+        result.message = res.message;
+        result.path = [key, ...currentPath];
+        result.type = res.type as T;
+
+        return { ok: false, result };
       }
 
       parsedEntries[key] = res.type;
     }
   }
 
-  return { parsedEntries };
+  return { ok: true, parsedEntries };
 }
 
 /**
@@ -98,7 +104,7 @@ function validateProvidedKeys<T extends Record<string, any>>(
  * updateSchema.test({ name: 'Jane', extra: 'x' }); // false (extra key not in schema)
  * ```
  */
-// eslint-disable-next-line complexity
+
 export function partial<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
@@ -107,39 +113,27 @@ export function partial<T extends Record<string, any>>(
     return RuleRunReturn.Failing(value);
   }
 
-  const dangerousSchemaKey = findDangerousOwnKey(schema);
-  if (dangerousSchemaKey) {
-    return {
-      ...RuleRunReturn.Failing(value),
-      path: [dangerousSchemaKey],
-    };
-  }
-
-  const dangerousValueKey = findDangerousOwnKey(value);
-  if (dangerousValueKey) {
-    return {
-      ...RuleRunReturn.Failing(value),
-      path: [dangerousValueKey],
-    };
+  const rejected = rejectDangerousKeys(value, schema);
+  if (rejected) {
+    return rejected;
   }
 
   const extraKey = getFirstExtraKey(value, schema);
   if (extraKey) {
-    return {
-      ...RuleRunReturn.Failing(value),
-      path: [extraKey],
-    };
+    const result = RuleRunReturn.Failing(value);
+    result.path = [extraKey];
+    return result;
   }
 
   const parsedValue = safeShallowCopy(value);
-  const parsedEntriesOrFailure = validateProvidedKeys(value, schema);
-  if ('pass' in parsedEntriesOrFailure) {
-    return parsedEntriesOrFailure;
+  const parsedEntriesResult = validateProvidedKeys(value, schema);
+  if (!parsedEntriesResult.ok) {
+    return parsedEntriesResult.result;
   }
 
   return RuleRunReturn.Passing({
     ...parsedValue,
-    ...parsedEntriesOrFailure.parsedEntries,
+    ...parsedEntriesResult.parsedEntries,
   } as T);
 }
 

--- a/packages/n4s/src/rules/schemaRules/partial.ts
+++ b/packages/n4s/src/rules/schemaRules/partial.ts
@@ -4,21 +4,28 @@ import { ctx } from '../../enforceContext';
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
+import {
+  findDangerousOwnKey,
+  ownKeys,
+  safeHasOwn,
+  safeShallowCopy,
+} from './schemaObjectUtils';
 import type { ShapeType } from './shape';
 
 /**
  * Checks if value has any keys not present in schema.
  */
-function hasExtraKeys<T extends Record<string, any>>(
+function getFirstExtraKey<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
-): boolean {
-  for (const key in value) {
-    if (!(key in schema)) {
-      return true;
+): string | null {
+  for (const key of ownKeys(value)) {
+    if (!safeHasOwn(schema, key)) {
+      return key;
     }
   }
-  return false;
+
+  return null;
 }
 
 /**
@@ -28,16 +35,23 @@ function hasExtraKeys<T extends Record<string, any>>(
 function validateProvidedKeys<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
+  parsedValue: Record<string, any>,
 ): RuleRunReturn<T> | null {
-  for (const key in schema) {
-    if (key in value) {
+  for (const key of ownKeys(schema)) {
+    if (safeHasOwn(value, key)) {
       const fieldValue = value[key];
       const res = ctx.run({ value: fieldValue, set: true, meta: { key } }, () =>
         schema[key].run(fieldValue),
       );
       if (!res.pass) {
-        return res as RuleRunReturn<T>;
+        const currentPath = res.path || [];
+        return {
+          ...res,
+          path: [key, ...currentPath],
+        } as RuleRunReturn<T>;
       }
+
+      parsedValue[key] = res.type;
     }
   }
   return null;
@@ -82,6 +96,7 @@ function validateProvidedKeys<T extends Record<string, any>>(
  * updateSchema.test({ name: 'Jane', extra: 'x' }); // false (extra key not in schema)
  * ```
  */
+// eslint-disable-next-line complexity
 export function partial<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
@@ -90,16 +105,37 @@ export function partial<T extends Record<string, any>>(
     return RuleRunReturn.Failing(value);
   }
 
-  if (hasExtraKeys(value, schema)) {
-    return RuleRunReturn.Failing(value);
+  const dangerousSchemaKey = findDangerousOwnKey(schema);
+  if (dangerousSchemaKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [dangerousSchemaKey],
+    };
   }
 
-  const validationResult = validateProvidedKeys(value, schema);
+  const dangerousValueKey = findDangerousOwnKey(value);
+  if (dangerousValueKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [dangerousValueKey],
+    };
+  }
+
+  const extraKey = getFirstExtraKey(value, schema);
+  if (extraKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [extraKey],
+    };
+  }
+
+  const parsedValue = safeShallowCopy(value);
+  const validationResult = validateProvidedKeys(value, schema, parsedValue);
   if (validationResult) {
     return validationResult;
   }
 
-  return RuleRunReturn.Passing(value);
+  return RuleRunReturn.Passing(parsedValue as T);
 }
 
 // Types colocated with partial rule

--- a/packages/n4s/src/rules/schemaRules/partial.ts
+++ b/packages/n4s/src/rules/schemaRules/partial.ts
@@ -1,4 +1,4 @@
-import { isObject } from 'vest-utils';
+import { hasOwnProperty, isObject } from 'vest-utils';
 
 import { ctx } from '../../enforceContext';
 import type { RuleInstance } from '../../utils/RuleInstance';
@@ -7,7 +7,6 @@ import { RuleRunReturn } from '../../utils/RuleRunReturn';
 import {
   findDangerousOwnKey,
   ownKeys,
-  safeHasOwn,
   safeShallowCopy,
 } from './schemaObjectUtils';
 import type { ShapeType } from './shape';
@@ -20,7 +19,7 @@ function getFirstExtraKey<T extends Record<string, any>>(
   schema: Record<string, any>,
 ): string | null {
   for (const key of ownKeys(value)) {
-    if (!safeHasOwn(schema, key)) {
+    if (!hasOwnProperty(schema, key)) {
       return key;
     }
   }
@@ -29,16 +28,18 @@ function getFirstExtraKey<T extends Record<string, any>>(
 }
 
 /**
- * Validates provided keys against their schema rules.
+ * Validates provided keys against their schema rules and returns parsed entries.
+ *
  * Missing keys are allowed (partial validation).
  */
 function validateProvidedKeys<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
-  parsedValue: Record<string, any>,
-): RuleRunReturn<T> | null {
+): RuleRunReturn<T> | { parsedEntries: Record<string, any> } {
+  const parsedEntries: Record<string, any> = {};
+
   for (const key of ownKeys(schema)) {
-    if (safeHasOwn(value, key)) {
+    if (hasOwnProperty(value, key)) {
       const fieldValue = value[key];
       const res = ctx.run({ value: fieldValue, set: true, meta: { key } }, () =>
         schema[key].run(fieldValue),
@@ -51,10 +52,11 @@ function validateProvidedKeys<T extends Record<string, any>>(
         } as RuleRunReturn<T>;
       }
 
-      parsedValue[key] = res.type;
+      parsedEntries[key] = res.type;
     }
   }
-  return null;
+
+  return { parsedEntries };
 }
 
 /**
@@ -130,12 +132,15 @@ export function partial<T extends Record<string, any>>(
   }
 
   const parsedValue = safeShallowCopy(value);
-  const validationResult = validateProvidedKeys(value, schema, parsedValue);
-  if (validationResult) {
-    return validationResult;
+  const parsedEntriesOrFailure = validateProvidedKeys(value, schema);
+  if ('pass' in parsedEntriesOrFailure) {
+    return parsedEntriesOrFailure;
   }
 
-  return RuleRunReturn.Passing(parsedValue as T);
+  return RuleRunReturn.Passing({
+    ...parsedValue,
+    ...parsedEntriesOrFailure.parsedEntries,
+  } as T);
 }
 
 // Types colocated with partial rule

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -1,0 +1,68 @@
+import { hasOwnProperty, isObject } from 'vest-utils';
+
+/**
+ * Keys that can mutate object prototypes when assigned.
+ *
+ * This set is intentionally tiny and lookup is O(1).
+ */
+const DANGEROUS_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+/**
+ * Returns only own enumerable keys for object-like values.
+ *
+ * Prototype keys are never traversed which prevents inherited-key surprises.
+ */
+export function ownKeys(value: unknown): string[] {
+  if (!isObject(value)) {
+    return [];
+  }
+
+  return Object.keys(value as Record<string, unknown>);
+}
+
+/**
+ * Checks whether a key is known to be unsafe for object assignment/traversal.
+ */
+export function isDangerousKey(key: string): boolean {
+  return DANGEROUS_KEYS.has(key);
+}
+
+/**
+ * Safe own-property check that does not rely on user-provided prototypes.
+ */
+export function safeHasOwn(value: unknown, key: string): boolean {
+  return hasOwnProperty(value, key);
+}
+
+/**
+ * Returns the first dangerous own key if present; otherwise null.
+ */
+export function findDangerousOwnKey(value: unknown): string | null {
+  for (const key of ownKeys(value)) {
+    if (isDangerousKey(key)) {
+      return key;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Produces a shallow sanitized copy that excludes dangerous keys.
+ *
+ * Shallow copy is intentional for performance; nested rules are responsible
+ * for validating nested payloads.
+ */
+export function safeShallowCopy<T extends Record<string, any>>(value: T): T {
+  const output: Record<string, any> = {};
+
+  for (const key of ownKeys(value)) {
+    if (isDangerousKey(key)) {
+      continue;
+    }
+
+    output[key] = value[key];
+  }
+
+  return output as T;
+}

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -75,7 +75,7 @@ export function rejectDangerousKeys<T extends Record<string, any>>(
   if (dangerousSchemaKey) {
     const result = RuleRunReturn.Failing(value);
     result.message = `dangerous key in schema: ${dangerousSchemaKey}`;
-    result.path = ['<schema>', dangerousSchemaKey];
+    result.path = [dangerousSchemaKey];
     return result;
   }
 

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -74,13 +74,15 @@ export function rejectDangerousKeys<T extends Record<string, any>>(
   const dangerousSchemaKey = findDangerousOwnKey(schema);
   if (dangerousSchemaKey) {
     const result = RuleRunReturn.Failing(value);
-    result.path = [dangerousSchemaKey];
+    result.message = `dangerous key in schema: ${dangerousSchemaKey}`;
+    result.path = ['<schema>', dangerousSchemaKey];
     return result;
   }
 
   const dangerousValueKey = findDangerousOwnKey(value);
   if (dangerousValueKey) {
     const result = RuleRunReturn.Failing(value);
+    result.message = `dangerous key in value: ${dangerousValueKey}`;
     result.path = [dangerousValueKey];
     return result;
   }

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -28,13 +28,6 @@ export function isDangerousKey(key: string): boolean {
 }
 
 /**
- * Safe own-property check that does not rely on user-provided prototypes.
- */
-export function safeHasOwn(value: unknown, key: string): boolean {
-  return hasOwnProperty(value, key);
-}
-
-/**
  * Returns the first dangerous own key if present; otherwise null.
  */
 export function findDangerousOwnKey(value: unknown): string | null {
@@ -48,12 +41,12 @@ export function findDangerousOwnKey(value: unknown): string | null {
 }
 
 /**
- * Produces a shallow sanitized copy that excludes dangerous keys.
- *
- * Shallow copy is intentional for performance; nested rules are responsible
- * for validating nested payloads.
+ * Produces a plain shallow sanitized copy that includes only own enumerable keys
+ * and excludes dangerous keys. Prototype and non-enumerable properties are not preserved.
  */
-export function safeShallowCopy<T extends Record<string, any>>(value: T): T {
+export function safeShallowCopy(
+  value: Record<string, any>,
+): Record<string, any> {
   const output: Record<string, any> = {};
 
   for (const key of ownKeys(value)) {
@@ -61,8 +54,10 @@ export function safeShallowCopy<T extends Record<string, any>>(value: T): T {
       continue;
     }
 
-    output[key] = value[key];
+    if (hasOwnProperty(value, key)) {
+      output[key] = value[key];
+    }
   }
 
-  return output as T;
+  return output;
 }

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -1,4 +1,6 @@
-import { hasOwnProperty, isObject } from 'vest-utils';
+import { isObject } from 'vest-utils';
+
+import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
 /**
  * Keys that can mutate object prototypes when assigned.
@@ -49,15 +51,39 @@ export function safeShallowCopy(
 ): Record<string, any> {
   const output: Record<string, any> = {};
 
+  // ownKeys already guarantees own enumerable keys only.
   for (const key of ownKeys(value)) {
     if (isDangerousKey(key)) {
       continue;
     }
 
-    if (hasOwnProperty(value, key)) {
-      output[key] = value[key];
-    }
+    output[key] = value[key];
   }
 
   return output;
+}
+
+/**
+ * Rejects dangerous keys in both schema and runtime value and returns a failing
+ * RuleRunReturn when such key is found.
+ */
+export function rejectDangerousKeys<T extends Record<string, any>>(
+  value: T,
+  schema: Record<string, any>,
+): RuleRunReturn<T> | null {
+  const dangerousSchemaKey = findDangerousOwnKey(schema);
+  if (dangerousSchemaKey) {
+    const result = RuleRunReturn.Failing(value);
+    result.path = [dangerousSchemaKey];
+    return result;
+  }
+
+  const dangerousValueKey = findDangerousOwnKey(value);
+  if (dangerousValueKey) {
+    const result = RuleRunReturn.Failing(value);
+    result.path = [dangerousValueKey];
+    return result;
+  }
+
+  return null;
 }

--- a/packages/n4s/src/rules/schemaRules/shape.ts
+++ b/packages/n4s/src/rules/schemaRules/shape.ts
@@ -1,8 +1,10 @@
+import { hasOwnProperty } from 'vest-utils';
+
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
 import { loose } from './loose';
-import { ownKeys, safeHasOwn } from './schemaObjectUtils';
+import { ownKeys } from './schemaObjectUtils';
 
 /**
  * Validates that an object matches a schema exactly - all keys required, no extra keys allowed.
@@ -44,7 +46,7 @@ export function shape<T extends Record<string, any>>(
   }
 
   for (const key of ownKeys(value)) {
-    if (!safeHasOwn(schema, key)) {
+    if (!hasOwnProperty(schema, key)) {
       const res = RuleRunReturn.Failing(value);
       const newRes = { ...res, path: [key] };
       return newRes;

--- a/packages/n4s/src/rules/schemaRules/shape.ts
+++ b/packages/n4s/src/rules/schemaRules/shape.ts
@@ -1,9 +1,8 @@
-import { hasOwnProperty } from 'vest-utils';
-
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
 import { loose } from './loose';
+import { ownKeys, safeHasOwn } from './schemaObjectUtils';
 
 /**
  * Validates that an object matches a schema exactly - all keys required, no extra keys allowed.
@@ -44,15 +43,15 @@ export function shape<T extends Record<string, any>>(
     return baseRes;
   }
 
-  for (const key in value) {
-    if (!hasOwnProperty(schema, key)) {
+  for (const key of ownKeys(value)) {
+    if (!safeHasOwn(schema, key)) {
       const res = RuleRunReturn.Failing(value);
       const newRes = { ...res, path: [key] };
       return newRes;
     }
   }
 
-  return RuleRunReturn.Passing(value);
+  return RuleRunReturn.Passing(baseRes.type);
 }
 
 // Types colocated with shape rule

--- a/packages/n4s/src/utils/RuleInstance.ts
+++ b/packages/n4s/src/utils/RuleInstance.ts
@@ -41,6 +41,9 @@ export class RuleInstance<T, Args extends any[] = any[]> {
   // Type-only declaration for the StandardSchema validate method
   validate!: (...args: Args) => StandardSchemaV1.Result<T>;
 
+  // Type-only declaration for parse helper that throws on issues
+  parse!: (...args: Args) => T;
+
   // Type-only declaration for StandardSchema property
   '~standard'!: StandardSchemaV1.Props<Args[0], T>;
 
@@ -77,6 +80,16 @@ export class RuleInstance<T, Args extends any[] = any[]> {
       return rule(...args);
     };
 
+    const parse = (...args: Args): T => {
+      const result = validate(...args);
+      if (!result.issues) {
+        return result.value;
+      }
+
+      const [firstIssue] = result.issues;
+      throw new TypeError(firstIssue?.message || 'Validation failed');
+    };
+
     return {
       '~standard': {
         types: {
@@ -89,6 +102,7 @@ export class RuleInstance<T, Args extends any[] = any[]> {
       },
       infer: {} as T,
       run,
+      parse,
       test: (...args: Args) => {
         const result = validate(...args);
         return !result.issues;

--- a/packages/n4s/src/utils/RuleRunReturn.ts
+++ b/packages/n4s/src/utils/RuleRunReturn.ts
@@ -65,13 +65,14 @@ export class RuleRunReturn<T> {
     }
 
     const resolvedPass = !!pass.pass;
-    const resolvedType = resolvedPass
-      ? (pass.type ?? type)
-      : (type ?? pass.type);
+
+    const successType = pass.type === undefined ? type : pass.type;
+    const failureType = type === undefined ? pass.type : type;
+    const resolvedType = (resolvedPass ? successType : failureType) as T;
 
     const res = new RuleRunReturn(
       resolvedPass,
-      resolvedType,
+      resolvedType as T,
       dynamicValue(message ?? pass.message, type),
     );
 

--- a/packages/n4s/src/utils/RuleRunReturn.ts
+++ b/packages/n4s/src/utils/RuleRunReturn.ts
@@ -52,6 +52,7 @@ export class RuleRunReturn<T> {
     return RuleRunReturn.fromObject(pass, type, message);
   }
 
+  // eslint-disable-next-line complexity
   private static fromObject<T>(
     pass: any,
     type: T,
@@ -63,9 +64,14 @@ export class RuleRunReturn<T> {
       return new RuleRunReturn(false, type, dynamicValue(message, type));
     }
 
+    const resolvedPass = !!pass.pass;
+    const resolvedType = resolvedPass
+      ? (pass.type ?? type)
+      : (type ?? pass.type);
+
     const res = new RuleRunReturn(
-      !!pass.pass,
-      type ?? pass.type,
+      resolvedPass,
+      resolvedType,
       dynamicValue(message ?? pass.message, type),
     );
 

--- a/packages/n4s/src/utils/__tests__/RuleInstance.test.ts
+++ b/packages/n4s/src/utils/__tests__/RuleInstance.test.ts
@@ -62,4 +62,34 @@ describe('RuleInstance.create', () => {
       ],
     });
   });
+
+  it('parse() returns transformed output for valid input', () => {
+    type R = RuleInstance<number, [string]>;
+
+    const toNumber = (value: string) => {
+      const parsed = Number(value);
+      return Number.isNaN(parsed)
+        ? RuleRunReturn.Failing(value as any, 'not a number')
+        : RuleRunReturn.Passing(parsed);
+    };
+
+    const rule = RuleInstance.create<R, number, [string]>(toNumber as any);
+
+    expect(rule.parse('15')).toBe(15);
+  });
+
+  it('parse() throws when validation fails', () => {
+    type R = RuleInstance<number, [string]>;
+
+    const toNumber = (value: string) => {
+      const parsed = Number(value);
+      return Number.isNaN(parsed)
+        ? RuleRunReturn.Failing(value as any, 'not a number')
+        : RuleRunReturn.Passing(parsed);
+    };
+
+    const rule = RuleInstance.create<R, number, [string]>(toNumber as any);
+
+    expect(() => rule.parse('bad')).toThrow('not a number');
+  });
 });

--- a/packages/n4s/src/utils/__tests__/RuleRunReturn.test.ts
+++ b/packages/n4s/src/utils/__tests__/RuleRunReturn.test.ts
@@ -67,8 +67,8 @@ describe('RuleRunReturn', () => {
       const msgFn = vi.fn((t: string) => `outer:${t}`);
       const res = RuleRunReturn.create(inner, 'OUTER', msgFn);
 
-      // final type prefers explicit type
-      expect(res.type).toBe('OUTER');
+      // final type preserves inner transformed type on pass
+      expect(res.type).toBe('INNER');
       // message function receives the second arg to create (OUTER)
       expect(res.message).toBe('outer:OUTER');
       expect(msgFn).toHaveBeenCalledTimes(1);

--- a/packages/n4s/src/utils/__tests__/RuleRunReturn.test.ts
+++ b/packages/n4s/src/utils/__tests__/RuleRunReturn.test.ts
@@ -62,6 +62,17 @@ describe('RuleRunReturn', () => {
       expect(res.message).toBe('outer');
     });
 
+    it('falls back to provided type when inner passing type is undefined', () => {
+      const inner = new (RuleRunReturn as any)(
+        true,
+        undefined,
+      ) as RuleRunReturn<any>;
+      const res = RuleRunReturn.create(inner, 'FALLBACK');
+
+      expect(res.pass).toBe(true);
+      expect(res.type).toBe('FALLBACK');
+    });
+
     it('invokes provided message function with provided type argument', () => {
       const inner = RuleRunReturn.Passing('INNER');
       const msgFn = vi.fn((t: string) => `outer:${t}`);

--- a/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
@@ -112,6 +112,37 @@ describe('suite schema parse integration', () => {
     expect(result.value).toBeUndefined();
   });
 
+  it('treats Valibot parse errors as expected validation failures', () => {
+    const schema = {
+      parse: () => {
+        throw { message: 'valibot parse failed', name: 'ValiError' };
+      },
+      run: () => ({
+        message: 'quantity must be numeric',
+        pass: false,
+        path: ['quantity'],
+        type: { quantity: NaN },
+      }),
+    };
+
+    const suite = create(() => {}, schema as any);
+
+    const result = suite.run({ quantity: 'not-a-number' } as any);
+
+    expect(result.hasErrors('quantity')).toBe(true);
+  });
+
+  it('fails with a clear error when schema is misconfigured', () => {
+    const suite = create(() => {}, { unexpected: true } as any);
+
+    const result = suite.run({ quantity: '10' } as any);
+
+    expect(result.hasErrors()).toBe(true);
+    expect(JSON.stringify(result.getErrors())).toContain(
+      'Misconfigured schema',
+    );
+  });
+
   it('maps security-related schema run paths into suite errors', () => {
     const schema = {
       parse: (value: any) => value,

--- a/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
@@ -83,7 +83,7 @@ describe('suite schema parse integration', () => {
       parse: (value: any) => {
         const quantity = Number(value.quantity);
         if (Number.isNaN(quantity)) {
-          throw new Error('parse failed');
+          throw { message: 'parse failed', name: 'ValidationError' };
         }
 
         return { quantity };

--- a/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import { create, enforce, test } from '../../vest';
+
+describe('suite schema parse integration', () => {
+  it('passes parsed output to callback and result.value', () => {
+    const schema = {
+      parse: (value: any) => ({
+        quantity: Number(value.quantity),
+        label: String(value.label).trim(),
+      }),
+      run: (value: any) => {
+        const quantity = Number(value.quantity);
+        if (Number.isNaN(quantity)) {
+          return {
+            message: 'quantity must be numeric',
+            pass: false,
+            path: ['quantity'],
+            type: value,
+          };
+        }
+
+        return {
+          pass: true,
+          type: {
+            quantity,
+            label: String(value.label).trim(),
+          },
+        };
+      },
+    };
+
+    let callbackData: any;
+
+    const suite = create((data: any) => {
+      callbackData = data;
+
+      test('quantity', () => {
+        enforce(data.quantity).isNumber();
+      });
+    }, schema as any);
+
+    const result = suite.run({ quantity: '10', label: '  item  ' } as any);
+
+    expect(callbackData).toEqual({ quantity: 10, label: 'item' });
+    expect(result.value).toEqual({ quantity: 10, label: 'item' });
+    expect((result.types as any)?.output).toEqual({
+      quantity: 10,
+      label: 'item',
+    });
+  });
+
+  it('uses parsed data with extra payload keys', () => {
+    const schema = {
+      parse: (value: any) => ({
+        amount: Number(value.amount),
+        extra: value.extra,
+      }),
+      run: (value: any) => ({
+        pass: !Number.isNaN(Number(value.amount)),
+        path: ['amount'],
+        type: { amount: Number(value.amount), extra: value.extra },
+      }),
+    };
+
+    let callbackAmount: unknown;
+
+    const suite = create((data: any) => {
+      callbackAmount = data.amount;
+      test('amount', () => {
+        enforce(data.amount).isNumber();
+      });
+    }, schema as any);
+
+    const result = suite.run({ amount: '7', extra: 'keep' } as any);
+
+    expect(callbackAmount).toBe(7);
+    expect(result.value).toEqual({ amount: 7, extra: 'keep' });
+  });
+
+  it('falls back to original input when parse fails', () => {
+    const schema = {
+      parse: (value: any) => {
+        const quantity = Number(value.quantity);
+        if (Number.isNaN(quantity)) {
+          throw new Error('parse failed');
+        }
+
+        return { quantity };
+      },
+      run: (value: any) => ({
+        message: 'quantity must be numeric',
+        pass: !Number.isNaN(Number(value.quantity)),
+        path: ['quantity'],
+        type: { quantity: Number(value.quantity) },
+      }),
+    };
+
+    let callbackData: any;
+
+    const suite = create((data: any) => {
+      callbackData = data;
+      test('quantity', () => {
+        enforce(data.quantity).isNotEmpty();
+      });
+    }, schema as any);
+
+    const result = suite.run({ quantity: 'not-a-number' } as any);
+
+    expect(callbackData).toEqual({ quantity: 'not-a-number' });
+    expect(result.hasErrors('quantity')).toBe(true);
+    expect(result.value).toBeUndefined();
+  });
+
+  it('maps security-related schema run paths into suite errors', () => {
+    const schema = {
+      parse: (value: any) => value,
+      run: () => ({
+        message: 'dangerous key',
+        pass: false,
+        path: ['security'],
+        type: {},
+      }),
+    };
+
+    const suite = create(() => {}, schema as any);
+
+    const result = suite.run({ name: 'safe' } as any);
+
+    expect(result.hasErrors()).toBe(true);
+    expect(result.hasErrors('security')).toBe(true);
+  });
+});

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -148,9 +148,9 @@ describe('Schema Runtime Validation', () => {
         user: { name: 123, age: 'thirty' },
       } as any);
 
-      // Schema will report the first failure under 'user' field
-      expect(result.hasErrors('user')).toBe(true);
-      const errors = result.getErrors('user');
+      // Schema reports nested paths with full field specificity
+      expect(result.hasErrors('user.name')).toBe(true);
+      const errors = result.getErrors('user.name');
 
       // The error message should be one of the nested field's custom messages
       expect(errors).toContain('User name must be a string');
@@ -271,26 +271,28 @@ describe('Schema Runtime Validation', () => {
     });
   });
 
-  it('should pass parsed schema output into the suite callback', () => {
-    const schemaWithParsing = {
-      parse: (value: any) => ({ age: Number(value.age) }),
-      run: (value: any) => ({ pass: true, type: { age: Number(value.age) } }),
-    } as any;
+  describe('Parsed schema output', () => {
+    it('should pass parsed schema output into the suite callback', () => {
+      const schemaWithParsing = {
+        parse: (value: any) => ({ age: Number(value.age) }),
+        run: (value: any) => ({ pass: true, type: { age: Number(value.age) } }),
+      } as any;
 
-    let receivedAge: unknown;
-    const parsedSuite = create((data: any) => {
-      receivedAge = data.age;
-      test('age', () => {
-        enforce(data.age).isNumber();
-      });
-    }, schemaWithParsing);
+      let receivedAge: unknown;
+      const parsedSuite = create((data: any) => {
+        receivedAge = data.age;
+        test('age', () => {
+          enforce(data.age).isNumber();
+        });
+      }, schemaWithParsing);
 
-    const result = parsedSuite.run({ age: '32' } as any);
+      const result = parsedSuite.run({ age: '32' } as any);
 
-    expect(receivedAge).toBe(32);
-    expect(result.value).toEqual({ age: 32 });
-    expect((result.types as any)?.output).toEqual({ age: 32 });
-    expect(result.isValid()).toBe(true);
+      expect(receivedAge).toBe(32);
+      expect(result.value).toEqual({ age: 32 });
+      expect((result.types as any)?.output).toEqual({ age: 32 });
+      expect(result.isValid()).toBe(true);
+    });
   });
 
   describe('Stateful behavior', () => {

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -4,6 +4,14 @@ import { describe, it, expect } from 'vitest';
 import { create, test } from '../../vest';
 
 describe('Schema Runtime Validation', () => {
+  enforce.extend({
+    toNumber: (value: unknown) => {
+      const parsed = Number(value);
+      return Number.isNaN(parsed)
+        ? { pass: false, type: value }
+        : { pass: true, type: parsed };
+    },
+  });
   const schema = enforce.shape({
     name: enforce.isString(),
     age: enforce.isNumber(),
@@ -261,6 +269,28 @@ describe('Schema Runtime Validation', () => {
       expect(res.pass).toBe(false);
       expect(res.path).toEqual(['users', '1', 'age']);
     });
+  });
+
+  it('should pass parsed schema output into the suite callback', () => {
+    const schemaWithParsing = {
+      parse: (value: any) => ({ age: Number(value.age) }),
+      run: (value: any) => ({ pass: true, type: { age: Number(value.age) } }),
+    } as any;
+
+    let receivedAge: unknown;
+    const parsedSuite = create((data: any) => {
+      receivedAge = data.age;
+      test('age', () => {
+        enforce(data.age).isNumber();
+      });
+    }, schemaWithParsing);
+
+    const result = parsedSuite.run({ age: '32' } as any);
+
+    expect(receivedAge).toBe(32);
+    expect(result.value).toEqual({ age: 32 });
+    expect((result.types as any)?.output).toEqual({ age: 32 });
+    expect(result.isValid()).toBe(true);
   });
 
   describe('Stateful behavior', () => {

--- a/packages/vest/src/suite/useCreateSuiteMethods.ts
+++ b/packages/vest/src/suite/useCreateSuiteMethods.ts
@@ -95,7 +95,9 @@ function useGetSuiteMethods<
 }): any {
   const { suiteCallback, modifiers, subscribe, schema } = ctx;
 
-  const get = VestRuntime.persist(() => useCreateSuiteResult<F, G, S>(schema));
+  const get = VestRuntime.persist(() =>
+    useCreateSuiteResult<F, G, S>(schema, undefined, undefined),
+  );
   return {
     ...useGetLifecycleMethods(ctx),
     dump: VestRuntime.persist(VestRuntime.useAvailableRoot<TIsolateSuite>),

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -20,6 +20,7 @@ import {
   TFieldName,
   TGroupName,
   InferSchemaData,
+  InferSchemaOutput,
   TSchema,
 } from '../suiteResult/SuiteResultTypes';
 import { useCreateSuiteResult } from '../suiteResult/suiteResult';
@@ -81,7 +82,7 @@ export function useCreateSuiteRunner<
           const useResolver = () => {
             const result = useCreateSuiteResult<F, G, S>(
               schema,
-              callbackInput,
+              callbackInput as InferSchemaOutput<S>,
               schemaInput,
             );
 
@@ -116,12 +117,16 @@ function getCallbackInput(
   schemaRunResult: SchemaRunResult[] | undefined,
   fallback: unknown,
 ): unknown {
-  if (!schemaRunResult || schemaRunResult.some(result => !result.pass)) {
+  if (
+    !schemaRunResult ||
+    schemaRunResult.length === 0 ||
+    schemaRunResult.some(result => !result.pass)
+  ) {
     return fallback;
   }
 
   const [firstResult] = schemaRunResult;
-  return firstResult?.type ?? fallback;
+  return firstResult.type ?? fallback;
 }
 
 /**
@@ -240,6 +245,17 @@ function runSchemaWithParse(schema: any, data: unknown): SchemaRunResult[] {
     } catch (error) {
       if (!isExpectedSchemaParseError(error)) {
         throw error;
+      }
+
+      if (!isFunction(schema.run)) {
+        return normalizeSchemaRunResult(
+          {
+            message:
+              error instanceof Error ? error.message : 'Validation failed',
+            pass: false,
+          },
+          data,
+        );
       }
       // Expected validation failures can fallback to run(raw) for field-level path/message details.
     }

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -39,6 +39,8 @@ const EXPECTED_PARSE_ERROR_NAMES = new Set([
   'ZodError',
   'ValidationError',
   'ValiError',
+  // n4s parse currently throws TypeError for schema validation failures.
+  'TypeError',
 ]);
 
 /**
@@ -216,8 +218,7 @@ function runSchemaValidation<
       }
 
       const pathArray = error.path?.length ? error.path : undefined;
-      const displayName =
-        pathArray?.join('.') ?? error.message ?? 'Validation failed';
+      const displayName = pathArray?.join('.') ?? '__schema__';
       const uniqueTestKey = `${JSON.stringify(pathArray ?? null)}:${index}`;
 
       test(

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -30,7 +30,7 @@ type SchemaRunResult = {
   message?: string;
   pass: boolean;
   path?: string[];
-  type: unknown;
+  type?: unknown;
 };
 
 /**
@@ -64,10 +64,7 @@ export function useCreateSuiteRunner<
       ? runSchemaWithParse(schema, schemaInput)
       : undefined;
 
-    // Only expose parsed output to the callback when schema processing succeeded.
-    const callbackInput = schemaRunResult?.pass
-      ? schemaRunResult.type
-      : schemaInput;
+    const callbackInput = getCallbackInput(schemaRunResult, schemaInput);
     const callbackArgs = [callbackInput, ...args.slice(1)] as Parameters<T>;
 
     return assign(
@@ -113,6 +110,21 @@ export function useCreateSuiteRunner<
 }
 
 /**
+ * Resolves the value that should be passed into the suite callback.
+ */
+function getCallbackInput(
+  schemaRunResult: SchemaRunResult[] | undefined,
+  fallback: unknown,
+): unknown {
+  if (!schemaRunResult || schemaRunResult.some(result => !result.pass)) {
+    return fallback;
+  }
+
+  const [firstResult] = schemaRunResult;
+  return firstResult?.type ?? fallback;
+}
+
+/**
  * Wraps suite callback execution and schema failure emission into an isolate callback.
  */
 function useRunSuiteCallback<
@@ -123,7 +135,7 @@ function useRunSuiteCallback<
   args: any[];
   modifiers: ReturnType<typeof useTransformedModifiers<F>>;
   schema: S | undefined;
-  schemaRunResult?: SchemaRunResult;
+  schemaRunResult?: SchemaRunResult[];
   suiteCallback: SuiteCallbackWithSchema<S, T>;
   useResolver: () => SuiteResult<F, any, S>;
 }) {
@@ -170,64 +182,66 @@ function useTransformedModifiers<F extends TFieldName>(
 }
 
 /**
- * Emits schema failure into vest test tree when schema processing failed.
+ * Emits schema failures into vest test tree.
  */
-
 function runSchemaValidation<
   F extends TFieldName,
   S extends TSchema = undefined,
 >(
   schema: S | undefined,
   modifiers: ReturnType<typeof useTransformedModifiers<F>>,
-  schemaRunResult?: SchemaRunResult,
+  schemaRunResult?: SchemaRunResult[],
 ) {
   // eslint-disable-next-line complexity
   return () => {
-    if (
-      !shouldRunSchema(schema, modifiers) ||
-      !schemaRunResult ||
-      schemaRunResult.pass
-    ) {
+    if (!shouldRunSchema(schema, modifiers) || !schemaRunResult) {
       return;
     }
 
-    const fieldName = schemaRunResult.path?.[0];
-    if (!fieldName) {
-      return;
-    }
+    for (const error of schemaRunResult) {
+      if (error.pass) {
+        continue;
+      }
 
-    test(
-      fieldName,
-      schemaRunResult.message ?? 'Validation failed',
-      () => false,
-      fieldName,
-    );
+      const fieldName = error.path?.length ? error.path.join('.') : '__root__';
+
+      test(
+        fieldName,
+        error.message ?? 'Validation failed',
+        () => false,
+        fieldName,
+      );
+    }
   };
 }
 
 /**
  * Runs schema parsing/validation in a safe order:
  * 1) try parse
- * 2) if parse succeeds and run exists, validate parsed value with run
- * 3) on parse failure, fallback to run(raw)
- *
- * Returned payload is normalized so downstream consumers can rely on shape.
+ * 2) if parse succeeds, treat it as the authoritative validation output
+ * 3) on expected parse validation failures, fallback to run(raw)
  */
-function runSchemaWithParse(schema: any, data: unknown): SchemaRunResult {
+// eslint-disable-next-line complexity
+function runSchemaWithParse(schema: any, data: unknown): SchemaRunResult[] {
   if (isFunction(schema.parse)) {
     try {
       const parsedValue = schema.parse(data);
 
-      if (isFunction(schema.run)) {
+      if (shouldRunAfterParse(schema)) {
         return normalizeSchemaRunResult(schema.run(parsedValue), parsedValue);
       }
 
-      return {
-        pass: true,
-        type: parsedValue,
-      };
-    } catch (_error) {
-      // parse may throw intentionally; fallback to run(raw) for path/message details.
+      return [
+        {
+          pass: true,
+          type: parsedValue,
+        },
+      ];
+    } catch (error) {
+      if (!isExpectedSchemaParseError(error)) {
+        throw error;
+      }
+      // Expected validation failures can fallback to run(raw) for field-level path/message details.
     }
   }
 
@@ -235,18 +249,34 @@ function runSchemaWithParse(schema: any, data: unknown): SchemaRunResult {
     return normalizeSchemaRunResult(schema.run(data), data);
   }
 
-  return {
-    pass: true,
-    type: data,
-  };
+  return [
+    {
+      pass: true,
+      type: data,
+    },
+  ];
 }
 
 /**
  * Converts unknown schema.run return value into a stable internal representation.
- *
- * This avoids runtime crashes when a custom schema returns malformed payloads.
  */
 function normalizeSchemaRunResult(
+  candidate: unknown,
+  fallbackType: unknown,
+): SchemaRunResult[] {
+  if (isArray(candidate)) {
+    return candidate.map(entry =>
+      normalizeSingleSchemaRunResult(entry, fallbackType),
+    );
+  }
+
+  return [normalizeSingleSchemaRunResult(candidate, fallbackType)];
+}
+
+/**
+ * Converts a single unknown run payload into a safe result shape.
+ */
+function normalizeSingleSchemaRunResult(
   candidate: unknown,
   fallbackType: unknown,
 ): SchemaRunResult {
@@ -261,14 +291,13 @@ function normalizeSchemaRunResult(
     message: candidate.message,
     pass: candidate.pass,
     path: candidate.path,
-    type: candidate.type,
+    type: candidate.type ?? fallbackType,
   };
 }
 
 /**
  * Runtime type guard for schema run payloads.
  */
-
 function isSchemaRunResult(candidate: unknown): candidate is SchemaRunResult {
   if (!isObject(candidate)) {
     return false;
@@ -285,11 +314,46 @@ function isSchemaRunResult(candidate: unknown): candidate is SchemaRunResult {
 }
 
 /**
+ * Detects parse errors that represent expected validation failures.
+ */
+function isExpectedSchemaParseError(error: unknown): boolean {
+  if (!isObject(error)) {
+    return false;
+  }
+
+  const typedError = error as { isValidation?: unknown; name?: unknown };
+  return (
+    typedError.isValidation === true ||
+    typedError.name === 'TypeError' ||
+    error instanceof Error
+  );
+}
+
+/**
+ * Determines whether schema.run should execute after a successful parse call.
+ *
+ * For n4s StandardSchema-backed rules, parse already performs full validation.
+ * Re-running run(parsed) can break coercion chains where post-parse types differ
+ * from pre-parse input expectations.
+ */
+function shouldRunAfterParse(schema: any): boolean {
+  if (!isFunction(schema.run)) {
+    return false;
+  }
+
+  return schema?.['~standard']?.vendor !== 'n4s';
+}
+
+/**
  * Schema should run only when schema exists and the run is not field-focused.
  */
 function shouldRunSchema(
   schema: unknown,
   modifiers: { only?: unknown },
 ): boolean {
-  return !modifiers.only && !!schema;
+  const hasOnly = isArray(modifiers.only)
+    ? modifiers.only.length > 0
+    : !!modifiers.only;
+
+  return !hasOnly && !!schema;
 }

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -34,6 +34,9 @@ type SchemaRunResult = {
   type?: unknown;
 };
 
+const VENDOR_N4S_SENTINEL = 'n4s';
+const EXPECTED_PARSE_ERROR_NAMES = new Set(['ZodError', 'ValidationError']);
+
 /**
  * Creates the suite runner bound to a callback, modifiers and (optional) schema.
  *
@@ -338,10 +341,14 @@ function isExpectedSchemaParseError(error: unknown): boolean {
   }
 
   const typedError = error as { isValidation?: unknown; name?: unknown };
+
+  if (typedError.isValidation === true) {
+    return true;
+  }
+
   return (
-    typedError.isValidation === true ||
-    typedError.name === 'TypeError' ||
-    error instanceof Error
+    typeof typedError.name === 'string' &&
+    EXPECTED_PARSE_ERROR_NAMES.has(typedError.name)
   );
 }
 
@@ -357,7 +364,7 @@ function shouldRunAfterParse(schema: any): boolean {
     return false;
   }
 
-  return schema?.['~standard']?.vendor !== 'n4s';
+  return schema?.['~standard']?.vendor !== VENDOR_N4S_SENTINEL;
 }
 
 /**

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -1,4 +1,12 @@
-import { assign, asArray, CB, isFunction, withResolvers } from 'vest-utils';
+import {
+  assign,
+  asArray,
+  CB,
+  isArray,
+  isFunction,
+  isObject,
+  withResolvers,
+} from 'vest-utils';
 
 import { useEmit } from '../core/VestBus/VestBus';
 
@@ -18,16 +26,19 @@ import { useCreateSuiteResult } from '../suiteResult/suiteResult';
 
 import { SuiteModifiers, SuiteCallbackWithSchema } from './SuiteTypes';
 
-/**
- * Creates the actual suite runner function.
- * This function is responsible for initializing the suite context,
- * running the suite callback, and returning the result.
- *
- * @param {Function} suiteCallback - The body of the suite.
- * @param {Object} modifiers - The modifiers for the suite (e.g., only).
- * @returns {Function} - The suite runner function.
- */
+type SchemaRunResult = {
+  message?: string;
+  pass: boolean;
+  path?: string[];
+  type: unknown;
+};
 
+/**
+ * Creates the suite runner bound to a callback, modifiers and (optional) schema.
+ *
+ * The runner performs schema preprocessing once per run, stores the original input
+ * and parsed output, and then executes the suite callback within SuiteContext.
+ */
 // eslint-disable-next-line max-lines-per-function
 export function useCreateSuiteRunner<
   F extends TFieldName,
@@ -40,34 +51,56 @@ export function useCreateSuiteRunner<
   schema?: S,
 ) {
   const transformedModifiers = useTransformedModifiers(modifiers);
+
   return function runSuite(
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
   ): SuiteResult<F, G, S> {
     const { resolve, promise } = withResolvers<SuiteResult<F, G, S>>();
+
+    const schemaInput = args[0];
+    const schemaRunResult = shouldRunSchema(schema, transformedModifiers)
+      ? runSchemaWithParse(schema, schemaInput)
+      : undefined;
+
+    // Only expose parsed output to the callback when schema processing succeeded.
+    const callbackInput = schemaRunResult?.pass
+      ? schemaRunResult.type
+      : schemaInput;
+    const callbackArgs = [callbackInput, ...args.slice(1)] as Parameters<T>;
+
     return assign(
       promise,
       SuiteContext.run(
         {
-          suiteParams: args as Parameters<T>,
+          suiteParams: callbackArgs,
           schema,
           modifiers: transformedModifiers,
         },
         () => {
           useEmit('SUITE_RUN_STARTED');
+
           const useResolver = () => {
-            const result = useCreateSuiteResult<F, G, S>(schema, args[0]);
+            const result = useCreateSuiteResult<F, G, S>(
+              schema,
+              callbackInput,
+              schemaInput,
+            );
+
             if (!result.isPending()) {
               resolve(result);
             }
+
             return result;
           };
+
           return IsolateSuite(
             useRunSuiteCallback<F, T, S>({
-              args,
+              args: callbackArgs,
               modifiers: transformedModifiers,
               schema,
+              schemaRunResult,
               suiteCallback,
               useResolver,
             }),
@@ -79,6 +112,9 @@ export function useCreateSuiteRunner<
   };
 }
 
+/**
+ * Wraps suite callback execution and schema failure emission into an isolate callback.
+ */
 function useRunSuiteCallback<
   F extends TFieldName,
   T extends CB = CB,
@@ -87,33 +123,42 @@ function useRunSuiteCallback<
   args: any[];
   modifiers: ReturnType<typeof useTransformedModifiers<F>>;
   schema: S | undefined;
+  schemaRunResult?: SchemaRunResult;
   suiteCallback: SuiteCallbackWithSchema<S, T>;
   useResolver: () => SuiteResult<F, any, S>;
 }) {
-  const { args, modifiers, schema, suiteCallback, useResolver } = params;
+  const {
+    args,
+    modifiers,
+    schema,
+    schemaRunResult,
+    suiteCallback,
+    useResolver,
+  } = params;
+
   return () => {
-    // Apply field-level focus modifiers. These create transient Focused
-    // isolates at the suite root that affect all tests in the suite.
-    // `only` restricts the run to matching fields; `skip` excludes them.
-    // `skipGroup` is handled separately inside `group()` — when a group
-    // with a matching name is entered, it injects `skip(true)` into
-    // the group's callback via the modifiers stored in SuiteContext.
+    // Focused modifiers are applied before user callback so every test in this run
+    // observes the same focus context.
     only(modifiers.only);
     skip(modifiers.skip);
     (suiteCallback as any)(...args);
 
     IsolateReorderable(
-      runSchemaValidation(schema, modifiers, args[0]),
+      runSchemaValidation(schema, modifiers, schemaRunResult),
       undefined,
       {
         tests: [],
       },
     );
+
     useEmit('SUITE_CALLBACK_RUN_FINISHED');
     return useResolver();
   };
 }
 
+/**
+ * Normalizes user-provided modifiers into deterministic sets for O(1) membership checks.
+ */
 function useTransformedModifiers<F extends TFieldName>(
   modifiers: SuiteModifiers<F>,
 ) {
@@ -124,27 +169,127 @@ function useTransformedModifiers<F extends TFieldName>(
   };
 }
 
+/**
+ * Emits schema failure into vest test tree when schema processing failed.
+ */
+
 function runSchemaValidation<
   F extends TFieldName,
   S extends TSchema = undefined,
 >(
   schema: S | undefined,
   modifiers: ReturnType<typeof useTransformedModifiers<F>>,
-  data: any,
+  schemaRunResult?: SchemaRunResult,
 ) {
+  // eslint-disable-next-line complexity
   return () => {
-    if (!shouldRunSchema(schema, modifiers)) return;
-
-    const runResult = (schema as any).run(data);
-
-    if (!runResult.pass && runResult.path) {
-      // Use the top-level field name (first segment) for error reporting
-      const fieldName = runResult.path[0];
-      test(fieldName, runResult.message, () => false, fieldName);
+    if (
+      !shouldRunSchema(schema, modifiers) ||
+      !schemaRunResult ||
+      schemaRunResult.pass
+    ) {
+      return;
     }
+
+    const fieldName = schemaRunResult.path?.[0];
+    if (!fieldName) {
+      return;
+    }
+
+    test(
+      fieldName,
+      schemaRunResult.message ?? 'Validation failed',
+      () => false,
+      fieldName,
+    );
   };
 }
 
-function shouldRunSchema(schema: any, modifiers: any): boolean {
-  return !modifiers.only && !!schema && isFunction(schema.run);
+/**
+ * Runs schema parsing/validation in a safe order:
+ * 1) try parse
+ * 2) if parse succeeds and run exists, validate parsed value with run
+ * 3) on parse failure, fallback to run(raw)
+ *
+ * Returned payload is normalized so downstream consumers can rely on shape.
+ */
+function runSchemaWithParse(schema: any, data: unknown): SchemaRunResult {
+  if (isFunction(schema.parse)) {
+    try {
+      const parsedValue = schema.parse(data);
+
+      if (isFunction(schema.run)) {
+        return normalizeSchemaRunResult(schema.run(parsedValue), parsedValue);
+      }
+
+      return {
+        pass: true,
+        type: parsedValue,
+      };
+    } catch (_error) {
+      // parse may throw intentionally; fallback to run(raw) for path/message details.
+    }
+  }
+
+  if (isFunction(schema.run)) {
+    return normalizeSchemaRunResult(schema.run(data), data);
+  }
+
+  return {
+    pass: true,
+    type: data,
+  };
+}
+
+/**
+ * Converts unknown schema.run return value into a stable internal representation.
+ *
+ * This avoids runtime crashes when a custom schema returns malformed payloads.
+ */
+function normalizeSchemaRunResult(
+  candidate: unknown,
+  fallbackType: unknown,
+): SchemaRunResult {
+  if (!isSchemaRunResult(candidate)) {
+    return {
+      pass: false,
+      type: fallbackType,
+    };
+  }
+
+  return {
+    message: candidate.message,
+    pass: candidate.pass,
+    path: candidate.path,
+    type: candidate.type,
+  };
+}
+
+/**
+ * Runtime type guard for schema run payloads.
+ */
+
+function isSchemaRunResult(candidate: unknown): candidate is SchemaRunResult {
+  if (!isObject(candidate)) {
+    return false;
+  }
+
+  const value = candidate as Partial<SchemaRunResult>;
+
+  const hasPass = typeof value.pass === 'boolean';
+  const hasPath =
+    value.path === undefined ||
+    (isArray(value.path) && value.path.every(item => typeof item === 'string'));
+
+  return hasPass && hasPath;
+}
+
+/**
+ * Schema should run only when schema exists and the run is not field-focused.
+ */
+function shouldRunSchema(
+  schema: unknown,
+  modifiers: { only?: unknown },
+): boolean {
+  return !modifiers.only && !!schema;
 }

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -35,7 +35,11 @@ type SchemaRunResult = {
 };
 
 const VENDOR_N4S_SENTINEL = 'n4s';
-const EXPECTED_PARSE_ERROR_NAMES = new Set(['ZodError', 'ValidationError']);
+const EXPECTED_PARSE_ERROR_NAMES = new Set([
+  'ZodError',
+  'ValidationError',
+  'TypeError',
+]);
 
 /**
  * Creates the suite runner bound to a callback, modifiers and (optional) schema.

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -38,7 +38,7 @@ const VENDOR_N4S_SENTINEL = 'n4s';
 const EXPECTED_PARSE_ERROR_NAMES = new Set([
   'ZodError',
   'ValidationError',
-  'TypeError',
+  'ValiError',
 ]);
 
 /**
@@ -210,18 +210,21 @@ function runSchemaValidation<
       return;
     }
 
-    for (const error of schemaRunResult) {
+    for (const [index, error] of schemaRunResult.entries()) {
       if (error.pass) {
         continue;
       }
 
-      const fieldName = error.path?.length ? error.path.join('.') : '__root__';
+      const pathArray = error.path?.length ? error.path : undefined;
+      const displayName =
+        pathArray?.join('.') ?? error.message ?? 'Validation failed';
+      const uniqueTestKey = `${JSON.stringify(pathArray ?? null)}:${index}`;
 
       test(
-        fieldName,
+        displayName,
         error.message ?? 'Validation failed',
         () => false,
-        fieldName,
+        uniqueTestKey,
       );
     }
   };
@@ -274,7 +277,10 @@ function runSchemaWithParse(schema: any, data: unknown): SchemaRunResult[] {
 
   return [
     {
-      pass: true,
+      message: `Misconfigured schema: expected parse or run function, received ${String(
+        schema,
+      )}`,
+      pass: false,
       type: data,
     },
   ];

--- a/packages/vest/src/suiteResult/SuiteResultTypes.ts
+++ b/packages/vest/src/suiteResult/SuiteResultTypes.ts
@@ -55,9 +55,21 @@ export type GetFailuresResponse = FailureMessages | string[];
 export type FailureMessages = Record<string, string[]>;
 export type TSchema = any;
 
-export type InferSchemaData<S> = S extends { infer: infer T }
-  ? { [K in keyof T]: T[K] } & NonNullable<unknown>
-  : any;
+export type InferSchemaData<S> = S extends {
+  '~standard': { types: { input: infer I } };
+}
+  ? I
+  : S extends { infer: infer T }
+    ? { [K in keyof T]: T[K] } & NonNullable<unknown>
+    : any;
+
+export type InferSchemaOutput<S> = S extends {
+  '~standard': { types: { output: infer O } };
+}
+  ? O
+  : S extends { infer: infer T }
+    ? { [K in keyof T]: T[K] } & NonNullable<unknown>
+    : any;
 
 type SuiteResultData<
   F extends TFieldName,
@@ -67,7 +79,7 @@ type SuiteResultData<
   | (Omit<SuiteSummary<F, G>, 'valid'> &
       SuiteSelectors<F, G> & {
         valid: true;
-        value: InferSchemaData<S>;
+        value: InferSchemaOutput<S>;
         issues?: undefined;
       })
   | (Omit<SuiteSummary<F, G>, 'valid'> &
@@ -94,7 +106,7 @@ export type SuiteResult<
   dump: CB<TIsolateSuite>;
   types: S extends undefined
     ? undefined
-    : { input: InferSchemaData<S>; output: InferSchemaData<S> };
+    : { input: InferSchemaData<S>; output: InferSchemaOutput<S> };
 };
 
 // Public-facing aliases remain plain strings; internals can still brand via FieldName/GroupName.

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -7,6 +7,8 @@ import { TIsolateSuite } from '../core/isolate/IsolateSuite/IsolateSuite';
 
 import { Severity } from './Severity';
 import {
+  InferSchemaData,
+  InferSchemaOutput,
   SuiteResult,
   SuiteSummary,
   TFieldName,
@@ -20,16 +22,22 @@ export function useCreateSuiteResult<
   F extends TFieldName,
   G extends TGroupName,
   S extends TSchema = undefined,
->(schema?: S, outputData?: any, inputData?: any): SuiteResult<F, G, S> {
+>(
+  schema?: S,
+  outputData?: InferSchemaOutput<S>,
+  inputData?: InferSchemaData<S>,
+): SuiteResult<F, G, S> {
   return useSuiteResultCache<F, G, S>(() => {
     // @vx-allow use-use
     const summary = useProduceSuiteSummary<F, G>();
     const resultBody = constructSuiteResultObject<F, G, S>(summary, outputData);
+    const frozenTypes = schema
+      ? Object.freeze({ input: inputData, output: outputData })
+      : undefined;
+
     return freezeAssign(resultBody as SuiteResult<F, G, S>, {
       dump: VestRuntime.persist(VestRuntime.useAvailableRoot<TIsolateSuite>),
-      types: (schema
-        ? { input: inputData, output: outputData }
-        : undefined) as SuiteResult<F, G, S>['types'],
+      types: frozenTypes as SuiteResult<F, G, S>['types'],
     }) as SuiteResult<F, G, S>;
   });
 }
@@ -40,7 +48,7 @@ export function constructSuiteResultObject<
   S extends TSchema = undefined,
 >(
   summary: SuiteSummary<F, G>,
-  outputData?: any,
+  outputData?: InferSchemaOutput<S>,
 ): Omit<SuiteResult<F, G, S>, 'dump' | 'types'> {
   const { valid, ...summaryWithoutValid } = summary;
   const selectors = suiteSelectors<F, G>(summary);
@@ -56,10 +64,16 @@ export function constructSuiteResultObject<
   } else if (valid === false) {
     const issues = summary[Severity.ERRORS].reduce((acc, failure) => {
       if (failure.message) {
-        acc.push({
-          message: failure.message,
-          path: [failure.fieldName],
-        });
+        if (failure.fieldName !== undefined) {
+          acc.push({
+            message: failure.message,
+            path: [failure.fieldName],
+          });
+        } else {
+          acc.push({
+            message: failure.message,
+          });
+        }
       }
       return acc;
     }, [] as StandardSchemaV1.Issue[]);

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -40,7 +40,7 @@ export function constructSuiteResultObject<
   S extends TSchema = undefined,
 >(
   summary: SuiteSummary<F, G>,
-  data?: any,
+  outputData?: any,
 ): Omit<SuiteResult<F, G, S>, 'dump' | 'types'> {
   const { valid, ...summaryWithoutValid } = summary;
   const selectors = suiteSelectors<F, G>(summary);
@@ -51,7 +51,7 @@ export function constructSuiteResultObject<
     return {
       ...common,
       valid: true,
-      value: data,
+      value: outputData,
     };
   } else if (valid === false) {
     const issues = summary[Severity.ERRORS].reduce((acc, failure) => {

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -20,15 +20,15 @@ export function useCreateSuiteResult<
   F extends TFieldName,
   G extends TGroupName,
   S extends TSchema = undefined,
->(schema?: S, data?: any): SuiteResult<F, G, S> {
+>(schema?: S, outputData?: any, inputData?: any): SuiteResult<F, G, S> {
   return useSuiteResultCache<F, G, S>(() => {
     // @vx-allow use-use
     const summary = useProduceSuiteSummary<F, G>();
-    const resultBody = constructSuiteResultObject<F, G, S>(summary, data);
+    const resultBody = constructSuiteResultObject<F, G, S>(summary, outputData);
     return freezeAssign(resultBody as SuiteResult<F, G, S>, {
       dump: VestRuntime.persist(VestRuntime.useAvailableRoot<TIsolateSuite>),
       types: (schema
-        ? { input: data, output: data }
+        ? { input: inputData, output: outputData }
         : undefined) as SuiteResult<F, G, S>['types'],
     }) as SuiteResult<F, G, S>;
   });

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -64,7 +64,11 @@ export function constructSuiteResultObject<
   } else if (valid === false) {
     const issues = summary[Severity.ERRORS].reduce((acc, failure) => {
       if (failure.message) {
-        if (failure.fieldName && failure.fieldName !== '__root__') {
+        if (
+          failure.fieldName &&
+          failure.fieldName !== '__root__' &&
+          failure.fieldName !== failure.message
+        ) {
           acc.push({
             message: failure.message,
             path: failure.fieldName.split('.'),

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -64,10 +64,10 @@ export function constructSuiteResultObject<
   } else if (valid === false) {
     const issues = summary[Severity.ERRORS].reduce((acc, failure) => {
       if (failure.message) {
-        if (failure.fieldName !== undefined) {
+        if (failure.fieldName && failure.fieldName !== '__root__') {
           acc.push({
             message: failure.message,
-            path: [failure.fieldName],
+            path: failure.fieldName.split('.'),
           });
         } else {
           acc.push({


### PR DESCRIPTION
### Motivation
- Provide a predictable single-pass parse pipeline so rules can both validate and coerce values, and ensure parsed/coerced objects are used by suites when a schema is provided. 
- Harden schema traversal against prototype-pollution and other unsafe keys and make schema parsing O(1) per-key where possible. 
- Improve interoperability by exposing a `parse()` API on rule instances and making chain execution propagate transformed values through the chain. 

### Description
- Added a small `schemaObjectUtils` helper (`ownKeys`, `safeHasOwn`, `findDangerousOwnKey`, `safeShallowCopy`, `isDangerousKey`) and applied it to `loose`, `partial`, and `shape` schema rules to reject dangerous keys and produce sanitized shallow copies. 
- Exposed `parse()` on `RuleInstance`, on the chain proxy, and in `createChainBuilder`, and updated `executeChain`/proxy handlers so chain predicates flow transformed `type` values forward. 
- Updated `RuleRunReturn` resolution logic so transformed `type` from inner rule results is preserved on success. 
- Wired schema parsing into Vest runner: `useCreateSuiteRunner` now attempts `schema.parse` (with safe fallback to `schema.run`), injects parsed output into the suite callback, and surfaces parsed output in `SuiteResult.value` and `types.output` while keeping `types.input` as original input. 
- Added documentation (`packages/n4s/docs/schema.md`) describing design, complexity, and security decisions, and added integration/unit tests in both `n4s` and `vest` to cover coercion, parsing, extra payload behavior, and security scenarios. 
- Small test typing cleanup: declared missing custom matcher typing in `packages/n4s/src/__tests__/standardSchema.test.ts` and replaced remaining `(enforce as any)` usage with typed matcher access. 

### Testing
- Ran the full test suite with `yarn test` and the run completed successfully (all tests passed). 
- Ran targeted vitest commands for the modified test files with `yarn vitest run packages/n4s/src/__tests__/standardSchema.test.ts packages/n4s/src/__tests__/parse.test.ts packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts` and `yarn vitest run` for the added Vest integration tests, and those targeted suites passed (new parse/integration tests are green). 
- Pre-commit tasks (`eslint`, `prettier` via lint-staged) were executed during validation and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8e887b748330b8d23f71c1858d64)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added parse() on rules; schema parsing now returns validated/coerced output and provides parsed data to suite callbacks (with fallback behavior on parse failures).

* **Security**
  * Prototype-pollution protections and safer own-key handling during schema parsing; dangerous keys are rejected.

* **Types**
  * Improved schema input/output inference and updated suite result typing to reflect parsed outputs.

* **Docs**
  * New documentation describing schema parsing behavior and safety guarantees.

* **Tests**
  * Expanded unit and integration tests covering parsing, coercions, fallbacks, and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->