### PR TITLE
Add schema parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vest-monorepo",
   "scripts": {
     "build": "vx build && yarn build:llms",
-    "test": "vx test run",
+    "test": "vx test run --typecheck",
     "test:watch": "vx test",
     "bench": "npx tsx vx/scripts/benchmark-reporter.ts --update",
     "release": "vx release",

--- a/packages/n4s/docs/schema.md
+++ b/packages/n4s/docs/schema.md
@@ -1,0 +1,59 @@
+# n4s schema parsing architecture
+
+## Goals
+
+1. **Single-pass validation and transformation** for schema rules (`shape`, `loose`, `partial`).
+2. **Predictable parse API** available across plain rules and chains.
+3. **Security-first object traversal**, with explicit protection against dangerous keys used in prototype-pollution attacks.
+4. **O(1) lookup behavior** by relying on native object property checks and set membership checks.
+
+## Pipeline design
+
+Schema execution is now modeled as a parse pipeline:
+
+1. Validate the input container (must be object-like).
+2. Reject dangerous own keys (`__proto__`, `prototype`, `constructor`) on both schema and user input.
+3. Iterate schema keys using own-key iteration only (`Object.keys`).
+4. Run each field rule and collect the transformed output (`RuleRunReturn.type`).
+5. Return a parsed object with validated/coerced values.
+
+This keeps validation and transformation in one pass over the relevant keys.
+
+## Security decisions
+
+Schema object utilities centralize safety behavior:
+
+- `ownKeys` avoids prototype chain traversal.
+- `safeHasOwn` avoids `in` checks that include inherited keys.
+- `findDangerousOwnKey` short-circuits when dangerous keys are detected.
+- `safeShallowCopy` creates a sanitized shallow clone and omits dangerous keys.
+
+These utilities are used by `shape`, `loose`, and `partial` to ensure consistent behavior.
+
+## Parse API semantics
+
+Every `RuleInstance` now exposes:
+
+- `test(value)` → boolean
+- `validate(value)` → standard-schema result (`value` or `issues`)
+- `parse(value)` → transformed output or throws on validation failure
+- `run(value)` → internal `RuleRunReturn`
+
+Chains propagate transformed values through each step, so rules can compose coercions predictably.
+
+## Vest integration
+
+When a suite is created with a schema:
+
+- The schema parsing path is executed before the suite callback.
+- If `schema.parse` exists, it is used first.
+- On parse throw, Vest falls back to `schema.run` for rich path/message reporting.
+- The suite callback receives parsed data.
+- `SuiteResult.value` and `types.output` are parsed output.
+- `types.input` remains the original input.
+
+## Complexity notes
+
+- Key checks are O(1) average-case (`Set.has`, own-property checks).
+- Rule execution remains linear in the number of relevant keys: O(n).
+- No recursive cloning is performed in schema wrappers; copying is shallow by design.

--- a/packages/n4s/src/__tests__/documentation-examples.test.ts
+++ b/packages/n4s/src/__tests__/documentation-examples.test.ts
@@ -215,6 +215,7 @@ describe('Documentation Examples', () => {
       const numbersRule = enforce.isArrayOf(enforce.isNumber());
 
       expect(numbersRule.test([1, 2, 3])).toBe(true);
+      // @ts-expect-error - string is not assignable to number
       expect(numbersRule.test([1, 'two', 3])).toBe(false);
     });
   });

--- a/packages/n4s/src/__tests__/parse.test.ts
+++ b/packages/n4s/src/__tests__/parse.test.ts
@@ -5,7 +5,7 @@ import { enforce } from '../n4s';
 declare global {
   namespace n4s {
     interface EnforceMatchers {
-      toNumber: (value: unknown) => { pass: boolean; type: unknown };
+      toNumber: (value: unknown) => { pass: boolean; type: number };
     }
   }
 }
