### PR TITLE
Optimize suite serialization by dropping messages on passing tests

### DIFF
--- a/packages/vest/src/exports/SuiteSerializer.ts
+++ b/packages/vest/src/exports/SuiteSerializer.ts
@@ -52,12 +52,22 @@ export class SuiteSerializer {
 
 function stripMessageFromPassingTests<T>(node: T): T {
   const visited = new WeakMap<object, any>();
+  const containsPassingMemo = new WeakMap<object, boolean>();
 
-  return strip(node, visited);
+  return strip(node, visited, containsPassingMemo);
 }
 
-function strip<T>(node: T, visited: WeakMap<object, any>): T {
+// eslint-disable-next-line complexity, max-statements
+function strip<T>(
+  node: T,
+  visited: WeakMap<object, any>,
+  containsPassingMemo: WeakMap<object, boolean>,
+): T {
   if (!node || typeof node !== 'object') {
+    return node;
+  }
+
+  if (!containsPassing(node, new WeakSet<object>(), containsPassingMemo)) {
     return node;
   }
 
@@ -70,7 +80,7 @@ function strip<T>(node: T, visited: WeakMap<object, any>): T {
     visited.set(node, arr);
 
     node.forEach(value => {
-      arr.push(strip(value, visited));
+      arr.push(strip(value, visited, containsPassingMemo));
     });
 
     return arr as T;
@@ -81,15 +91,58 @@ function strip<T>(node: T, visited: WeakMap<object, any>): T {
   const clonedNode: Record<string, any> = {};
   visited.set(node, clonedNode);
 
-  Object.keys(root).forEach(key => {
+  for (const [key, value] of Object.entries(root)) {
     if (shouldStripMessage && key === 'message') {
-      return;
+      continue;
     }
 
-    clonedNode[key] = strip(root[key], visited);
-  });
+    clonedNode[key] = strip(value, visited, containsPassingMemo);
+  }
 
   return clonedNode as T;
+}
+
+// eslint-disable-next-line complexity, max-statements
+function containsPassing(
+  node: unknown,
+  seen: WeakSet<object>,
+  memo: WeakMap<object, boolean>,
+): boolean {
+  if (!node || typeof node !== 'object') {
+    return false;
+  }
+
+  if (memo.has(node)) {
+    return memo.get(node) ?? false;
+  }
+
+  if (seen.has(node)) {
+    return false;
+  }
+
+  if ((node as Record<string, unknown>).testStatus === TestStatus.PASSING) {
+    memo.set(node, true);
+    return true;
+  }
+
+  seen.add(node);
+
+  const values = Array.isArray(node)
+    ? node
+    : Object.values(node as Record<string, unknown>);
+
+  for (const value of values) {
+    if (containsPassing(value, seen, memo)) {
+      memo.set(node, true);
+      seen.delete(node);
+      return true;
+    }
+  }
+
+  memo.set(node, false);
+  seen.delete(node);
+
+  return false;
 }
 
 function suiteSerializerReplacer(value: any, key: string) {

--- a/packages/vest/src/exports/SuiteSerializer.ts
+++ b/packages/vest/src/exports/SuiteSerializer.ts
@@ -16,7 +16,7 @@ type Dumpable = {
 
 export class SuiteSerializer {
   static serialize(suite: Dumpable) {
-    const dump = { ...suite.dump() };
+    const dump = stripMessageFromPassingTests(suite.dump());
 
     return IsolateSerializer.serialize(dump, suiteSerializerReplacer);
   }
@@ -48,6 +48,48 @@ export class SuiteSerializer {
 
     suite.resume(suiteRoot);
   }
+}
+
+function stripMessageFromPassingTests<T>(node: T): T {
+  const visited = new WeakMap<object, any>();
+
+  return strip(node, visited);
+}
+
+function strip<T>(node: T, visited: WeakMap<object, any>): T {
+  if (!node || typeof node !== 'object') {
+    return node;
+  }
+
+  if (visited.has(node as object)) {
+    return visited.get(node as object);
+  }
+
+  if (Array.isArray(node)) {
+    const arr: any[] = [];
+    visited.set(node, arr);
+
+    node.forEach(value => {
+      arr.push(strip(value, visited));
+    });
+
+    return arr as T;
+  }
+
+  const root = node as Record<string, any>;
+  const shouldStripMessage = root.testStatus === TestStatus.PASSING;
+  const clonedNode: Record<string, any> = {};
+  visited.set(node, clonedNode);
+
+  Object.keys(root).forEach(key => {
+    if (shouldStripMessage && key === 'message') {
+      return;
+    }
+
+    clonedNode[key] = strip(root[key], visited);
+  });
+
+  return clonedNode as T;
 }
 
 function suiteSerializerReplacer(value: any, key: string) {

--- a/packages/vest/src/exports/SuiteSerializer.ts
+++ b/packages/vest/src/exports/SuiteSerializer.ts
@@ -104,6 +104,12 @@ function strip<T>(
   return clonedNode as T;
 }
 
+// `strip` calls this with a shared `seen` set that is expected to be empty
+// at call boundaries. Inside this DFS, revisiting a node (`seen.has(node)`) means
+// we've encountered a cycle currently in-flight, so we conservatively return `true`
+// to avoid suppressing message-stripping while still preventing infinite recursion.
+// This is safe because every path that adds to `seen` removes it (`seen.delete`) on
+// return, and `memo` only stores final computed booleans for completed nodes.
 // eslint-disable-next-line complexity, max-statements
 function containsPassing(
   node: unknown,

--- a/packages/vest/src/exports/SuiteSerializer.ts
+++ b/packages/vest/src/exports/SuiteSerializer.ts
@@ -53,8 +53,9 @@ export class SuiteSerializer {
 function stripMessageFromPassingTests<T>(node: T): T {
   const visited = new WeakMap<object, any>();
   const containsPassingMemo = new WeakMap<object, boolean>();
+  const seen = new WeakSet<object>();
 
-  return strip(node, visited, containsPassingMemo);
+  return strip(node, visited, containsPassingMemo, seen);
 }
 
 // eslint-disable-next-line complexity, max-statements
@@ -62,12 +63,9 @@ function strip<T>(
   node: T,
   visited: WeakMap<object, any>,
   containsPassingMemo: WeakMap<object, boolean>,
+  seen: WeakSet<object>,
 ): T {
   if (!node || typeof node !== 'object') {
-    return node;
-  }
-
-  if (!containsPassing(node, new WeakSet<object>(), containsPassingMemo)) {
     return node;
   }
 
@@ -75,12 +73,16 @@ function strip<T>(
     return visited.get(node as object);
   }
 
+  if (!containsPassing(node, seen, containsPassingMemo)) {
+    return node;
+  }
+
   if (Array.isArray(node)) {
     const arr: any[] = [];
     visited.set(node, arr);
 
     node.forEach(value => {
-      arr.push(strip(value, visited, containsPassingMemo));
+      arr.push(strip(value, visited, containsPassingMemo, seen));
     });
 
     return arr as T;
@@ -96,7 +98,7 @@ function strip<T>(
       continue;
     }
 
-    clonedNode[key] = strip(value, visited, containsPassingMemo);
+    clonedNode[key] = strip(value, visited, containsPassingMemo, seen);
   }
 
   return clonedNode as T;

--- a/packages/vest/src/exports/SuiteSerializer.ts
+++ b/packages/vest/src/exports/SuiteSerializer.ts
@@ -117,7 +117,7 @@ function containsPassing(
   }
 
   if (seen.has(node)) {
-    return false;
+    return true;
   }
 
   if ((node as Record<string, unknown>).testStatus === TestStatus.PASSING) {

--- a/packages/vest/src/exports/__tests__/SuiteSerializer.test.ts
+++ b/packages/vest/src/exports/__tests__/SuiteSerializer.test.ts
@@ -26,6 +26,22 @@ describe('SuiteSerializer', () => {
     const serialized = SuiteSerializer.serialize(suite);
     expect(serialized).toMatchSnapshot();
   });
+
+  it('should strip message from passing tests only', () => {
+    const suite = vest.create(() => {
+      vest.test('passing_field', 'passing_field_message', () => true);
+      vest.test('failing_field', 'failing_field_message', () => false);
+    });
+
+    suite.run();
+
+    const serialized = SuiteSerializer.serialize(suite);
+    const parsed = SuiteSerializer.deserialize(serialized);
+    const [passingTest, failingTest] = parsed.children ?? [];
+
+    expect(passingTest?.data).not.toHaveProperty('message');
+    expect(failingTest?.data.message).toBe('failing_field_message');
+  });
 });
 
 describe('suite.resume', () => {

--- a/packages/vest/src/exports/__tests__/SuiteSerializer.test.ts
+++ b/packages/vest/src/exports/__tests__/SuiteSerializer.test.ts
@@ -37,8 +37,21 @@ describe('SuiteSerializer', () => {
 
     const serialized = SuiteSerializer.serialize(suite);
     const parsed = SuiteSerializer.deserialize(serialized);
-    const [passingTest, failingTest] = parsed.children ?? [];
 
+    expect(parsed.children).toBeDefined();
+
+    const testChildren = parsed.children?.filter(child => child.data.fieldName);
+    expect(testChildren).toHaveLength(2);
+
+    const passingTest = testChildren?.find(
+      child => child.data.fieldName === 'passing_field',
+    );
+    const failingTest = testChildren?.find(
+      child => child.data.fieldName === 'failing_field',
+    );
+
+    expect(passingTest).toBeDefined();
+    expect(failingTest).toBeDefined();
     expect(passingTest?.data).not.toHaveProperty('message');
     expect(failingTest?.data.message).toBe('failing_field_message');
   });


### PR DESCRIPTION
### Motivation
- Reduce serialized payload size by omitting `message` from test nodes that are `PASSING`, since those messages are not displayed.  
- Preserve messages for `FAILED` and `WARNING` tests so user-visible data is intact.  
- Avoid mutating the original dump and handle potential cycles in the isolate graph during transformation.

### Description
- Update `SuiteSerializer.serialize` to pre-process the suite dump with `stripMessageFromPassingTests` before calling `IsolateSerializer.serialize`.  
- Implement `stripMessageFromPassingTests` as a cycle-safe deep transform that uses a `WeakMap` to clone the dump and remove the `message` key when `testStatus === TestStatus.PASSING`.  
- Keep existing `suiteSerializerReplacer` logic and disallowed-key filtering intact.  
- Add a unit test in `packages/vest/src/exports/__tests__/SuiteSerializer.test.ts` that verifies messages are stripped for passing tests but preserved for failing tests.

### Testing
- Ran `yarn vitest run packages/vest/src/exports/__tests__/SuiteSerializer.test.ts`, and the focused test file passed: all 5 tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f51b4066c8330af10e53a7e066137)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Passing tests no longer include message fields in serialized output; failing tests retain messages during export/import, reducing serialized payloads.

* **Tests**
  * Added test coverage ensuring serialization/deserialization omits messages for passing tests while preserving messages for failing tests, verifying round-trip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->