### PR TITLE
docs: document async-safe `useWarn()` and update API reference

### DIFF
--- a/website/docs/api_reference.md
+++ b/website/docs/api_reference.md
@@ -14,6 +14,7 @@ keywords:
     suite.resetField,
     test,
     warn,
+    useWarn,
     enforce,
     enforce.extend,
     compose,
@@ -194,9 +195,15 @@ Asserts that a value matches your desired result.
 
 #### `warn()`
 
-Sets the test's severity to warning.
+Sets the test's severity to warning in the synchronous part of a test.
 
 - [Read more about `warn`](./writing_tests/warn_only_tests.md)
+
+#### `useWarn()`
+
+Returns a setter function that marks the current test as warning severity, including async flows after an `await`.
+
+- [Read more about `useWarn`](./writing_tests/warn_only_tests.md)
 
 #### `only(fieldName)`
 

--- a/website/docs/writing_tests/warn_only_tests.md
+++ b/website/docs/writing_tests/warn_only_tests.md
@@ -1,24 +1,27 @@
 ---
 sidebar_position: 4
 title: Warn only tests
-description: How to use the warn function in Vest to create warn-only tests. Warn-only tests are useful when you want to fail a test without marking the suite as invalid..
-keywords: [vest, warn, warn only tests, validation, password strength]
+description: How to use warn and useWarn in Vest to create warn-only tests. Warn-only tests are useful when you want to fail a test without marking the suite as invalid.
+keywords: [vest, warn, useWarn, warn only tests, validation, password strength]
 ---
 
 # Warn-only tests
 
 By default, a failing test has a severity of `error`. Sometimes you may need to lower the severity level of a given test to `warn` so that even when it fails, it should not prevent submission. An example of this would be validating password strength.
 
-To set a test's severity level to `warn` call the warn function from the body of your test.
+To set a test's severity level to `warn`, call `warn()` from the body of your test.
+
+If you need to set warning severity after an `await` in an async test, use `useWarn()` and call the setter it returns.
 
 import WarnOnlyTestsSandpack from '@site/src/components/Sandpack/WarnOnlyTests';
 
 <WarnOnlyTestsSandpack />
 
-**Limitations when using warn()**
+## `warn()` vs `useWarn()` in async tests
 
-- You may only use warn from within the body of a `test` function.
-- When using `warn()` in an async test you should call the `warn` function in the sync portion of your test (and not after an `await` call or in the Promise body). Ideally, you want to call `warn()` at the top of your test function.
+- You may only use `warn()` and `useWarn()` from within the body of a `test` function.
+- `warn()` should be called in the synchronous portion of your test.
+- `useWarn()` is the async-safe alternative when warning severity needs to be set later.
 
 ```js
 // ✔
@@ -45,6 +48,16 @@ test('password', () => {
   return anAsyncFunction().then(() => {
     warn(); // 🚨
   });
+});
+
+// ✔ Use useWarn() when you need to set warn after await
+test('password', async () => {
+  const setWarn = useWarn();
+
+  await someAsyncFunction();
+  setWarn();
+
+  enforce(passwordStrength).isNotWeak();
 });
 ```
 


### PR DESCRIPTION
### Motivation

- Clarify the distinction between `warn()` (sync-only) and the new async-safe `useWarn()` so users know how to mark tests as warnings when the severity must be set after an `await`.

### Description

- Updated `website/docs/writing_tests/warn_only_tests.md` to mention `useWarn()`, replace the old limitations section with a `warn()` vs `useWarn()` explanation, and added an example showing `useWarn()` used after an async boundary.
- Updated `website/docs/api_reference.md` to add `useWarn()` to the top-level exports and to include a brief API entry for `useWarn()`, and clarified that `warn()` is intended for the synchronous part of a test.
- Ran Prettier formatting on the edited files to keep docs style consistent.

### Testing

- Ran `yarn prettier --check website/docs/writing_tests/warn_only_tests.md website/docs/api_reference.md` and it succeeded.
- Pre-commit tasks (via lint-staged / Prettier) executed as part of the commit flow and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eb16611948330a13698511ad8be65)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `useWarn()` function for async-safe warning handling in tests.

* **Documentation**
  * Updated warn-only test documentation with guidance on `warn()` vs `useWarn()` usage and async patterns.
  * Clarified synchronous scope requirements and async-safe alternatives for setting warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->