@@ -43,7 +43,7 @@ describe('parse()', () => {
 
   it('should throw on failed parse', () => {
     const validator = enforce.isString().message('Must be string');
-    expect(() => validator.parse(100 as any)).toThrow('Must be string');
+    expect(() => validator.parse(100)).toThrow('Must be string');
   });
 
   it('should return transformed output for schema rules', () => {
@@ -56,6 +56,7 @@ describe('parse()', () => {
 
   it('should transform items when used in isArrayOf', () => {
     const schema = enforce.isArrayOf(enforce.toNumber());
+
     expect(schema.parse(['42', '100', 5])).toEqual([42, 100, 5]);
   });
 

--- a/packages/n4s/src/__tests__/parse.test.ts
+++ b/packages/n4s/src/__tests__/parse.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { enforce } from '../n4s';
+
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      toNumber: (value: unknown) => { pass: boolean; type: unknown };
+    }
+  }
+}
+
+describe('parse()', () => {
+  let originalToNumber: unknown;
+
+  beforeEach(() => {
+    originalToNumber = (enforce as unknown as Record<string, unknown>).toNumber;
+
+    enforce.extend({
+      toNumber: (value: unknown) => {
+        const parsed = Number(value);
+        return Number.isNaN(parsed)
+          ? { pass: false, type: value }
+          : { pass: true, type: parsed };
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (originalToNumber === undefined) {
+      delete (enforce as unknown as Record<string, unknown>).toNumber;
+      return;
+    }
+
+    (enforce as unknown as Record<string, unknown>).toNumber = originalToNumber;
+  });
+
+  it('should expose parse on lazy rules', () => {
+    const validator = enforce.isString();
+    expect(typeof validator.parse).toBe('function');
+    expect(validator.parse('hello')).toBe('hello');
+  });
+
+  it('should throw on failed parse', () => {
+    const validator = enforce.isString().message('Must be string');
+    expect(() => validator.parse(100 as any)).toThrow('Must be string');
+  });
+
+  it('should return transformed output for schema rules', () => {
+    const schema = enforce.shape({
+      age: enforce.toNumber(),
+    });
+
+    expect(schema.parse({ age: '42' })).toEqual({ age: 42 });
+  });
+});

--- a/packages/n4s/src/__tests__/parse.test.ts
+++ b/packages/n4s/src/__tests__/parse.test.ts
@@ -53,4 +53,14 @@ describe('parse()', () => {
 
     expect(schema.parse({ age: '42' })).toEqual({ age: 42 });
   });
+
+  it('should transform items when used in isArrayOf', () => {
+    const schema = enforce.isArrayOf(enforce.toNumber());
+    expect(schema.parse(['42', '100', 5])).toEqual([42, 100, 5]);
+  });
+
+  it('should throw an error if an item in isArrayOf fails to parse', () => {
+    const schema = enforce.isArrayOf(enforce.toNumber());
+    expect(() => schema.parse(['42', 'not-a-number'])).toThrow();
+  });
 });

--- a/packages/n4s/src/__tests__/standardSchema.test.ts
+++ b/packages/n4s/src/__tests__/standardSchema.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from 'vitest';
 
 import { enforce } from '../n4s';
 
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      toNumberForParse: (value: unknown) => {
+        message: string;
+        pass: boolean;
+        type: number;
+      };
+    }
+  }
+}
+
 describe('n4s StandardSchema Support', () => {
   describe('Lazy Interface', () => {
     it('Should have the "~standard" property', () => {
@@ -60,6 +72,22 @@ describe('n4s StandardSchema Support', () => {
       expect((invalidResult as any).issues?.[0]).toHaveProperty('path');
       expect(Array.isArray((invalidResult as any).issues?.[0].path)).toBe(true);
     });
+  });
+
+  it('should expose .parse() and return transformed value when valid', async () => {
+    const { enforce } = await import('../n4s');
+    enforce.extend({
+      toNumberForParse: (value: any) => {
+        const parsed = Number(value);
+        return {
+          pass: !Number.isNaN(parsed),
+          type: parsed,
+          message: 'not numeric',
+        };
+      },
+    });
+
+    expect(enforce.toNumberForParse().parse('12')).toBe(12);
   });
 
   describe('Direct validate() method usage', () => {

--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -18,9 +18,17 @@ import { type RuleInstance } from './utils/RuleInstance';
 import { RuleRunReturn } from './utils/RuleRunReturn';
 
 /**
- * Type mapping for custom rules in the lazy (builder) API.
- * Excludes schema and compound rules as they have special handling.
+ * Extracts the output type from a custom matcher function.
+ * If the matcher returns { type: T }, uses T (coercion rules like toNumber).
+ * Otherwise falls back to the first parameter type (validation rules like isPositive).
  */
+type InferMatcherOutput<K extends keyof n4s.EnforceMatchers> =
+  ReturnType<Extract<n4s.EnforceMatchers[K], (...args: any[]) => any>> extends {
+    type: infer T;
+  }
+    ? T
+    : FirstParam<n4s.EnforceMatchers[K]>;
+
 type TCustomLazyRules = {
   [K in keyof n4s.EnforceMatchers as K extends keyof SchemaRuleLazyTypes
     ? never
@@ -29,7 +37,7 @@ type TCustomLazyRules = {
       : K]: (
     ...args: CustomMatcherArgs<K>
   ) => RuleInstance<
-    FirstParam<n4s.EnforceMatchers[K]>,
+    InferMatcherOutput<K>,
     [FirstParam<n4s.EnforceMatchers[K]>]
   >;
 };

--- a/packages/n4s/src/rules/__tests__/compoundAndSchemaRuleTypes.test.ts
+++ b/packages/n4s/src/rules/__tests__/compoundAndSchemaRuleTypes.test.ts
@@ -105,10 +105,12 @@ describe('Compound and Schema Rule Types', () => {
     void arr;
 
     // Type test: number[] is not string[]
+    // @ts-expect-error - number is not assignable to string
     const badArr: InferredType = [1, 2, 3];
     void badArr;
 
     expect(rule.run(['a', 'b']).pass).toBe(true);
+    // @ts-expect-error - number is not assignable to string
     expect(rule.run([1, 2]).pass).toBe(false);
   });
 

--- a/packages/n4s/src/rules/arrayRules.ts
+++ b/packages/n4s/src/rules/arrayRules.ts
@@ -55,8 +55,8 @@ const arrayRules = {
   shorterThanOrEquals,
 } as const;
 
-export type ArrayRuleInstance<T = any> = BuildRuleInstance<
+export type ArrayRuleInstance<T = any, TInput = T> = BuildRuleInstance<
   T[],
-  [T[]],
+  [TInput[]],
   ExtractRuleFunctions<typeof arrayRules>
 >;

--- a/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
+++ b/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
@@ -14,7 +14,7 @@ import { executeChain, type Predicate } from './chainExecutor';
 import { createChainProxyHandlers } from './proxyHandlers';
 
 export type RuleFunctions<T extends RuleInstance<any, any>> = Record<
-  keyof Omit<T, 'infer' | 'test' | 'validate' | '~standard'>,
+  keyof Omit<T, 'infer' | 'test' | 'validate' | 'parse' | '~standard'>,
   (...args: any[]) => boolean
 >;
 
@@ -72,6 +72,17 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
   }) as T['test'];
 
   // Internal compatibility method - converts StandardSchema Result to RuleRunReturn
+
+  const parse: T['parse'] = ((...args: any[]) => {
+    const result = validate(...args);
+    if (!result.issues) {
+      return result.value;
+    }
+
+    const [firstIssue] = result.issues;
+    throw new TypeError(firstIssue?.message || 'Validation failed');
+  }) as T['parse'];
+
   const run: T['run'] = ((...args: any[]) => {
     const result = executeChain(chain, args[0]);
     if (!result.pass && lazyMessage) {
@@ -105,6 +116,7 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
       } as StandardSchemaV1.Props<any, any>,
       add,
       message,
+      parse,
       run,
       test,
       validate,

--- a/packages/n4s/src/rules/chainBuilder/chainExecutor.ts
+++ b/packages/n4s/src/rules/chainBuilder/chainExecutor.ts
@@ -12,15 +12,18 @@ export function executeChain(
   chain: Predicate[],
   value: any,
 ): RuleRunReturn<any> {
+  let currentValue = value;
+
   for (const predicate of chain) {
-    const result = predicate(value);
+    const result = predicate(currentValue);
 
     if (isRuleRunReturn(result)) {
       if (!result.pass) return result as RuleRunReturn<any>;
+      currentValue = result.type;
     } else if (!result) {
-      return RuleRunReturn.Failing(value);
+      return RuleRunReturn.Failing(currentValue);
     }
   }
 
-  return RuleRunReturn.Passing(value);
+  return RuleRunReturn.Passing(currentValue);
 }

--- a/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
+++ b/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
@@ -8,7 +8,7 @@ import { getLazyRule } from './lazyRegistry';
 
 export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
   rules: Record<
-    keyof Omit<T, 'infer' | 'test' | 'validate' | '~standard'>,
+    keyof Omit<T, 'infer' | 'test' | 'validate' | 'parse' | '~standard'>,
     (...args: any[]) => boolean
   >,
   {
@@ -16,6 +16,7 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
     test,
     validate,
     run,
+    parse,
     message,
     '~standard': standard,
   }: {
@@ -23,16 +24,25 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
     test: T['test'];
     validate: T['validate'];
     run: T['run'];
+    parse: T['parse'];
     message: (msg: any) => T;
     '~standard': StandardSchemaV1.Props<any, any>;
   },
 ) {
-  const methods = { '~standard': standard, message, run, test, validate };
+  const methods = {
+    '~standard': standard,
+    message,
+    parse,
+    run,
+    test,
+    validate,
+  };
   const methodKeys = new Set([
     'infer',
     'test',
     'validate',
     'run',
+    'parse',
     'message',
     '~standard',
   ]);

--- a/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expectTypeOf, it } from 'vitest';
 
 import { enforce } from '../../../n4s';
 import type { ShapeType } from '../shape';
@@ -25,7 +25,6 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     // @ts-expect-error - object is not assignable to number | string
     const badArr2: Arr = [{}];
     void badArr2;
-    expect(true).toBe(true);
   });
 
   it('shape: exact fields and correct types', () => {
@@ -70,7 +69,6 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
       zip: true,
     } satisfies Addr;
     void badZip;
-    expect(true).toBe(true);
   });
 
   it('optional + base shape: wrong inner types should error', () => {
@@ -116,7 +114,6 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
       totals: { subtotal: 1, tax: 0 },
     } satisfies T;
     void badMaybe;
-    expect(true).toBe(true);
   });
 
   it('anyOf/noneOf: union types vs mismatches', () => {
@@ -139,7 +136,6 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     // Type test: expects string inferred type, assigning number
     const badNotStr: NotStr = 1;
     void badNotStr;
-    expect(true).toBe(true);
   });
 
   it('composed shapes with nested arrays: incorrect element type', () => {
@@ -168,7 +164,6 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
       items: [{ price: 1, qty: true, sku: 'x' }],
     } satisfies Cart;
     void badCart2;
-    expect(true).toBe(true);
   });
 
   it('parse() return type for shape is correctly inferred', () => {
@@ -177,21 +172,18 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
       age: enforce.isNumber(),
     });
 
-    // Compile-time check: parse() should return { name: string; age: number }
-    const parseResult = schema.parse({ name: 'Alice', age: 30 });
-    const _checkShape: { name: string; age: number } = parseResult;
-    void _checkShape;
-    expect(true).toBe(true);
+    // eslint-disable-next-line vitest/valid-expect
+    expectTypeOf(schema.parse).returns.toMatchTypeOf<{
+      name: string;
+      age: number;
+    }>();
   });
 
   it('parse() return type for isArrayOf is correctly inferred', () => {
     const schema = enforce.isArrayOf(enforce.isNumber());
 
-    // Compile-time check: parse() should return number[]
-    const parseResult = schema.parse([1, 2, 3]);
-    const _checkArr: number[] = parseResult;
-    void _checkArr;
-    expect(true).toBe(true);
+    // eslint-disable-next-line vitest/valid-expect
+    expectTypeOf(schema.parse).returns.toMatchTypeOf<number[]>();
   });
 
   it('parse() return type for nested isArrayOf(shape) is correctly inferred', () => {
@@ -201,10 +193,9 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     });
     const listSchema = enforce.isArrayOf(itemSchema);
 
-    // Compile-time check: parse() should return { id: number; label: string }[]
-    const parseResult = listSchema.parse([{ id: 1, label: 'x' }]);
-    const _checkNested: { id: number; label: string }[] = parseResult;
-    void _checkNested;
-    expect(true).toBe(true);
+    // eslint-disable-next-line vitest/valid-expect
+    expectTypeOf(listSchema.parse).returns.toMatchTypeOf<
+      { id: number; label: string }[]
+    >();
   });
 });

--- a/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
@@ -17,10 +17,12 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     void ok1;
 
     // Type test: boolean is not allowed in (number | string)[]
+    // @ts-expect-error - boolean is not assignable to number | string
     const badArr1: Arr = [true];
     void badArr1;
 
     // Type test: object is not allowed in (number | string)[]
+    // @ts-expect-error - object is not assignable to number | string
     const badArr2: Arr = [{}];
     void badArr2;
     expect(true).toBe(true);
@@ -156,14 +158,53 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     void ok;
 
     // Type test: items must be array of lineItem
+    // @ts-expect-error - string is not a valid lineItem
     const badCart1 = { items: ['x'] } satisfies Cart;
     void badCart1;
 
     const badCart2 = {
       // Type test: qty must be number > 0 (type-wise: number, so boolean is invalid)
+      // @ts-expect-error - qty must be number, not boolean
       items: [{ price: 1, qty: true, sku: 'x' }],
     } satisfies Cart;
     void badCart2;
+    expect(true).toBe(true);
+  });
+
+  it('parse() return type for shape is correctly inferred', () => {
+    const schema = enforce.shape({
+      name: enforce.isString(),
+      age: enforce.isNumber(),
+    });
+
+    // Compile-time check: parse() should return { name: string; age: number }
+    const parseResult = schema.parse({ name: 'Alice', age: 30 });
+    const _checkShape: { name: string; age: number } = parseResult;
+    void _checkShape;
+    expect(true).toBe(true);
+  });
+
+  it('parse() return type for isArrayOf is correctly inferred', () => {
+    const schema = enforce.isArrayOf(enforce.isNumber());
+
+    // Compile-time check: parse() should return number[]
+    const parseResult = schema.parse([1, 2, 3]);
+    const _checkArr: number[] = parseResult;
+    void _checkArr;
+    expect(true).toBe(true);
+  });
+
+  it('parse() return type for nested isArrayOf(shape) is correctly inferred', () => {
+    const itemSchema = enforce.shape({
+      id: enforce.isNumber(),
+      label: enforce.isString(),
+    });
+    const listSchema = enforce.isArrayOf(itemSchema);
+
+    // Compile-time check: parse() should return { id: number; label: string }[]
+    const parseResult = listSchema.parse([{ id: 1, label: 'x' }]);
+    const _checkNested: { id: number; label: string }[] = parseResult;
+    void _checkNested;
     expect(true).toBe(true);
   });
 });

--- a/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
@@ -97,4 +97,23 @@ describe('schema parse integration', () => {
     expect(result.pass).toBe(false);
     expect(result.path).toEqual(['__proto__']);
   });
+
+  it('isArrayOf parses array elements and preserves type transformations', () => {
+    const schema = enforce.isArrayOf(
+      enforce.shape({
+        name: enforce.trimString(),
+        age: enforce.toNumber(),
+      }),
+    );
+
+    const result = schema.parse([
+      { name: '  Jane  ', age: '34' },
+      { name: ' John ', age: '45' },
+    ]);
+
+    expect(result).toEqual([
+      { name: 'Jane', age: 34 },
+      { name: 'John', age: 45 },
+    ]);
+  });
 });

