### PR TITLE
fix(classnames): accept schema-typed suite results

### DIFF
--- a/packages/vest/src/exports/__tests__/classnames.test.ts
+++ b/packages/vest/src/exports/__tests__/classnames.test.ts
@@ -38,7 +38,7 @@ describe('Utility: classnames', () => {
     });
   });
 
-  it('accepts suite results created with schema typings', () => {
+  it('accepts schema-typed suite results from suite.get()', () => {
     const typedSuite = vest.create(
       data => {
         vest.test('travelerName', 'Traveler name is required', () => {
@@ -50,7 +50,9 @@ describe('Utility: classnames', () => {
       }),
     );
 
-    const cn = classnames(typedSuite.run({ travelerName: '' }), {
+    typedSuite.run({ travelerName: '' });
+
+    const cn = classnames(typedSuite.get(), {
       warning: 'warning',
       invalid: 'invalid',
     });

--- a/packages/vest/src/exports/__tests__/classnames.test.ts
+++ b/packages/vest/src/exports/__tests__/classnames.test.ts
@@ -38,6 +38,26 @@ describe('Utility: classnames', () => {
     });
   });
 
+  it('accepts suite results created with schema typings', () => {
+    const typedSuite = vest.create(
+      data => {
+        vest.test('travelerName', 'Traveler name is required', () => {
+          vest.enforce(data.travelerName).isNotBlank();
+        });
+      },
+      vest.enforce.shape({
+        travelerName: vest.enforce.isString(),
+      }),
+    );
+
+    const cn = classnames(typedSuite.run({ travelerName: '' }), {
+      warning: 'warning',
+      invalid: 'invalid',
+    });
+
+    expect(cn('travelerName')).toContain('invalid');
+  });
+
   const suite = vest.create(() => {
     vest.mode(Modes.ALL);
     vest.skip('field_1');

--- a/packages/vest/src/exports/classnames.ts
+++ b/packages/vest/src/exports/classnames.ts
@@ -4,6 +4,7 @@ import {
   SuiteResult,
   TFieldName,
   TGroupName,
+  TSchema,
 } from '../suiteResult/SuiteResultTypes';
 
 import { ParsedVestObject, parse } from './parser';
@@ -11,8 +12,12 @@ import { ParsedVestObject, parse } from './parser';
 /**
  * Creates a function that returns class names that match the validation result
  */
-export default function classnames<F extends TFieldName, G extends TGroupName>(
-  res: SuiteResult<F, G>,
+export default function classnames<
+  F extends TFieldName,
+  G extends TGroupName,
+  S extends TSchema,
+>(
+  res: SuiteResult<F, G, S>,
   classes: SupportedClasses = {},
 ): (fieldName: string) => string {
   const selectors = parse(res);

--- a/packages/vest/src/exports/parser.ts
+++ b/packages/vest/src/exports/parser.ts
@@ -12,12 +12,15 @@ import {
   SuiteSummary,
   TFieldName,
   TGroupName,
+  TSchema,
 } from '../suiteResult/SuiteResultTypes';
 import { suiteSelectors } from '../vest';
 
-export function parse<F extends TFieldName, G extends TGroupName>(
-  summary: SuiteSummary<F, G> | SuiteResult<F, G>,
-): ParsedVestObject<F> {
+export function parse<
+  F extends TFieldName,
+  G extends TGroupName,
+  S extends TSchema,
+>(summary: SuiteSummary<F, G> | SuiteResult<F, G, S>): ParsedVestObject<F> {
   invariant(
     summary && hasOwnProperty(summary, 'valid'),
     ErrorStrings.PARSER_EXPECT_RESULT_OBJECT,


### PR DESCRIPTION
### Motivation
- `classnames` did not accept schema-typed `SuiteResult` objects returned from typed suites, causing type errors when passing results from schema-typed suites into `vest/classnames`.
- The parser helper was also not typed to accept schema-typed `SuiteResult`, preventing `classnames` from composing cleanly with typed results.

### Description
- Made `classnames` generic over the suite schema by adding `S extends TSchema` and changed its parameter to `res: SuiteResult<F, G, S>` so it accepts all `SuiteResult` variants.
- Updated `parse` signature to accept `SuiteResult<F, G, S>` and imported `TSchema` where needed.
- Added a regression test that creates a schema-typed suite and asserts `classnames` works with the typed suite result.
- Adjusted imports and ran formatting to keep code style consistent.

### Testing
- Ran unit tests for the modified file with `yarn vitest run packages/vest/src/exports/__tests__/classnames.test.ts` and all tests passed.
- Ran type-checked tests with `yarn vitest run --typecheck packages/vest/src/exports/__tests__/classnames.test.ts` and there were no type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e29c099108330b24561f96a5a654c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test verifying class name behavior when using schema-typed suite results.

* **Refactor**
  * Type-level enhancements to validation and parsing utilities to accept schema-typed suites (no runtime behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->