### PR TITLE
feat(n4s): support isNumeric().toNumber() parser chaining

### DIFF
--- a/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
+++ b/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
@@ -15,7 +15,7 @@ import { createChainProxyHandlers } from './proxyHandlers';
 
 export type RuleFunctions<T extends RuleInstance<any, any>> = Record<
   keyof Omit<T, 'infer' | 'test' | 'validate' | 'parse' | '~standard'>,
-  (...args: any[]) => boolean
+  (...args: any[]) => boolean | ReturnType<Predicate>
 >;
 
 type LazyMessage = DynamicValue<

--- a/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
+++ b/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
@@ -9,7 +9,7 @@ import { getLazyRule } from './lazyRegistry';
 export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
   rules: Record<
     keyof Omit<T, 'infer' | 'test' | 'validate' | 'parse' | '~standard'>,
-    (...args: any[]) => boolean
+    (...args: any[]) => boolean | ReturnType<Predicate>
   >,
   {
     add,

--- a/packages/n4s/src/rules/numberRules.ts
+++ b/packages/n4s/src/rules/numberRules.ts
@@ -14,6 +14,7 @@ import { isOdd } from './number/isOdd';
 import { isPositive } from './number/isPositive';
 import { lessThan } from './number/lessThan';
 import { lessThanOrEquals } from './number/lessThanOrEquals';
+import { toNumber } from './numeric/toNumber';
 import { numberNotEquals } from './number/numberNotEquals';
 
 const gt = greaterThan;
@@ -55,6 +56,7 @@ export {
   lessThanOrEquals,
   numberEquals,
   numberNotEquals,
+  toNumber,
 };
 
 const numberRules = {
@@ -75,6 +77,7 @@ const numberRules = {
   lessThanOrEquals,
   numberEquals,
   numberNotEquals,
+  toNumber,
 } as const;
 
 export type NumberRuleInstance = BuildRuleInstance<

--- a/packages/n4s/src/rules/numeric/__tests__/isNumeric.test.ts
+++ b/packages/n4s/src/rules/numeric/__tests__/isNumeric.test.ts
@@ -177,6 +177,38 @@ describe('isNumeric', () => {
     });
   });
 
+  describe('toNumber', () => {
+    it('transforms numeric strings to numbers in parse', () => {
+      expect(enforce.isNumeric().toNumber().parse('1985')).toBe(1985);
+    });
+
+    it('coerces numeric strings in shape parsing', () => {
+      const ChronoSchema = enforce.shape({
+        travelerName: enforce.isString(),
+        mission: enforce.isString(),
+        birthYear: enforce.isNumeric().toNumber(),
+        destinationYear: enforce.isNumeric(),
+        plutoniumCores: enforce.isNumeric(),
+      });
+
+      expect(
+        ChronoSchema.parse({
+          travelerName: 'Marty McFly',
+          mission: 'Save Doc',
+          birthYear: '1968',
+          destinationYear: '1955',
+          plutoniumCores: 1,
+        }),
+      ).toEqual({
+        travelerName: 'Marty McFly',
+        mission: 'Save Doc',
+        birthYear: 1968,
+        destinationYear: '1955',
+        plutoniumCores: 1,
+      });
+    });
+  });
+
   describe('isPositive', () => {
     it('pass for positive numeric strings', () => {
       expect(enforce.isNumeric().isPositive().run('1').pass).toBe(true);

--- a/packages/n4s/src/rules/numeric/__tests__/isNumeric.test.ts
+++ b/packages/n4s/src/rules/numeric/__tests__/isNumeric.test.ts
@@ -207,6 +207,10 @@ describe('isNumeric', () => {
         plutoniumCores: 1,
       });
     });
+
+    it('throws when parsing a value that is not a valid number', () => {
+      expect(() => enforce.isNumeric().toNumber().parse('1.2.3')).toThrow();
+    });
   });
 
   describe('isPositive', () => {

--- a/packages/n4s/src/rules/numeric/toNumber.ts
+++ b/packages/n4s/src/rules/numeric/toNumber.ts
@@ -1,11 +1,11 @@
-import { toNumber as toNumberValue } from 'vest-utils';
+import { isFailure, toNumber as toNumberValue } from 'vest-utils';
 
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
 export function toNumber(value: unknown): RuleRunReturn<number> {
   const result = toNumberValue(value);
 
-  if (result.type === 'err') {
+  if (isFailure(result)) {
     return RuleRunReturn.Failing(NaN, result.error);
   }
 

--- a/packages/n4s/src/rules/numeric/toNumber.ts
+++ b/packages/n4s/src/rules/numeric/toNumber.ts
@@ -1,0 +1,13 @@
+import { toNumber as toNumberValue } from 'vest-utils';
+
+import { RuleRunReturn } from '../../utils/RuleRunReturn';
+
+export function toNumber(value: unknown): RuleRunReturn<number> {
+  const result = toNumberValue(value);
+
+  if (result.type === 'err') {
+    return RuleRunReturn.Failing(NaN, result.error);
+  }
+
+  return RuleRunReturn.Passing(result.value);
+}


### PR DESCRIPTION
### Motivation
- Allow numeric schema rules to participate in the parser/coercion pipeline so numeric strings can be converted to numbers during `parse`/`shape` operations (e.g. `birthYear: enforce.isNumeric().toNumber()`).

### Description
- Added a new numeric rule `toNumber` that returns a `RuleRunReturn` transform when conversion succeeds or a failing `RuleRunReturn` when it doesn't (`packages/n4s/src/rules/numeric/toNumber.ts`).
- Exposed `toNumber` via the `numberRules` exports so it can be chained from `enforce.isNumeric()` (`packages/n4s/src/rules/numberRules.ts`).
- Broadened chain-builder and proxy handler typings to accept rules that return `RuleRunReturn` (transforming rules) in addition to boolean predicates (`packages/n4s/src/rules/chainBuilder/chainBuilder.ts` and `packages/n4s/src/rules/chainBuilder/proxyHandlers.ts`).
- Added tests covering `toNumber` usage both directly (`.toNumber().parse(...)`) and inside a schema `shape` to verify coercion (`packages/n4s/src/rules/numeric/__tests__/isNumeric.test.ts`).

### Testing
- Ran unit tests: `yarn vitest packages/n4s/src/rules/numeric/__tests__/isNumeric.test.ts` and the file passed (31 tests).
- Ran TypeScript validation: `yarn tsc -p packages/n4s/tsconfig.json --noEmit` and it succeeded.
- Ran formatting checks: `yarn prettier -c ...` and then `yarn prettier --write` where necessary; final formatting checks passed.
- All automated checks listed above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1900cb9c83309a48a5cd15ad0e35)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toNumber rule to convert/coerce string values to numbers in validation chains.

* **Tests**
  * Added tests covering toNumber behavior (parsing, shape coercion, and invalid input handling).

* **Chores**
  * Broadened allowed predicate return results for rule functions to support more flexible rule outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->