--- a/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { enforce } from '../../../n4s';
+
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      toNumber: (value: unknown) => { pass: boolean; type: unknown };
+      trimString: (value: unknown) => { pass: boolean; type: unknown };
+    }
+  }
+}
+
+enforce.extend({
+  toNumber: (value: unknown) => {
+    const parsed = Number(value);
+    return Number.isNaN(parsed)
+      ? { pass: false, type: value }
+      : { pass: true, type: parsed };
+  },
+  trimString: (value: unknown) => {
+    if (typeof value !== 'string') {
+      return { pass: false, type: value };
+    }
+
+    return { pass: true, type: value.trim() };
+  },
+});
+
+describe('schema parse integration', () => {
+  it('shape parses nested values with custom coercions', () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        name: enforce.trimString(),
+        age: enforce.toNumber(),
+      }),
+    });
+
+    const result = schema.parse({
+      profile: { name: '  Jane  ', age: '34' },
+    });
+
+    expect(result).toEqual({
+      profile: { name: 'Jane', age: 34 },
+    });
+  });
+
+  it('loose parses known keys while keeping extra payload fields', () => {
+    const schema = enforce.loose({
+      amount: enforce.toNumber(),
+      title: enforce.trimString(),
+    });
+
+    const result = schema.parse({
+      amount: '49',
+      title: '  invoice ',
+      metadata: { source: 'api' },
+    });
+
+    expect(result).toEqual({
+      amount: 49,
+      title: 'invoice',
+      metadata: { source: 'api' },
+    });
+  });
+
+  it('partial parses only provided keys', () => {
+    const schema = enforce.partial({
+      page: enforce.toNumber(),
+      search: enforce.trimString(),
+    });
+
+    expect(schema.parse({ page: '2' })).toEqual({ page: 2 });
+    expect(schema.parse({ search: '  vest  ' })).toEqual({ search: 'vest' });
+  });
+
+  it('rejects dangerous own keys to prevent prototype pollution', () => {
+    const schema = enforce.loose({
+      safe: enforce.isString(),
+    });
+
+    const payload = JSON.parse('{"safe":"ok","__proto__":{"polluted":true}}');
+    const result = schema.run(payload);
+
+    expect(result.pass).toBe(false);
+    expect(result.path).toEqual(['__proto__']);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('rejects dangerous schema keys', () => {
+    const schema = enforce.shape(
+      JSON.parse('{"__proto__":true}') as Record<string, unknown> as any,
+    );
+
+    const result = schema.run({});
+
+    expect(result.pass).toBe(false);
+    expect(result.path).toEqual(['__proto__']);
+  });
+});

--- a/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
@@ -5,8 +5,8 @@ import { enforce } from '../../../n4s';
 declare global {
   namespace n4s {
     interface EnforceMatchers {
-      toNumber: (value: unknown) => { pass: boolean; type: unknown };
-      trimString: (value: unknown) => { pass: boolean; type: unknown };
+      toNumber: (value: unknown) => { pass: boolean; type: number };
+      trimString: (value: unknown) => { pass: boolean; type: string };
     }
   }
 }

--- a/packages/n4s/src/rules/schemaRules/isArrayOf.ts
+++ b/packages/n4s/src/rules/schemaRules/isArrayOf.ts
@@ -52,37 +52,45 @@ export function isArrayOf<T>(value: T[], ...rules: any[]): RuleRunReturn<T[]> {
     return RuleRunReturn.Failing(value);
   }
 
-  return (
-    mapFirst(value, (item, breakout, index) => {
-      const res = ctx.run({ value: item, set: true, meta: { index } }, () => {
-        let lastRes: RuleRunReturn<any> | undefined;
-        // Try each rule with the item - any rule passing is OK
-        const anyPass = rules.some(rule => {
-          const rawResult = rule.run(item);
-          lastRes = rawResult;
-          const transformed = transformResult(rawResult, 'isArrayOf', item);
-          return transformed.pass;
-        });
+  const parsedArray: any[] = [];
 
-        if (anyPass) {
-          return RuleRunReturn.Passing(item);
+  const failingResult = mapFirst(value, (item, breakout, index) => {
+    const res = ctx.run({ value: item, set: true, meta: { index } }, () => {
+      let lastRes: RuleRunReturn<any> | undefined;
+      let passingTransformedType: any = item;
+
+      // Try each rule with the item - any rule passing is OK
+      const anyPass = rules.some(rule => {
+        const rawResult = rule.run(item);
+        lastRes = rawResult;
+        const transformed = transformResult(rawResult, 'isArrayOf', item);
+        if (transformed.pass) {
+          passingTransformedType = rawResult.type ?? item;
         }
-
-        // If failed and we have a single rule, return its failure (might contain nested path)
-        if (lengthEquals(rules, 1) && lastRes) {
-          return lastRes;
-        }
-
-        return RuleRunReturn.Failing(item);
+        return transformed.pass;
       });
 
-      if (!res.pass) {
-        const currentPath = res.path || [];
-        const newRes = { ...res, path: [index.toString(), ...currentPath] };
-        breakout(true, newRes);
+      if (anyPass) {
+        parsedArray.push(passingTransformedType);
+        return RuleRunReturn.Passing(passingTransformedType);
       }
-    }) || RuleRunReturn.Passing(value)
-  );
+
+      // If failed and we have a single rule, return its failure (might contain nested path)
+      if (lengthEquals(rules, 1) && lastRes) {
+        return lastRes;
+      }
+
+      return RuleRunReturn.Failing(item);
+    });
+
+    if (!res.pass) {
+      const currentPath = res.path || [];
+      const newRes = { ...res, path: [index.toString(), ...currentPath] };
+      breakout(true, newRes);
+    }
+  });
+
+  return failingResult || RuleRunReturn.Passing(parsedArray as T[]);
 }
 
 // Type for isArrayOf rule instance - should chain array rules like isArray does

--- a/packages/n4s/src/rules/schemaRules/isArrayOf.ts
+++ b/packages/n4s/src/rules/schemaRules/isArrayOf.ts
@@ -94,5 +94,7 @@ export function isArrayOf<T>(value: T[], ...rules: any[]): RuleRunReturn<T[]> {
 }
 
 // Type for isArrayOf rule instance - should chain array rules like isArray does
-export type IsArrayOfRuleInstance<T> =
-  import('../arrayRules').ArrayRuleInstance<T>;
+export type IsArrayOfRuleInstance<
+  T,
+  TInput = T,
+> = import('../arrayRules').ArrayRuleInstance<T, TInput>;

--- a/packages/n4s/src/rules/schemaRules/loose.ts
+++ b/packages/n4s/src/rules/schemaRules/loose.ts
@@ -9,7 +9,8 @@ import {
   ownKeys,
   safeShallowCopy,
 } from './schemaObjectUtils';
-import type { ShapeType } from './shape';
+import type { Prettify } from './schemaRulesTypes';
+import type { ShapeInputType, ShapeType } from './shape';
 
 /**
  * Validates that an object matches a schema loosely - all schema keys required, extra keys allowed.
@@ -88,9 +89,9 @@ export function loose<T extends Record<string, any>>(
 // Types colocated with loose rule
 export type LooseRuleInstance<S extends Record<string, RuleInstance<any>>> =
   RuleInstance<
-    ShapeType<S> & Record<string, unknown>,
-    [ShapeType<S> & Record<string, unknown>]
+    Prettify<ShapeType<S> & Record<string, unknown>>,
+    [Prettify<ShapeInputType<S> & Record<string, unknown>>]
   >;
 
 export type LooseShapeValue<S extends Record<string, RuleInstance<any>>> =
-  ShapeType<S> & Record<string, unknown>;
+  Prettify<ShapeType<S> & Record<string, unknown>>;

--- a/packages/n4s/src/rules/schemaRules/loose.ts
+++ b/packages/n4s/src/rules/schemaRules/loose.ts
@@ -1,9 +1,14 @@
-import { isObject } from 'vest-utils';
+import { hasOwnProperty, isObject } from 'vest-utils';
 
 import { ctx } from '../../enforceContext';
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
+import {
+  findDangerousOwnKey,
+  ownKeys,
+  safeShallowCopy,
+} from './schemaObjectUtils';
 import type { ShapeType } from './shape';
 
 /**
@@ -45,8 +50,26 @@ export function loose<T extends Record<string, any>>(
     return RuleRunReturn.Failing(value);
   }
 
-  for (const key in schema) {
-    const fieldValue = key in value ? value[key] : undefined;
+  const dangerousSchemaKey = findDangerousOwnKey(schema);
+  if (dangerousSchemaKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [dangerousSchemaKey],
+    };
+  }
+
+  const dangerousValueKey = findDangerousOwnKey(value);
+  if (dangerousValueKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [dangerousValueKey],
+    };
+  }
+
+  const parsedValue: Record<string, any> = safeShallowCopy(value);
+
+  for (const key of ownKeys(schema)) {
+    const fieldValue = hasOwnProperty(value, key) ? value[key] : undefined;
     const res = ctx.run({ value: fieldValue, set: true, meta: { key } }, () =>
       schema[key].run(fieldValue),
     );
@@ -55,8 +78,11 @@ export function loose<T extends Record<string, any>>(
       const newRes = { ...res, path: [key, ...currentPath] };
       return newRes as RuleRunReturn<T>;
     }
+
+    parsedValue[key] = res.type;
   }
-  return RuleRunReturn.Passing(value);
+
+  return RuleRunReturn.Passing(parsedValue as T);
 }
 
 // Types colocated with loose rule

--- a/packages/n4s/src/rules/schemaRules/partial.ts
+++ b/packages/n4s/src/rules/schemaRules/partial.ts
@@ -9,7 +9,7 @@ import {
   ownKeys,
   safeShallowCopy,
 } from './schemaObjectUtils';
-import type { ShapeType } from './shape';
+import type { ShapeInputType, ShapeType } from './shape';
 
 /**
  * Checks if value has any keys not present in schema.
@@ -145,7 +145,7 @@ export function partial<T extends Record<string, any>>(
 
 // Types colocated with partial rule
 export type PartialRuleInstance<S extends Record<string, RuleInstance<any>>> =
-  RuleInstance<Partial<ShapeType<S>>, [Partial<ShapeType<S>>]>;
+  RuleInstance<Partial<ShapeType<S>>, [Partial<ShapeInputType<S>>]>;
 
 export type PartialShapeValue<S extends Record<string, RuleInstance<any>>> =
   Partial<ShapeType<S>>;

--- a/packages/n4s/src/rules/schemaRules/partial.ts
+++ b/packages/n4s/src/rules/schemaRules/partial.ts
@@ -1,46 +1,62 @@
-import { isObject } from 'vest-utils';
+import { hasOwnProperty, isObject } from 'vest-utils';
 
 import { ctx } from '../../enforceContext';
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
+import {
+  findDangerousOwnKey,
+  ownKeys,
+  safeShallowCopy,
+} from './schemaObjectUtils';
 import type { ShapeType } from './shape';
 
 /**
  * Checks if value has any keys not present in schema.
  */
-function hasExtraKeys<T extends Record<string, any>>(
+function getFirstExtraKey<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
-): boolean {
-  for (const key in value) {
-    if (!(key in schema)) {
-      return true;
+): string | null {
+  for (const key of ownKeys(value)) {
+    if (!hasOwnProperty(schema, key)) {
+      return key;
     }
   }
-  return false;
+
+  return null;
 }
 
 /**
- * Validates provided keys against their schema rules.
+ * Validates provided keys against their schema rules and returns parsed entries.
+ *
  * Missing keys are allowed (partial validation).
  */
 function validateProvidedKeys<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
-): RuleRunReturn<T> | null {
-  for (const key in schema) {
-    if (key in value) {
+): RuleRunReturn<T> | { parsedEntries: Record<string, any> } {
+  const parsedEntries: Record<string, any> = {};
+
+  for (const key of ownKeys(schema)) {
+    if (hasOwnProperty(value, key)) {
       const fieldValue = value[key];
       const res = ctx.run({ value: fieldValue, set: true, meta: { key } }, () =>
         schema[key].run(fieldValue),
       );
       if (!res.pass) {
-        return res as RuleRunReturn<T>;
+        const currentPath = res.path || [];
+        return {
+          ...res,
+          path: [key, ...currentPath],
+        } as RuleRunReturn<T>;
       }
+
+      parsedEntries[key] = res.type;
     }
   }
-  return null;
+
+  return { parsedEntries };
 }
 
 /**
@@ -82,6 +98,7 @@ function validateProvidedKeys<T extends Record<string, any>>(
  * updateSchema.test({ name: 'Jane', extra: 'x' }); // false (extra key not in schema)
  * ```
  */
+// eslint-disable-next-line complexity
 export function partial<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
@@ -90,16 +107,40 @@ export function partial<T extends Record<string, any>>(
     return RuleRunReturn.Failing(value);
   }
 
-  if (hasExtraKeys(value, schema)) {
-    return RuleRunReturn.Failing(value);
+  const dangerousSchemaKey = findDangerousOwnKey(schema);
+  if (dangerousSchemaKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [dangerousSchemaKey],
+    };
   }
 
-  const validationResult = validateProvidedKeys(value, schema);
-  if (validationResult) {
-    return validationResult;
+  const dangerousValueKey = findDangerousOwnKey(value);
+  if (dangerousValueKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [dangerousValueKey],
+    };
   }
 
-  return RuleRunReturn.Passing(value);
+  const extraKey = getFirstExtraKey(value, schema);
+  if (extraKey) {
+    return {
+      ...RuleRunReturn.Failing(value),
+      path: [extraKey],
+    };
+  }
+
+  const parsedValue = safeShallowCopy(value);
+  const parsedEntriesOrFailure = validateProvidedKeys(value, schema);
+  if ('pass' in parsedEntriesOrFailure) {
+    return parsedEntriesOrFailure;
+  }
+
+  return RuleRunReturn.Passing({
+    ...parsedValue,
+    ...parsedEntriesOrFailure.parsedEntries,
+  } as T);
 }
 
 // Types colocated with partial rule

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -1,0 +1,63 @@
+import { hasOwnProperty, isObject } from 'vest-utils';
+
+/**
+ * Keys that can mutate object prototypes when assigned.
+ *
+ * This set is intentionally tiny and lookup is O(1).
+ */
+const DANGEROUS_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+/**
+ * Returns only own enumerable keys for object-like values.
+ *
+ * Prototype keys are never traversed which prevents inherited-key surprises.
+ */
+export function ownKeys(value: unknown): string[] {
+  if (!isObject(value)) {
+    return [];
+  }
+
+  return Object.keys(value as Record<string, unknown>);
+}
+
+/**
+ * Checks whether a key is known to be unsafe for object assignment/traversal.
+ */
+export function isDangerousKey(key: string): boolean {
+  return DANGEROUS_KEYS.has(key);
+}
+
+/**
+ * Returns the first dangerous own key if present; otherwise null.
+ */
+export function findDangerousOwnKey(value: unknown): string | null {
+  for (const key of ownKeys(value)) {
+    if (isDangerousKey(key)) {
+      return key;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Produces a plain shallow sanitized copy that includes only own enumerable keys
+ * and excludes dangerous keys. Prototype and non-enumerable properties are not preserved.
+ */
+export function safeShallowCopy(
+  value: Record<string, any>,
+): Record<string, any> {
+  const output: Record<string, any> = {};
+
+  for (const key of ownKeys(value)) {
+    if (isDangerousKey(key)) {
+      continue;
+    }
+
+    if (hasOwnProperty(value, key)) {
+      output[key] = value[key];
+    }
+  }
+
+  return output;
+}

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -1,4 +1,4 @@
-import { hasOwnProperty, isObject } from 'vest-utils';
+import { isObject } from 'vest-utils';
 
 /**
  * Keys that can mutate object prototypes when assigned.
@@ -54,9 +54,7 @@ export function safeShallowCopy(
       continue;
     }
 
-    if (hasOwnProperty(value, key)) {
-      output[key] = value[key];
-    }
+    output[key] = value[key];
   }
 
   return output;

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -1,11 +1,4 @@
-import { isObject } from 'vest-utils';
-
-/**
- * Keys that can mutate object prototypes when assigned.
- *
- * This set is intentionally tiny and lookup is O(1).
- */
-const DANGEROUS_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+import { isObject, isUnsafeKey } from 'vest-utils';
 
 /**
  * Returns only own enumerable keys for object-like values.
@@ -21,18 +14,11 @@ export function ownKeys(value: unknown): string[] {
 }
 
 /**
- * Checks whether a key is known to be unsafe for object assignment/traversal.
- */
-export function isDangerousKey(key: string): boolean {
-  return DANGEROUS_KEYS.has(key);
-}
-
-/**
  * Returns the first dangerous own key if present; otherwise null.
  */
 export function findDangerousOwnKey(value: unknown): string | null {
   for (const key of ownKeys(value)) {
-    if (isDangerousKey(key)) {
+    if (isUnsafeKey(key)) {
       return key;
     }
   }
@@ -50,7 +36,7 @@ export function safeShallowCopy(
   const output: Record<string, any> = {};
 
   for (const key of ownKeys(value)) {
-    if (isDangerousKey(key)) {
+    if (isUnsafeKey(key)) {
       continue;
     }
 

--- a/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
@@ -8,6 +8,7 @@ import './partial';
 import './shape';
 
 import type { RuleInstance } from '../../utils/RuleInstance';
+import { MultiTypeInput, MultiTypeInputArgs } from './schemaRulesTypes';
 
 import type {
   IsArrayOfRuleInstance,
@@ -21,7 +22,9 @@ import type {
  * Type mappings for schema rule lazy API return types
  */
 export type SchemaRuleLazyTypes = {
-  isArrayOf: <T>(...rules: any[]) => IsArrayOfRuleInstance<T>;
+  isArrayOf: <Rules extends RuleInstance<any, any>[]>(
+    ...rules: Rules
+  ) => IsArrayOfRuleInstance<MultiTypeInput<Rules>, MultiTypeInputArgs<Rules>>;
   loose: <S extends Record<string, RuleInstance<any>>>(
     schema: S,
   ) => LooseRuleInstance<S>;

--- a/packages/n4s/src/rules/schemaRules/schemaRulesTypes.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRulesTypes.ts
@@ -1,16 +1,67 @@
 import { RuleInstance } from '../../utils/RuleInstance';
 
+/**
+ * Forces TypeScript to eagerly expand object type aliases in hover hints.
+ */
+export type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+/** Extracts the OUTPUT type from a RuleInstance (what parse() returns). */
 export type InferShape<T> = T extends RuleInstance<infer R, any> ? R : never;
 
-export type SchemaInfer<T extends Record<string, RuleInstance<any>>> = {
-  [K in keyof T as undefined extends InferShape<T[K]> ? never : K]: InferShape<
-    T[K]
-  >;
-} & {
-  [K in keyof T as undefined extends InferShape<T[K]> ? K : never]?: InferShape<
-    T[K]
-  >;
-};
+/** Extracts the INPUT type from a RuleInstance (what parse() accepts). */
+export type InferShapeInput<T> =
+  T extends RuleInstance<any, [infer A, ...any[]]> ? A : never;
+
+/**
+ * True only when T is exactly `unknown` (not a union that includes unknown).
+ * Used to prevent `unknown` fields from being wrongly classified as optional.
+ */
+type IsUnknown<T> = unknown extends T
+  ? T extends unknown
+    ? [T] extends [undefined]
+      ? false
+      : true
+    : false
+  : false;
+
+/**
+ * True when a field should be modelled as optional: its type explicitly includes
+ * undefined (e.g. via `optional()`) but is NOT just the bare `unknown` type.
+ */
+type ShouldBeOptional<T> =
+  IsUnknown<T> extends true ? false : undefined extends T ? true : false;
+
+/** Maps a schema record to its OUTPUT type (post-coercion). */
+export type SchemaInfer<T extends Record<string, RuleInstance<any>>> = Prettify<
+  {
+    [K in keyof T as ShouldBeOptional<InferShape<T[K]>> extends true
+      ? never
+      : K]: InferShape<T[K]>;
+  } & {
+    [K in keyof T as ShouldBeOptional<InferShape<T[K]>> extends true
+      ? K
+      : never]?: InferShape<T[K]>;
+  }
+>;
+
+/** Maps a schema record to its INPUT type (pre-coercion). */
+export type SchemaInput<T extends Record<string, RuleInstance<any>>> = Prettify<
+  {
+    [K in keyof T as ShouldBeOptional<InferShapeInput<T[K]>> extends true
+      ? never
+      : K]: InferShapeInput<T[K]>;
+  } & {
+    [K in keyof T as ShouldBeOptional<InferShapeInput<T[K]>> extends true
+      ? K
+      : never]?: InferShapeInput<T[K]>;
+  }
+>;
 
 export type MultiTypeInput<T extends RuleInstance<any, any>[]> =
   InferShape<T[number]> extends never ? unknown : InferShape<T[number]>;
+
+/** Extracts the input element type from rule instances (what the array accepts). */
+export type MultiTypeInputArgs<T extends RuleInstance<any, any>[]> =
+  InferShapeInput<T[number]> extends never
+    ? unknown
+    : InferShapeInput<T[number]>;

--- a/packages/n4s/src/rules/schemaRules/shape.ts
+++ b/packages/n4s/src/rules/schemaRules/shape.ts
@@ -6,6 +6,9 @@ import { RuleRunReturn } from '../../utils/RuleRunReturn';
 import { loose } from './loose';
 import { ownKeys } from './schemaObjectUtils';
 
+// Types colocated with shape rule
+import type { InferShape, SchemaInfer, SchemaInput } from './schemaRulesTypes';
+
 /**
  * Validates that an object matches a schema exactly - all keys required, no extra keys allowed.
  * Each field value is validated against its corresponding RuleInstance in the schema.
@@ -56,24 +59,16 @@ export function shape<T extends Record<string, any>>(
   return RuleRunReturn.Passing(baseRes.type);
 }
 
-// Types colocated with shape rule
-export type InferShape<T> = T extends RuleInstance<infer R, any> ? R : never;
-
-export type SchemaInfer<T extends Record<string, RuleInstance<any>>> = {
-  [K in keyof T as undefined extends InferShape<T[K]> ? never : K]: InferShape<
-    T[K]
-  >;
-} & {
-  [K in keyof T as undefined extends InferShape<T[K]> ? K : never]?: InferShape<
-    T[K]
-  >;
-};
+export type { InferShape, SchemaInfer };
 
 export type ShapeType<T extends Record<string, RuleInstance<any>>> =
   SchemaInfer<T>;
 
+export type ShapeInputType<T extends Record<string, RuleInstance<any>>> =
+  SchemaInput<T>;
+
 export type ShapeRuleInstance<S extends Record<string, RuleInstance<any>>> =
-  RuleInstance<ShapeType<S>, [ShapeType<S>]>;
+  RuleInstance<ShapeType<S>, [ShapeInputType<S>]>;
 
 export type ShapeValue<S extends Record<string, RuleInstance<any>>> =
   ShapeType<S>;

--- a/packages/n4s/src/rules/schemaRules/shape.ts
+++ b/packages/n4s/src/rules/schemaRules/shape.ts
@@ -4,6 +4,7 @@ import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
 import { loose } from './loose';
+import { ownKeys } from './schemaObjectUtils';
 
 /**
  * Validates that an object matches a schema exactly - all keys required, no extra keys allowed.
@@ -44,7 +45,7 @@ export function shape<T extends Record<string, any>>(
     return baseRes;
   }
 
-  for (const key in value) {
+  for (const key of ownKeys(value)) {
     if (!hasOwnProperty(schema, key)) {
       const res = RuleRunReturn.Failing(value);
       const newRes = { ...res, path: [key] };
@@ -52,7 +53,7 @@ export function shape<T extends Record<string, any>>(
     }
   }
 
-  return RuleRunReturn.Passing(value);
+  return RuleRunReturn.Passing(baseRes.type);
 }
 
 // Types colocated with shape rule

--- a/packages/n4s/src/utils/RuleInstance.ts
+++ b/packages/n4s/src/utils/RuleInstance.ts
@@ -41,6 +41,9 @@ export class RuleInstance<T, Args extends any[] = any[]> {
   // Type-only declaration for the StandardSchema validate method
   validate!: (...args: Args) => StandardSchemaV1.Result<T>;
 
+  // Type-only declaration for parse helper that throws on issues
+  parse!: (...args: Args) => T;
+
   // Type-only declaration for StandardSchema property
   '~standard'!: StandardSchemaV1.Props<Args[0], T>;
 
@@ -77,6 +80,16 @@ export class RuleInstance<T, Args extends any[] = any[]> {
       return rule(...args);
     };
 
+    const parse = (...args: Args): T => {
+      const result = validate(...args);
+      if (!result.issues) {
+        return result.value;
+      }
+
+      const [firstIssue] = result.issues;
+      throw new TypeError(firstIssue?.message || 'Validation failed');
+    };
+
     return {
       '~standard': {
         types: {
@@ -89,6 +102,7 @@ export class RuleInstance<T, Args extends any[] = any[]> {
       },
       infer: {} as T,
       run,
+      parse,
       test: (...args: Args) => {
         const result = validate(...args);
         return !result.issues;

--- a/packages/n4s/src/utils/RuleRunReturn.ts
+++ b/packages/n4s/src/utils/RuleRunReturn.ts
@@ -52,6 +52,7 @@ export class RuleRunReturn<T> {
     return RuleRunReturn.fromObject(pass, type, message);
   }
 
+  // eslint-disable-next-line complexity
   private static fromObject<T>(
     pass: any,
     type: T,
@@ -63,9 +64,15 @@ export class RuleRunReturn<T> {
       return new RuleRunReturn(false, type, dynamicValue(message, type));
     }
 
+    const resolvedPass = !!pass.pass;
+
+    const successType = pass.type === undefined ? type : pass.type;
+    const failureType = type === undefined ? pass.type : type;
+    const resolvedType = (resolvedPass ? successType : failureType) as T;
+
     const res = new RuleRunReturn(
-      !!pass.pass,
-      type ?? pass.type,
+      resolvedPass,
+      resolvedType as T,
       dynamicValue(message ?? pass.message, type),
     );
 

--- a/packages/n4s/src/utils/__tests__/RuleInstance.test.ts
+++ b/packages/n4s/src/utils/__tests__/RuleInstance.test.ts
@@ -62,4 +62,34 @@ describe('RuleInstance.create', () => {
       ],
     });
   });
+
+  it('parse() returns transformed output for valid input', () => {
+    type R = RuleInstance<number, [string]>;
+
+    const toNumber = (value: string) => {
+      const parsed = Number(value);
+      return Number.isNaN(parsed)
+        ? RuleRunReturn.Failing(value as any, 'not a number')
+        : RuleRunReturn.Passing(parsed);
+    };
+
+    const rule = RuleInstance.create<R, number, [string]>(toNumber as any);
+
+    expect(rule.parse('15')).toBe(15);
+  });
+
+  it('parse() throws when validation fails', () => {
+    type R = RuleInstance<number, [string]>;
+
+    const toNumber = (value: string) => {
+      const parsed = Number(value);
+      return Number.isNaN(parsed)
+        ? RuleRunReturn.Failing(value as any, 'not a number')
+        : RuleRunReturn.Passing(parsed);
+    };
+
+    const rule = RuleInstance.create<R, number, [string]>(toNumber as any);
+
+    expect(() => rule.parse('bad')).toThrow('not a number');
+  });
 });

--- a/packages/n4s/src/utils/__tests__/RuleRunReturn.test.ts
+++ b/packages/n4s/src/utils/__tests__/RuleRunReturn.test.ts
@@ -62,13 +62,24 @@ describe('RuleRunReturn', () => {
       expect(res.message).toBe('outer');
     });
 
+    it('falls back to provided type when inner passing type is undefined', () => {
+      const inner = new (RuleRunReturn as any)(
+        true,
+        undefined,
+      ) as RuleRunReturn<any>;
+      const res = RuleRunReturn.create(inner, 'FALLBACK');
+
+      expect(res.pass).toBe(true);
+      expect(res.type).toBe('FALLBACK');
+    });
+
     it('invokes provided message function with provided type argument', () => {
       const inner = RuleRunReturn.Passing('INNER');
       const msgFn = vi.fn((t: string) => `outer:${t}`);
       const res = RuleRunReturn.create(inner, 'OUTER', msgFn);
 
-      // final type prefers explicit type
-      expect(res.type).toBe('OUTER');
+      // final type preserves inner transformed type on pass
+      expect(res.type).toBe('INNER');
       // message function receives the second arg to create (OUTER)
       expect(res.message).toBe('outer:OUTER');
       expect(msgFn).toHaveBeenCalledTimes(1);

--- a/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
@@ -62,6 +62,46 @@ describe('suite schema parse integration', () => {
     });
   });
 
+  it('passes parsed array of objects output into suite body', () => {
+    const schema = {
+      parse: (value: any) => ({
+        users: value.users.map((u: any) => ({
+          age: Number(u.age),
+          name: String(u.name).trim(),
+        })),
+      }),
+      run: (value: any) => ({ pass: true, type: value }),
+    } as any;
+
+    let callbackUsers: any;
+
+    const suite = create((data: any) => {
+      callbackUsers = data.users;
+      test('users', () => {
+        enforce(data.users).isNotEmpty();
+      });
+    }, schema);
+
+    const result = suite.run({
+      users: [
+        { age: '25', name: '  Alice  ' },
+        { age: '30', name: ' Bob ' },
+      ],
+    } as any);
+
+    expect(callbackUsers).toEqual([
+      { age: 25, name: 'Alice' },
+      { age: 30, name: 'Bob' },
+    ]);
+    expect(result.isValid()).toBe(true);
+    expect(result.value).toEqual({
+      users: [
+        { age: 25, name: 'Alice' },
+        { age: 30, name: 'Bob' },
+      ],
+    });
+  });
+
   it('passes parsed output to callback and result.value', () => {
     const schema = {
       parse: (value: any) => ({
@@ -142,7 +182,7 @@ describe('suite schema parse integration', () => {
       parse: (value: any) => {
         const quantity = Number(value.quantity);
         if (Number.isNaN(quantity)) {
-          throw new Error('parse failed');
+          throw new TypeError('parse failed');
         }
 
         return { quantity };

--- a/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+
+import { create, enforce, test } from '../../vest';
+
+describe('suite schema parse integration', () => {
+  it('passes parsed schema object output into suite body', () => {
+    const schema = {
+      parse: (value: any) => ({ amount: Number(value.amount) }),
+      run: (value: any) => ({ pass: true, type: value }),
+    } as any;
+
+    let callbackValue: unknown;
+
+    const suite = create((data: any) => {
+      callbackValue = data.amount;
+
+      test('amount', () => {
+        enforce(data.amount).isNumber();
+      });
+    }, schema);
+
+    const result = suite.run({ amount: '12' } as any);
+
+    expect(callbackValue).toBe(12);
+    expect(result.isValid()).toBe(true);
+    expect(result.value).toEqual({ amount: 12 });
+  });
+
+  it('passes parsed nested schema object output into suite body', () => {
+    const schema = {
+      parse: (value: any) => ({
+        profile: {
+          age: Number(value.profile.age),
+          name: String(value.profile.name).trim(),
+        },
+      }),
+      run: (value: any) => ({ pass: true, type: value }),
+    } as any;
+
+    let callbackProfile: any;
+
+    const suite = create((data: any) => {
+      callbackProfile = data.profile;
+
+      test('profile.age', () => {
+        enforce(data.profile.age).isNumber();
+      });
+
+      test('profile.name', () => {
+        enforce(data.profile.name).isString();
+      });
+    }, schema);
+
+    const result = suite.run({
+      profile: { age: '33', name: '  Jane  ' },
+    } as any);
+
+    expect(callbackProfile).toEqual({ age: 33, name: 'Jane' });
+    expect(result.isValid()).toBe(true);
+    expect(result.value).toEqual({
+      profile: { age: 33, name: 'Jane' },
+    });
+  });
+
+  it('passes parsed output to callback and result.value', () => {
+    const schema = {
+      parse: (value: any) => ({
+        quantity: Number(value.quantity),
+        label: String(value.label).trim(),
+      }),
+      run: (value: any) => {
+        const quantity = Number(value.quantity);
+        if (Number.isNaN(quantity)) {
+          return {
+            message: 'quantity must be numeric',
+            pass: false,
+            path: ['quantity'],
+            type: value,
+          };
+        }
+
+        return {
+          pass: true,
+          type: {
+            quantity,
+            label: String(value.label).trim(),
+          },
+        };
+      },
+    };
+
+    let callbackData: any;
+
+    const suite = create((data: any) => {
+      callbackData = data;
+
+      test('quantity', () => {
+        enforce(data.quantity).isNumber();
+      });
+    }, schema as any);
+
+    const result = suite.run({ quantity: '10', label: '  item  ' } as any);
+
+    expect(callbackData).toEqual({ quantity: 10, label: 'item' });
+    expect(result.value).toEqual({ quantity: 10, label: 'item' });
+    expect((result.types as any)?.output).toEqual({
+      quantity: 10,
+      label: 'item',
+    });
+  });
+
+  it('uses parsed data with extra payload keys', () => {
+    const schema = {
+      parse: (value: any) => ({
+        amount: Number(value.amount),
+        extra: value.extra,
+      }),
+      run: (value: any) => ({
+        pass: !Number.isNaN(Number(value.amount)),
+        path: ['amount'],
+        type: { amount: Number(value.amount), extra: value.extra },
+      }),
+    };
+
+    let callbackAmount: unknown;
+
+    const suite = create((data: any) => {
+      callbackAmount = data.amount;
+      test('amount', () => {
+        enforce(data.amount).isNumber();
+      });
+    }, schema as any);
+
+    const result = suite.run({ amount: '7', extra: 'keep' } as any);
+
+    expect(callbackAmount).toBe(7);
+    expect(result.value).toEqual({ amount: 7, extra: 'keep' });
+  });
+
+  it('falls back to original input when parse fails', () => {
+    const schema = {
+      parse: (value: any) => {
+        const quantity = Number(value.quantity);
+        if (Number.isNaN(quantity)) {
+          throw new Error('parse failed');
+        }
+
+        return { quantity };
+      },
+      run: (value: any) => ({
+        message: 'quantity must be numeric',
+        pass: !Number.isNaN(Number(value.quantity)),
+        path: ['quantity'],
+        type: { quantity: Number(value.quantity) },
+      }),
+    };
+
+    let callbackData: any;
+
+    const suite = create((data: any) => {
+      callbackData = data;
+      test('quantity', () => {
+        enforce(data.quantity).isNotEmpty();
+      });
+    }, schema as any);
+
+    const result = suite.run({ quantity: 'not-a-number' } as any);
+
+    expect(callbackData).toEqual({ quantity: 'not-a-number' });
+    expect(result.hasErrors('quantity')).toBe(true);
+    expect(result.value).toBeUndefined();
+  });
+
+  it('maps security-related schema run paths into suite errors', () => {
+    const schema = {
+      parse: (value: any) => value,
+      run: () => ({
+        message: 'dangerous key',
+        pass: false,
+        path: ['security'],
+        type: {},
+      }),
+    };
+
+    const suite = create(() => {}, schema as any);
+
+    const result = suite.run({ name: 'safe' } as any);
+
+    expect(result.hasErrors()).toBe(true);
+    expect(result.hasErrors('security')).toBe(true);
+  });
+});

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -4,6 +4,14 @@ import { describe, it, expect } from 'vitest';
 import { create, test } from '../../vest';
 
 describe('Schema Runtime Validation', () => {
+  enforce.extend({
+    toNumber: (value: unknown) => {
+      const parsed = Number(value);
+      return Number.isNaN(parsed)
+        ? { pass: false, type: value }
+        : { pass: true, type: parsed };
+    },
+  });
   const schema = enforce.shape({
     name: enforce.isString(),
     age: enforce.isNumber(),
@@ -140,9 +148,9 @@ describe('Schema Runtime Validation', () => {
         user: { name: 123, age: 'thirty' },
       } as any);
 
-      // Schema will report the first failure under 'user' field
-      expect(result.hasErrors('user')).toBe(true);
-      const errors = result.getErrors('user');
+      // Schema reports nested paths with full field specificity
+      expect(result.hasErrors('user.name')).toBe(true);
+      const errors = result.getErrors('user.name');
 
       // The error message should be one of the nested field's custom messages
       expect(errors).toContain('User name must be a string');
@@ -260,6 +268,30 @@ describe('Schema Runtime Validation', () => {
 
       expect(res.pass).toBe(false);
       expect(res.path).toEqual(['users', '1', 'age']);
+    });
+  });
+
+  describe('Parsed schema output', () => {
+    it('should pass parsed schema output into the suite callback', () => {
+      const schemaWithParsing = {
+        parse: (value: any) => ({ age: Number(value.age) }),
+        run: (value: any) => ({ pass: true, type: { age: Number(value.age) } }),
+      } as any;
+
+      let receivedAge: unknown;
+      const parsedSuite = create((data: any) => {
+        receivedAge = data.age;
+        test('age', () => {
+          enforce(data.age).isNumber();
+        });
+      }, schemaWithParsing);
+
+      const result = parsedSuite.run({ age: '32' } as any);
+
+      expect(receivedAge).toBe(32);
+      expect(result.value).toEqual({ age: 32 });
+      expect((result.types as any)?.output).toEqual({ age: 32 });
+      expect(result.isValid()).toBe(true);
     });
   });
 

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -242,6 +242,7 @@ describe('Schema Runtime Validation', () => {
       });
 
       const res = schema.run({
+        // @ts-expect-error - Invalid data: 123 is not a string
         tags: ['valid', 123, 'valid'],
       });
 
@@ -262,6 +263,7 @@ describe('Schema Runtime Validation', () => {
       const res = schema.run({
         users: [
           { name: 'John', age: 30 },
+          // @ts-expect-error - Invalid data: '25' is not a number
           { name: 'Jane', age: '25' }, // Invalid age
         ],
       });

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -27,10 +27,10 @@ import { useCreateSuiteResult } from '../suiteResult/suiteResult';
 import { SuiteModifiers, SuiteCallbackWithSchema } from './SuiteTypes';
 
 type SchemaRunResult = {
-  message?: string;
-  pass: boolean;
-  path?: string[];
-  type?: unknown;
+  readonly message?: string;
+  readonly pass: boolean;
+  readonly path?: readonly string[];
+  readonly type?: unknown;
 };
 
 /**
@@ -198,7 +198,8 @@ function runSchemaValidation<
       return;
     }
 
-    for (const error of schemaRunResult) {
+    for (let i = 0; i < schemaRunResult.length; i++) {
+      const error = schemaRunResult[i];
       if (error.pass) {
         continue;
       }
@@ -209,10 +210,41 @@ function runSchemaValidation<
         fieldName,
         error.message ?? 'Validation failed',
         () => false,
-        fieldName,
+        `${fieldName}_${i}`,
       );
     }
   };
+}
+
+/**
+ * Attempts to parse the schema. Returns null if parse fails gracefully,
+ * so the caller can fall back to schema.run.
+ */
+function tryParseSchema(schema: any, data: unknown): SchemaRunResult[] | null {
+  if (!isFunction(schema.parse)) {
+    return null;
+  }
+
+  try {
+    const parsedValue = schema.parse(data);
+
+    if (shouldRunAfterParse(schema)) {
+      return normalizeSchemaRunResult(schema.run(parsedValue), parsedValue);
+    }
+
+    return [
+      {
+        pass: true,
+        type: parsedValue,
+      },
+    ];
+  } catch (error) {
+    if (!isExpectedSchemaParseError(error)) {
+      throw error;
+    }
+    // Expected validation failures can fallback to run(raw) for field-level path/message details.
+    return null;
+  }
 }
 
 /**
@@ -221,28 +253,10 @@ function runSchemaValidation<
  * 2) if parse succeeds, treat it as the authoritative validation output
  * 3) on expected parse validation failures, fallback to run(raw)
  */
-// eslint-disable-next-line complexity
 function runSchemaWithParse(schema: any, data: unknown): SchemaRunResult[] {
-  if (isFunction(schema.parse)) {
-    try {
-      const parsedValue = schema.parse(data);
-
-      if (shouldRunAfterParse(schema)) {
-        return normalizeSchemaRunResult(schema.run(parsedValue), parsedValue);
-      }
-
-      return [
-        {
-          pass: true,
-          type: parsedValue,
-        },
-      ];
-    } catch (error) {
-      if (!isExpectedSchemaParseError(error)) {
-        throw error;
-      }
-      // Expected validation failures can fallback to run(raw) for field-level path/message details.
-    }
+  const parseResult = tryParseSchema(schema, data);
+  if (parseResult) {
+    return parseResult;
   }
 
   if (isFunction(schema.run)) {
@@ -317,17 +331,19 @@ function isSchemaRunResult(candidate: unknown): candidate is SchemaRunResult {
  * Detects parse errors that represent expected validation failures.
  */
 function isExpectedSchemaParseError(error: unknown): boolean {
+  if (error instanceof TypeError) {
+    return true;
+  }
+
   if (!isObject(error)) {
     return false;
   }
 
   const typedError = error as { isValidation?: unknown; name?: unknown };
-  return (
-    typedError.isValidation === true ||
-    typedError.name === 'TypeError' ||
-    error instanceof Error
-  );
+  return typedError.isValidation === true || typedError.name === 'TypeError';
 }
+
+const N4S_VENDOR = 'n4s';
 
 /**
  * Determines whether schema.run should execute after a successful parse call.
@@ -341,7 +357,7 @@ function shouldRunAfterParse(schema: any): boolean {
     return false;
   }
 
-  return schema?.['~standard']?.vendor !== 'n4s';
+  return schema?.['~standard']?.vendor !== N4S_VENDOR;
 }
 
 /**

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -1,4 +1,12 @@
-import { assign, asArray, CB, isFunction, withResolvers } from 'vest-utils';
+import {
+  assign,
+  asArray,
+  CB,
+  isArray,
+  isFunction,
+  isObject,
+  withResolvers,
+} from 'vest-utils';
 
 import { useEmit } from '../core/VestBus/VestBus';
 
@@ -18,16 +26,19 @@ import { useCreateSuiteResult } from '../suiteResult/suiteResult';
 
 import { SuiteModifiers, SuiteCallbackWithSchema } from './SuiteTypes';
 
-/**
- * Creates the actual suite runner function.
- * This function is responsible for initializing the suite context,
- * running the suite callback, and returning the result.
- *
- * @param {Function} suiteCallback - The body of the suite.
- * @param {Object} modifiers - The modifiers for the suite (e.g., only).
- * @returns {Function} - The suite runner function.
- */
+type SchemaRunResult = {
+  message?: string;
+  pass: boolean;
+  path?: string[];
+  type?: unknown;
+};
 
+/**
+ * Creates the suite runner bound to a callback, modifiers and (optional) schema.
+ *
+ * The runner performs schema preprocessing once per run, stores the original input
+ * and parsed output, and then executes the suite callback within SuiteContext.
+ */
 // eslint-disable-next-line max-lines-per-function
 export function useCreateSuiteRunner<
   F extends TFieldName,
@@ -40,34 +51,53 @@ export function useCreateSuiteRunner<
   schema?: S,
 ) {
   const transformedModifiers = useTransformedModifiers(modifiers);
+
   return function runSuite(
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
   ): SuiteResult<F, G, S> {
     const { resolve, promise } = withResolvers<SuiteResult<F, G, S>>();
+
+    const schemaInput = args[0];
+    const schemaRunResult = shouldRunSchema(schema, transformedModifiers)
+      ? runSchemaWithParse(schema, schemaInput)
+      : undefined;
+
+    const callbackInput = getCallbackInput(schemaRunResult, schemaInput);
+    const callbackArgs = [callbackInput, ...args.slice(1)] as Parameters<T>;
+
     return assign(
       promise,
       SuiteContext.run(
         {
-          suiteParams: args as Parameters<T>,
+          suiteParams: callbackArgs,
           schema,
           modifiers: transformedModifiers,
         },
         () => {
           useEmit('SUITE_RUN_STARTED');
+
           const useResolver = () => {
-            const result = useCreateSuiteResult<F, G, S>(schema, args[0]);
+            const result = useCreateSuiteResult<F, G, S>(
+              schema,
+              callbackInput,
+              schemaInput,
+            );
+
             if (!result.isPending()) {
               resolve(result);
             }
+
             return result;
           };
+
           return IsolateSuite(
             useRunSuiteCallback<F, T, S>({
-              args,
+              args: callbackArgs,
               modifiers: transformedModifiers,
               schema,
+              schemaRunResult,
               suiteCallback,
               useResolver,
             }),
@@ -79,6 +109,24 @@ export function useCreateSuiteRunner<
   };
 }
 
+/**
+ * Resolves the value that should be passed into the suite callback.
+ */
+function getCallbackInput(
+  schemaRunResult: SchemaRunResult[] | undefined,
+  fallback: unknown,
+): unknown {
+  if (!schemaRunResult || schemaRunResult.some(result => !result.pass)) {
+    return fallback;
+  }
+
+  const [firstResult] = schemaRunResult;
+  return firstResult?.type ?? fallback;
+}
+
+/**
+ * Wraps suite callback execution and schema failure emission into an isolate callback.
+ */
 function useRunSuiteCallback<
   F extends TFieldName,
   T extends CB = CB,
@@ -87,33 +135,42 @@ function useRunSuiteCallback<
   args: any[];
   modifiers: ReturnType<typeof useTransformedModifiers<F>>;
   schema: S | undefined;
+  schemaRunResult?: SchemaRunResult[];
   suiteCallback: SuiteCallbackWithSchema<S, T>;
   useResolver: () => SuiteResult<F, any, S>;
 }) {
-  const { args, modifiers, schema, suiteCallback, useResolver } = params;
+  const {
+    args,
+    modifiers,
+    schema,
+    schemaRunResult,
+    suiteCallback,
+    useResolver,
+  } = params;
+
   return () => {
-    // Apply field-level focus modifiers. These create transient Focused
-    // isolates at the suite root that affect all tests in the suite.
-    // `only` restricts the run to matching fields; `skip` excludes them.
-    // `skipGroup` is handled separately inside `group()` — when a group
-    // with a matching name is entered, it injects `skip(true)` into
-    // the group's callback via the modifiers stored in SuiteContext.
+    // Focused modifiers are applied before user callback so every test in this run
+    // observes the same focus context.
     only(modifiers.only);
     skip(modifiers.skip);
     (suiteCallback as any)(...args);
 
     IsolateReorderable(
-      runSchemaValidation(schema, modifiers, args[0]),
+      runSchemaValidation(schema, modifiers, schemaRunResult),
       undefined,
       {
         tests: [],
       },
     );
+
     useEmit('SUITE_CALLBACK_RUN_FINISHED');
     return useResolver();
   };
 }
 
+/**
+ * Normalizes user-provided modifiers into deterministic sets for O(1) membership checks.
+ */
 function useTransformedModifiers<F extends TFieldName>(
   modifiers: SuiteModifiers<F>,
 ) {
@@ -124,27 +181,179 @@ function useTransformedModifiers<F extends TFieldName>(
   };
 }
 
+/**
+ * Emits schema failures into vest test tree.
+ */
 function runSchemaValidation<
   F extends TFieldName,
   S extends TSchema = undefined,
 >(
   schema: S | undefined,
   modifiers: ReturnType<typeof useTransformedModifiers<F>>,
-  data: any,
+  schemaRunResult?: SchemaRunResult[],
 ) {
+  // eslint-disable-next-line complexity
   return () => {
-    if (!shouldRunSchema(schema, modifiers)) return;
+    if (!shouldRunSchema(schema, modifiers) || !schemaRunResult) {
+      return;
+    }
 
-    const runResult = (schema as any).run(data);
+    for (const error of schemaRunResult) {
+      if (error.pass) {
+        continue;
+      }
 
-    if (!runResult.pass && runResult.path) {
-      // Use the top-level field name (first segment) for error reporting
-      const fieldName = runResult.path[0];
-      test(fieldName, runResult.message, () => false, fieldName);
+      const fieldName = error.path?.length ? error.path.join('.') : '__root__';
+
+      test(
+        fieldName,
+        error.message ?? 'Validation failed',
+        () => false,
+        fieldName,
+      );
     }
   };
 }
 
-function shouldRunSchema(schema: any, modifiers: any): boolean {
-  return !modifiers.only && !!schema && isFunction(schema.run);
+/**
+ * Runs schema parsing/validation in a safe order:
+ * 1) try parse
+ * 2) if parse succeeds, treat it as the authoritative validation output
+ * 3) on expected parse validation failures, fallback to run(raw)
+ */
+// eslint-disable-next-line complexity
+function runSchemaWithParse(schema: any, data: unknown): SchemaRunResult[] {
+  if (isFunction(schema.parse)) {
+    try {
+      const parsedValue = schema.parse(data);
+
+      if (shouldRunAfterParse(schema)) {
+        return normalizeSchemaRunResult(schema.run(parsedValue), parsedValue);
+      }
+
+      return [
+        {
+          pass: true,
+          type: parsedValue,
+        },
+      ];
+    } catch (error) {
+      if (!isExpectedSchemaParseError(error)) {
+        throw error;
+      }
+      // Expected validation failures can fallback to run(raw) for field-level path/message details.
+    }
+  }
+
+  if (isFunction(schema.run)) {
+    return normalizeSchemaRunResult(schema.run(data), data);
+  }
+
+  return [
+    {
+      pass: true,
+      type: data,
+    },
+  ];
+}
+
+/**
+ * Converts unknown schema.run return value into a stable internal representation.
+ */
+function normalizeSchemaRunResult(
+  candidate: unknown,
+  fallbackType: unknown,
+): SchemaRunResult[] {
+  if (isArray(candidate)) {
+    return candidate.map(entry =>
+      normalizeSingleSchemaRunResult(entry, fallbackType),
+    );
+  }
+
+  return [normalizeSingleSchemaRunResult(candidate, fallbackType)];
+}
+
+/**
+ * Converts a single unknown run payload into a safe result shape.
+ */
+function normalizeSingleSchemaRunResult(
+  candidate: unknown,
+  fallbackType: unknown,
+): SchemaRunResult {
+  if (!isSchemaRunResult(candidate)) {
+    return {
+      pass: false,
+      type: fallbackType,
+    };
+  }
+
+  return {
+    message: candidate.message,
+    pass: candidate.pass,
+    path: candidate.path,
+    type: candidate.type ?? fallbackType,
+  };
+}
+
+/**
+ * Runtime type guard for schema run payloads.
+ */
+function isSchemaRunResult(candidate: unknown): candidate is SchemaRunResult {
+  if (!isObject(candidate)) {
+    return false;
+  }
+
+  const value = candidate as Partial<SchemaRunResult>;
+
+  const hasPass = typeof value.pass === 'boolean';
+  const hasPath =
+    value.path === undefined ||
+    (isArray(value.path) && value.path.every(item => typeof item === 'string'));
+
+  return hasPass && hasPath;
+}
+
+/**
+ * Detects parse errors that represent expected validation failures.
+ */
+function isExpectedSchemaParseError(error: unknown): boolean {
+  if (!isObject(error)) {
+    return false;
+  }
+
+  const typedError = error as { isValidation?: unknown; name?: unknown };
+  return (
+    typedError.isValidation === true ||
+    typedError.name === 'TypeError' ||
+    error instanceof Error
+  );
+}
+
+/**
+ * Determines whether schema.run should execute after a successful parse call.
+ *
+ * For n4s StandardSchema-backed rules, parse already performs full validation.
+ * Re-running run(parsed) can break coercion chains where post-parse types differ
+ * from pre-parse input expectations.
+ */
+function shouldRunAfterParse(schema: any): boolean {
+  if (!isFunction(schema.run)) {
+    return false;
+  }
+
+  return schema?.['~standard']?.vendor !== 'n4s';
+}
+
+/**
+ * Schema should run only when schema exists and the run is not field-focused.
+ */
+function shouldRunSchema(
+  schema: unknown,
+  modifiers: { only?: unknown },
+): boolean {
+  const hasOnly = isArray(modifiers.only)
+    ? modifiers.only.length > 0
+    : !!modifiers.only;
+
+  return !hasOnly && !!schema;
 }

--- a/packages/vest/src/suiteResult/SuiteResultTypes.ts
+++ b/packages/vest/src/suiteResult/SuiteResultTypes.ts
@@ -55,9 +55,21 @@ export type GetFailuresResponse = FailureMessages | string[];
 export type FailureMessages = Record<string, string[]>;
 export type TSchema = any;
 
-export type InferSchemaData<S> = S extends { infer: infer T }
-  ? { [K in keyof T]: T[K] } & NonNullable<unknown>
-  : any;
+export type InferSchemaData<S> = S extends {
+  '~standard': { types: { input: infer I } };
+}
+  ? I
+  : S extends { infer: infer T }
+    ? { [K in keyof T]: T[K] } & NonNullable<unknown>
+    : any;
+
+export type InferSchemaOutput<S> = S extends {
+  '~standard': { types: { output: infer O } };
+}
+  ? O
+  : S extends { infer: infer T }
+    ? { [K in keyof T]: T[K] } & NonNullable<unknown>
+    : any;
 
 type SuiteResultData<
   F extends TFieldName,
@@ -67,7 +79,7 @@ type SuiteResultData<
   | (Omit<SuiteSummary<F, G>, 'valid'> &
       SuiteSelectors<F, G> & {
         valid: true;
-        value: InferSchemaData<S>;
+        value: InferSchemaOutput<S>;
         issues?: undefined;
       })
   | (Omit<SuiteSummary<F, G>, 'valid'> &
@@ -94,7 +106,7 @@ export type SuiteResult<
   dump: CB<TIsolateSuite>;
   types: S extends undefined
     ? undefined
-    : { input: InferSchemaData<S>; output: InferSchemaData<S> };
+    : { input: InferSchemaData<S>; output: InferSchemaOutput<S> };
 };
 
 // Public-facing aliases remain plain strings; internals can still brand via FieldName/GroupName.

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -20,15 +20,15 @@ export function useCreateSuiteResult<
   F extends TFieldName,
   G extends TGroupName,
   S extends TSchema = undefined,
->(schema?: S, data?: any): SuiteResult<F, G, S> {
+>(schema?: S, outputData?: any, inputData?: any): SuiteResult<F, G, S> {
   return useSuiteResultCache<F, G, S>(() => {
     // @vx-allow use-use
     const summary = useProduceSuiteSummary<F, G>();
-    const resultBody = constructSuiteResultObject<F, G, S>(summary, data);
+    const resultBody = constructSuiteResultObject<F, G, S>(summary, outputData);
     return freezeAssign(resultBody as SuiteResult<F, G, S>, {
       dump: VestRuntime.persist(VestRuntime.useAvailableRoot<TIsolateSuite>),
       types: (schema
-        ? { input: data, output: data }
+        ? { input: inputData, output: outputData }
         : undefined) as SuiteResult<F, G, S>['types'],
     }) as SuiteResult<F, G, S>;
   });
@@ -40,7 +40,7 @@ export function constructSuiteResultObject<
   S extends TSchema = undefined,
 >(
   summary: SuiteSummary<F, G>,
-  data?: any,
+  outputData?: any,
 ): Omit<SuiteResult<F, G, S>, 'dump' | 'types'> {
   const { valid, ...summaryWithoutValid } = summary;
   const selectors = suiteSelectors<F, G>(summary);
@@ -51,7 +51,7 @@ export function constructSuiteResultObject<
     return {
       ...common,
       valid: true,
-      value: data,
+      value: outputData,
     };
   } else if (valid === false) {
     const issues = summary[Severity.ERRORS].reduce((acc, failure) => {


### PR DESCRIPTION
### Motivation
- Provide a predictable single-pass parse pipeline so rules can both validate and coerce values, and ensure parsed/coerced objects are used by suites when a schema is provided. 
- Harden schema traversal against prototype-pollution and other unsafe keys and make schema parsing O(1) per-key where possible. 
- Improve interoperability by exposing a `parse()` API on rule instances and making chain execution propagate transformed values through the chain. 

### Description
- Added a small `schemaObjectUtils` helper (`ownKeys`, `safeHasOwn`, `findDangerousOwnKey`, `safeShallowCopy`, `isDangerousKey`) and applied it to `loose`, `partial`, and `shape` schema rules to reject dangerous keys and produce sanitized shallow copies. 
- Exposed `parse()` on `RuleInstance`, on the chain proxy, and in `createChainBuilder`, and updated `executeChain`/proxy handlers so chain predicates flow transformed `type` values forward. 
- Updated `RuleRunReturn` resolution logic so transformed `type` from inner rule results is preserved on success. 
- Wired schema parsing into Vest runner: `useCreateSuiteRunner` now attempts `schema.parse` (with safe fallback to `schema.run`), injects parsed output into the suite callback, and surfaces parsed output in `SuiteResult.value` and `types.output` while keeping `types.input` as original input. 
- Added documentation (`packages/n4s/docs/schema.md`) describing design, complexity, and security decisions, and added integration/unit tests in both `n4s` and `vest` to cover coercion, parsing, extra payload behavior, and security scenarios. 
- Small test typing cleanup: declared missing custom matcher typing in `packages/n4s/src/__tests__/standardSchema.test.ts` and replaced remaining `(enforce as any)` usage with typed matcher access. 

### Testing
- Ran the full test suite with `yarn test` and the run completed successfully (all tests passed). 
- Ran targeted vitest commands for the modified test files with `yarn vitest run packages/n4s/src/__tests__/standardSchema.test.ts packages/n4s/src/__tests__/parse.test.ts packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts` and `yarn vitest run` for the added Vest integration tests, and those targeted suites passed (new parse/integration tests are green). 
- Pre-commit tasks (`eslint`, `prettier` via lint-staged) were executed during validation and completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added .parse() to validation rules for coercion/transform and throwing on failure.
  * Parsed schema output now flows into suite callbacks and result objects; array/item parsing preserves transformed values.

* **Bug Fixes / Security**
  * Rejects prototype-polluting/dangerous keys and reports precise nested error paths.
  * Schema parsing returns transformed copies without mutating inputs.

* **Documentation**
  * New comprehensive schema parsing architecture guide.

* **Tests**
  * Many unit and integration tests for parsing, coercions, arrays, types, and suite integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->