### PR TITLE
Attach typed run metadata to SuiteResult and propagate through runner

### DIFF
--- a/packages/vest/src/core/Runtime.ts
+++ b/packages/vest/src/core/Runtime.ts
@@ -60,10 +60,11 @@ export function useSuiteResultCache<
   F extends TFieldName,
   G extends TGroupName,
   S extends TSchema = undefined,
->(action: CB<SuiteResult<F, G, S>>): SuiteResult<F, G, S> {
+  D = unknown,
+>(action: CB<SuiteResult<F, G, S, D>>): SuiteResult<F, G, S, D> {
   const suiteResultCache = useVestState().suiteResultCache;
 
-  return suiteResultCache([useSuiteId()], action) as SuiteResult<F, G, S>;
+  return suiteResultCache([useSuiteId()], action) as SuiteResult<F, G, S, D>;
 }
 
 export function useExpireSuiteResultCache() {

--- a/packages/vest/src/exports/__tests__/SuiteSerializer.test.ts
+++ b/packages/vest/src/exports/__tests__/SuiteSerializer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 
 import { SuiteSerializer } from '../SuiteSerializer';
 import * as vest from '../../vest';
@@ -115,5 +115,33 @@ describe('suite.resume', () => {
         expect(suite2.getErrors()).toMatchSnapshot();
       });
     });
+  });
+});
+
+describe('SuiteSerializer type-compatibility', () => {
+  it('accepts schema-typed suites in resume()', () => {
+    const schema = vest.enforce.shape({
+      username: vest.enforce.isString(),
+    });
+
+    const suite = vest.create(data => {
+      vest.test('username', () => {
+        vest.enforce(data.username).isNotBlank();
+      });
+    }, schema);
+
+    suite.run({ username: '' });
+
+    const serialized = SuiteSerializer.serialize(suite);
+
+    const suite2 = vest.create(data => {
+      vest.test('username', () => {
+        vest.enforce(data.username).isNotBlank();
+      });
+    }, schema);
+
+    expectTypeOf(SuiteSerializer.resume).toBeFunction();
+    SuiteSerializer.resume(suite2, serialized);
+    expect(suite2.hasErrors('username')).toBe(true);
   });
 });

--- a/packages/vest/src/exports/__tests__/classnames.test.ts
+++ b/packages/vest/src/exports/__tests__/classnames.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, expectTypeOf, vi } from 'vitest';
 
 import { dummyTest } from '../../testUtils/testDummy';
 import classnames from '../classnames';
@@ -57,6 +57,29 @@ describe('Utility: classnames', () => {
       invalid: 'invalid',
     });
 
+    expect(cn('travelerName')).toContain('invalid');
+  });
+
+  it('accepts schema-typed suite results from suite.run() and preserves parser output type', () => {
+    const typedSuite = vest.create(
+      data => {
+        vest.test('travelerName', 'Traveler name is required', () => {
+          vest.enforce(data.travelerName).isNotBlank();
+        });
+      },
+      vest.enforce.shape({
+        travelerName: vest.enforce.isString(),
+      }),
+    );
+
+    const result = typedSuite.run({ travelerName: '' });
+
+    const cn = classnames(result, {
+      warning: 'warning',
+      invalid: 'invalid',
+    });
+
+    expectTypeOf(cn).toEqualTypeOf<(fieldName: string) => string>();
     expect(cn('travelerName')).toContain('invalid');
   });
 

--- a/packages/vest/src/exports/__tests__/parser.test.ts
+++ b/packages/vest/src/exports/__tests__/parser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 
 import * as suiteDummy from '../../testUtils/suiteDummy';
 import { ser } from '../../testUtils/suiteDummy';
@@ -499,5 +499,27 @@ describe('parser.parse', () => {
         parse({});
       }).toThrow();
     });
+  });
+});
+
+describe('parser.parse type-compatibility', () => {
+  it('accepts schema-driven suite.run() results and returns typed selectors', () => {
+    const suite = vest.create(
+      data => {
+        vest.test('email', () => {
+          vest.enforce(data.email).isString();
+        });
+      },
+      vest.enforce.shape({
+        email: vest.enforce.isString(),
+      }),
+    );
+
+    const parsed = parse(suite.run({ email: 'a@b.com' }));
+
+    expectTypeOf(parsed.valid).toEqualTypeOf<
+      (fieldName?: string | undefined) => boolean
+    >();
+    expect(parsed.valid('email')).toBe(true);
   });
 });

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -15,9 +15,15 @@ import { SuiteSelectors } from '../suiteResult/selectors/suiteSelectors';
 
 import { TTypedMethods } from './getTypedMethods';
 
-type SuiteRunData<S extends TSchema, T extends CB> = S extends undefined
+type SuiteRunData<
+  S extends TSchema,
+  T extends CB,
+  IsFocused extends boolean = false,
+> = S extends undefined
   ? Parameters<T>[0]
-  : InferSchemaData<S>;
+  : IsFocused extends true
+    ? Partial<InferSchemaData<S>>
+    : InferSchemaData<S>;
 
 export type SuiteCallbackWithSchema<
   S extends TSchema,
@@ -89,7 +95,7 @@ type FocusedMethods<
     ...args: S extends undefined
       ? Parameters<T>
       : [data: Partial<InferSchemaData<S>>, ...args: any[]]
-  ) => SuiteResult<F, G, S, SuiteRunData<S, T>>;
+  ) => SuiteResult<F, G, S, SuiteRunData<S, T, true>>;
 };
 
 type AfterMethods<

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -15,7 +15,7 @@ import { SuiteSelectors } from '../suiteResult/selectors/suiteSelectors';
 
 import { TTypedMethods } from './getTypedMethods';
 
-type SuiteRunData<
+export type SuiteRunData<
   S extends TSchema,
   T extends CB,
   IsFocused extends boolean = false,

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -15,6 +15,10 @@ import { SuiteSelectors } from '../suiteResult/selectors/suiteSelectors';
 
 import { TTypedMethods } from './getTypedMethods';
 
+type SuiteRunData<S extends TSchema, T extends CB> = S extends undefined
+  ? Parameters<T>[0]
+  : InferSchemaData<S>;
+
 export type SuiteCallbackWithSchema<
   S extends TSchema,
   T extends CB,
@@ -47,17 +51,17 @@ type SuiteMethods<
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
-  ) => SuiteResult<F, G>;
+  ) => SuiteResult<F, G, S, SuiteRunData<S, T>>;
   runStatic: (
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
-  ) => SuiteResult<F, G>;
+  ) => SuiteResult<F, G, S, SuiteRunData<S, T>>;
   validate: (
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
-  ) => SuiteResult<F, G>;
+  ) => SuiteResult<F, G, S, SuiteRunData<S, T>>;
   subscribe: Subscribe;
 } & AfterMethods<F, G, T, S> &
   TTypedMethods<F, G> &
@@ -85,7 +89,7 @@ type FocusedMethods<
     ...args: S extends undefined
       ? Parameters<T>
       : [data: Partial<InferSchemaData<S>>, ...args: any[]]
-  ) => SuiteResult<F, G>;
+  ) => SuiteResult<F, G, S, SuiteRunData<S, T>>;
 };
 
 type AfterMethods<
@@ -108,7 +112,7 @@ type AfterMethods<
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
-  ) => SuiteResult<F, G>;
+  ) => SuiteResult<F, G, S, SuiteRunData<S, T>>;
 };
 
 /**

--- a/packages/vest/src/suite/__tests__/runSummary.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/runSummary.integration.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { create } from '../../vest';
+
+describe('suite result run summary metadata', () => {
+  it('stores the original run object and timestamp for non-schema suites', () => {
+    const payload = { name: 'alice', meta: { age: 33 } };
+    const suite = create((_data: any) => {});
+
+    const before = Date.now();
+    const result = suite.run(payload);
+    const after = Date.now();
+
+    expect(result.run.data).toBe(payload);
+    expect(result.run.time).toBeInstanceOf(Date);
+    expect(result.run.time.getTime()).toBeGreaterThanOrEqual(before);
+    expect(result.run.time.getTime()).toBeLessThanOrEqual(after);
+  });
+
+  it('stores parsed schema data in run metadata', () => {
+    const schema = {
+      parse: (value: any) => ({ amount: Number(value.amount) }),
+      run: (value: any) => ({ pass: true, type: value }),
+    } as any;
+
+    let callbackValue: unknown;
+    const suite = create((data: any) => {
+      callbackValue = data;
+    }, schema);
+
+    const result = suite.run({ amount: '12' } as any);
+
+    expect(result.run.data).toEqual({ amount: 12 });
+    expect(callbackValue).toEqual(result.run.data);
+  });
+
+  it('falls back to the original data in run metadata when parse fails', () => {
+    const schema = {
+      parse: () => {
+        throw new TypeError('parse failed');
+      },
+      run: (value: any) => ({
+        pass: true,
+        type: value,
+      }),
+    } as any;
+
+    const payload = { amount: '12' };
+    const suite = create(() => {}, schema);
+
+    const result = suite.run(payload);
+
+    expect(result.run.data).toBe(payload);
+  });
+
+  it('captures run.time per run', () => {
+    const suite = create((_data: any) => {});
+
+    const first = suite.run({ count: 1 });
+    const second = suite.run({ count: 2 });
+
+    expect(second.run.time.getTime()).toBeGreaterThanOrEqual(
+      first.run.time.getTime(),
+    );
+    expect(first.run.data).toEqual({ count: 1 });
+    expect(second.run.data).toEqual({ count: 2 });
+  });
+});

--- a/packages/vest/src/suite/__tests__/runSummary.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/runSummary.integration.test.ts
@@ -12,6 +12,9 @@ describe('suite result run summary metadata', () => {
     const after = Date.now();
 
     expect(result.run.data).toBe(payload);
+    expect(Object.prototype.propertyIsEnumerable.call(result, 'run')).toBe(
+      false,
+    );
     expect(result.run.time).toBeInstanceOf(Date);
     expect(result.run.time.getTime()).toBeGreaterThanOrEqual(before);
     expect(result.run.time.getTime()).toBeLessThanOrEqual(after);

--- a/packages/vest/src/suite/__tests__/runSummary.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/runSummary.integration.test.ts
@@ -15,6 +15,7 @@ describe('suite result run summary metadata', () => {
     expect(Object.prototype.propertyIsEnumerable.call(result, 'run')).toBe(
       false,
     );
+    expect(Object.isFrozen(result.run)).toBe(true);
     expect(result.run.time).toBeInstanceOf(Date);
     expect(result.run.time.getTime()).toBeGreaterThanOrEqual(before);
     expect(result.run.time.getTime()).toBeLessThanOrEqual(after);

--- a/packages/vest/src/suite/__tests__/schema.types.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.types.test.ts
@@ -33,10 +33,9 @@ describe('schema driven suite types', () => {
 
     suite.run({ name: 'john', age: 42 });
 
-    expectTypeOf(suite.run({ name: 'jane', age: 30 }).run.data).toEqualTypeOf<{
-      name: string;
-      age: number;
-    }>();
+    expectTypeOf(suite.run({ name: 'jane', age: 30 }).run.data).toEqualTypeOf<
+      { name: string; age: number } | undefined
+    >();
 
     void (0 as unknown as AssertTrue<
       IsEqual<
@@ -145,7 +144,9 @@ describe('schema driven suite types', () => {
 
     suite.run(10, true);
 
-    expectTypeOf(suite.run(10, true).run.data).toEqualTypeOf<number>();
+    expectTypeOf(suite.run(10, true).run.data).toEqualTypeOf<
+      number | undefined
+    >();
 
     void (0 as unknown as AssertTrue<
       IsEqual<ReturnType<typeof suite.get>['types'], undefined>
@@ -165,10 +166,9 @@ describe('schema driven suite types', () => {
 
     suite.run({ name: 'john', age: 42 });
 
-    expectTypeOf(suite.run({ name: 'john', age: 42 }).run.data).toEqualTypeOf<{
-      name: string;
-      age: number;
-    }>();
+    expectTypeOf(suite.run({ name: 'john', age: 42 }).run.data).toEqualTypeOf<
+      { name: string; age: number } | undefined
+    >();
 
     expectTypeOf(suite.get().types).toBeUndefined();
 

--- a/packages/vest/src/suite/__tests__/schema.types.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.types.test.ts
@@ -33,6 +33,11 @@ describe('schema driven suite types', () => {
 
     suite.run({ name: 'john', age: 42 });
 
+    expectTypeOf(suite.run({ name: 'jane', age: 30 }).run.data).toEqualTypeOf<{
+      name: string;
+      age: number;
+    }>();
+
     void (0 as unknown as AssertTrue<
       IsEqual<
         ReturnType<typeof suite.get>['types']['output'],
@@ -140,6 +145,8 @@ describe('schema driven suite types', () => {
 
     suite.run(10, true);
 
+    expectTypeOf(suite.run(10, true).run.data).toEqualTypeOf<number>();
+
     void (0 as unknown as AssertTrue<
       IsEqual<ReturnType<typeof suite.get>['types'], undefined>
     >);
@@ -157,6 +164,11 @@ describe('schema driven suite types', () => {
     }>();
 
     suite.run({ name: 'john', age: 42 });
+
+    expectTypeOf(suite.run({ name: 'john', age: 42 }).run.data).toEqualTypeOf<{
+      name: string;
+      age: number;
+    }>();
 
     expectTypeOf(suite.get().types).toBeUndefined();
 

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -24,7 +24,11 @@ import {
 } from '../suiteResult/SuiteResultTypes';
 import { useCreateSuiteResult } from '../suiteResult/suiteResult';
 
-import { SuiteModifiers, SuiteCallbackWithSchema } from './SuiteTypes';
+import {
+  SuiteModifiers,
+  SuiteCallbackWithSchema,
+  SuiteRunData,
+} from './SuiteTypes';
 
 type SchemaRunResult = {
   readonly message?: string;
@@ -56,15 +60,10 @@ export function useCreateSuiteRunner<
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
-  ): SuiteResult<
-    F,
-    G,
-    S,
-    S extends undefined ? Parameters<T>[0] : InferSchemaData<S>
-  > {
-    type RunData = S extends undefined ? Parameters<T>[0] : InferSchemaData<S>;
+  ): SuiteResult<F, G, S, SuiteRunData<S, T>> {
     const runTime = new Date();
-    const { resolve, promise } = withResolvers<SuiteResult<F, G, S, RunData>>();
+    const { resolve, promise } =
+      withResolvers<SuiteResult<F, G, S, SuiteRunData<S, T>>>();
 
     const schemaInput = args[0];
     const schemaRunResult = shouldRunSchema(schema, transformedModifiers)
@@ -73,7 +72,7 @@ export function useCreateSuiteRunner<
 
     const callbackInput = getCallbackInput(schemaRunResult, schemaInput);
     const callbackArgs = [callbackInput, ...args.slice(1)] as Parameters<T>;
-    const runData = callbackInput as RunData | undefined;
+    const runData = callbackInput as SuiteRunData<S, T> | undefined;
 
     const suiteResult = SuiteContext.run(
       {
@@ -85,7 +84,7 @@ export function useCreateSuiteRunner<
         useEmit('SUITE_RUN_STARTED');
 
         const useResolver = () => {
-          const result = useCreateSuiteResult<F, G, S, RunData>(
+          const result = useCreateSuiteResult<F, G, S, SuiteRunData<S, T>>(
             schema,
             callbackInput,
             runData,
@@ -100,7 +99,7 @@ export function useCreateSuiteRunner<
         };
 
         return IsolateSuite(
-          useRunSuiteCallback<F, T, S, G, RunData>({
+          useRunSuiteCallback<F, T, S, G, SuiteRunData<S, T>>({
             args: callbackArgs,
             modifiers: transformedModifiers,
             schema,
@@ -118,10 +117,10 @@ export function useCreateSuiteRunner<
     Object.defineProperty(result, 'run', {
       configurable: true,
       enumerable: false,
-      value: {
+      value: Object.freeze({
         data: runData,
         time: runTime,
-      },
+      }),
       writable: true,
     });
 

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -56,8 +56,22 @@ export function useCreateSuiteRunner<
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
-  ): SuiteResult<F, G, S> {
-    const { resolve, promise } = withResolvers<SuiteResult<F, G, S>>();
+  ): SuiteResult<
+    F,
+    G,
+    S,
+    S extends undefined ? Parameters<T>[0] : InferSchemaData<S>
+  > {
+    const runTime = new Date();
+    const { resolve, promise } =
+      withResolvers<
+        SuiteResult<
+          F,
+          G,
+          S,
+          S extends undefined ? Parameters<T>[0] : InferSchemaData<S>
+        >
+      >();
 
     const schemaInput = args[0];
     const schemaRunResult = shouldRunSchema(schema, transformedModifiers)
@@ -66,46 +80,60 @@ export function useCreateSuiteRunner<
 
     const callbackInput = getCallbackInput(schemaRunResult, schemaInput);
     const callbackArgs = [callbackInput, ...args.slice(1)] as Parameters<T>;
+    const runData = callbackInput as
+      | (S extends undefined ? Parameters<T>[0] : InferSchemaData<S>)
+      | undefined;
 
-    return assign(
-      promise,
-      SuiteContext.run(
-        {
-          suiteParams: callbackArgs,
-          schema,
-          modifiers: transformedModifiers,
-        },
-        () => {
-          useEmit('SUITE_RUN_STARTED');
+    const suiteResult = SuiteContext.run(
+      {
+        suiteParams: callbackArgs,
+        schema,
+        modifiers: transformedModifiers,
+      },
+      () => {
+        useEmit('SUITE_RUN_STARTED');
 
-          const useResolver = () => {
-            const result = useCreateSuiteResult<F, G, S>(
-              schema,
-              callbackInput,
-              schemaInput,
-            );
+        const useResolver = () => {
+          const result = useCreateSuiteResult<
+            F,
+            G,
+            S,
+            S extends undefined ? Parameters<T>[0] : InferSchemaData<S>
+          >(schema, callbackInput, runData, runTime);
 
-            if (!result.isPending()) {
-              resolve(result);
-            }
+          if (!result.isPending()) {
+            resolve(result);
+          }
 
-            return result;
-          };
+          return result;
+        };
 
-          return IsolateSuite(
-            useRunSuiteCallback<F, T, S>({
-              args: callbackArgs,
-              modifiers: transformedModifiers,
-              schema,
-              schemaRunResult,
-              suiteCallback,
-              useResolver,
-            }),
+        return IsolateSuite(
+          useRunSuiteCallback<F, T, S>({
+            args: callbackArgs,
+            modifiers: transformedModifiers,
+            schema,
+            schemaRunResult,
+            suiteCallback,
             useResolver,
-          ).output;
-        },
-      ),
+          }),
+          useResolver,
+        ).output;
+      },
     );
+
+    const result = assign(promise, suiteResult);
+
+    if (suiteResult && 'run' in suiteResult) {
+      Object.defineProperty(result, 'run', {
+        configurable: true,
+        enumerable: false,
+        value: suiteResult.run,
+        writable: true,
+      });
+    }
+
+    return result;
   };
 }
 

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -62,16 +62,9 @@ export function useCreateSuiteRunner<
     S,
     S extends undefined ? Parameters<T>[0] : InferSchemaData<S>
   > {
+    type RunData = S extends undefined ? Parameters<T>[0] : InferSchemaData<S>;
     const runTime = new Date();
-    const { resolve, promise } =
-      withResolvers<
-        SuiteResult<
-          F,
-          G,
-          S,
-          S extends undefined ? Parameters<T>[0] : InferSchemaData<S>
-        >
-      >();
+    const { resolve, promise } = withResolvers<SuiteResult<F, G, S, RunData>>();
 
     const schemaInput = args[0];
     const schemaRunResult = shouldRunSchema(schema, transformedModifiers)
@@ -80,9 +73,7 @@ export function useCreateSuiteRunner<
 
     const callbackInput = getCallbackInput(schemaRunResult, schemaInput);
     const callbackArgs = [callbackInput, ...args.slice(1)] as Parameters<T>;
-    const runData = callbackInput as
-      | (S extends undefined ? Parameters<T>[0] : InferSchemaData<S>)
-      | undefined;
+    const runData = callbackInput as RunData | undefined;
 
     const suiteResult = SuiteContext.run(
       {
@@ -94,12 +85,12 @@ export function useCreateSuiteRunner<
         useEmit('SUITE_RUN_STARTED');
 
         const useResolver = () => {
-          const result = useCreateSuiteResult<
-            F,
-            G,
-            S,
-            S extends undefined ? Parameters<T>[0] : InferSchemaData<S>
-          >(schema, callbackInput, runData, runTime);
+          const result = useCreateSuiteResult<F, G, S, RunData>(
+            schema,
+            callbackInput,
+            runData,
+            runTime,
+          );
 
           if (!result.isPending()) {
             resolve(result);
@@ -109,7 +100,7 @@ export function useCreateSuiteRunner<
         };
 
         return IsolateSuite(
-          useRunSuiteCallback<F, T, S>({
+          useRunSuiteCallback<F, T, S, G, RunData>({
             args: callbackArgs,
             modifiers: transformedModifiers,
             schema,
@@ -124,14 +115,15 @@ export function useCreateSuiteRunner<
 
     const result = assign(promise, suiteResult);
 
-    if (suiteResult && 'run' in suiteResult) {
-      Object.defineProperty(result, 'run', {
-        configurable: true,
-        enumerable: false,
-        value: suiteResult.run,
-        writable: true,
-      });
-    }
+    Object.defineProperty(result, 'run', {
+      configurable: true,
+      enumerable: false,
+      value: {
+        data: runData,
+        time: runTime,
+      },
+      writable: true,
+    });
 
     return result;
   };
@@ -159,13 +151,15 @@ function useRunSuiteCallback<
   F extends TFieldName,
   T extends CB = CB,
   S extends TSchema = undefined,
+  G extends TGroupName = TGroupName,
+  D = unknown,
 >(params: {
   args: any[];
   modifiers: ReturnType<typeof useTransformedModifiers<F>>;
   schema: S | undefined;
   schemaRunResult?: SchemaRunResult[];
   suiteCallback: SuiteCallbackWithSchema<S, T>;
-  useResolver: () => SuiteResult<F, any, S>;
+  useResolver: () => SuiteResult<F, G, S, D>;
 }) {
   const {
     args,

--- a/packages/vest/src/suiteResult/SuiteResultTypes.ts
+++ b/packages/vest/src/suiteResult/SuiteResultTypes.ts
@@ -17,12 +17,28 @@ export class SummaryBase {
 export class SuiteSummary<
   F extends TFieldName,
   G extends TGroupName,
+  D = unknown,
 > extends SummaryBase {
   public [Severity.ERRORS]: SummaryFailure<F, G>[] = [];
   public [Severity.WARNINGS]: SummaryFailure<F, G>[] = [];
   public groups: Groups<G, F> = {} as Groups<G, F>;
   public tests: Tests<F> = {} as Tests<F>;
+  public run!: { data: D; time: Date };
   public valid: Nullable<boolean> = null;
+
+  constructor() {
+    super();
+
+    Object.defineProperty(this, 'run', {
+      configurable: true,
+      enumerable: false,
+      value: {
+        data: undefined as D,
+        time: new Date(0),
+      },
+      writable: true,
+    });
+  }
 }
 
 export type TestsContainer<F extends TFieldName, _G extends TGroupName> =
@@ -75,20 +91,21 @@ type SuiteResultData<
   F extends TFieldName,
   G extends TGroupName,
   S extends TSchema = undefined,
+  D = unknown,
 > =
-  | (Omit<SuiteSummary<F, G>, 'valid'> &
+  | (Omit<SuiteSummary<F, G, D>, 'valid'> &
       SuiteSelectors<F, G> & {
         valid: true;
         value: InferSchemaOutput<S>;
         issues?: undefined;
       })
-  | (Omit<SuiteSummary<F, G>, 'valid'> &
+  | (Omit<SuiteSummary<F, G, D>, 'valid'> &
       SuiteSelectors<F, G> & {
         valid: false;
         issues: ReadonlyArray<StandardSchemaV1.Issue>;
         value?: undefined;
       })
-  | (Omit<SuiteSummary<F, G>, 'valid'> &
+  | (Omit<SuiteSummary<F, G, D>, 'valid'> &
       SuiteSelectors<F, G> & {
         valid: null;
         issues?: undefined;
@@ -102,7 +119,8 @@ export type SuiteResult<
   F extends string = TFieldName,
   G extends string = TGroupName,
   S extends TSchema = undefined,
-> = SuiteResultData<BrandedFieldName<F>, BrandedGroupName<G>, S> & {
+  D = unknown,
+> = SuiteResultData<BrandedFieldName<F>, BrandedGroupName<G>, S, D> & {
   dump: CB<TIsolateSuite>;
   types: S extends undefined
     ? undefined

--- a/packages/vest/src/suiteResult/SuiteResultTypes.ts
+++ b/packages/vest/src/suiteResult/SuiteResultTypes.ts
@@ -23,7 +23,7 @@ export class SuiteSummary<
   public [Severity.WARNINGS]: SummaryFailure<F, G>[] = [];
   public groups: Groups<G, F> = {} as Groups<G, F>;
   public tests: Tests<F> = {} as Tests<F>;
-  public run!: { data: D; time: Date };
+  public run!: { data: D | undefined; time: Date };
   public valid: Nullable<boolean> = null;
 
   constructor() {
@@ -33,7 +33,7 @@ export class SuiteSummary<
       configurable: true,
       enumerable: false,
       value: {
-        data: undefined as D,
+        data: undefined,
         time: new Date(0),
       },
       writable: true,

--- a/packages/vest/src/suiteResult/selectors/useProduceSuiteSummary.ts
+++ b/packages/vest/src/suiteResult/selectors/useProduceSuiteSummary.ts
@@ -26,10 +26,11 @@ import {
 export function useProduceSuiteSummary<
   F extends TFieldName,
   G extends TGroupName,
->(): SuiteSummary<F, G> {
+  D = unknown,
+>(): SuiteSummary<F, G, D> {
   const root = VestRuntime.useAvailableRoot<TIsolateSuite>();
 
-  const summary = new SuiteSummary<F, G>();
+  const summary = new SuiteSummary<F, G, D>();
 
   if (isVestIsolate(root)) {
     useProcessTests(root.data.tests, summary);

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -31,7 +31,7 @@ export function useCreateSuiteResult<
     // @vx-allow use-use
     const summary = useProduceSuiteSummary<F, G, D>();
     summary.run = {
-      data: inputData as D,
+      data: inputData,
       time: runTime,
     };
 

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -1,4 +1,4 @@
-import { assign, freezeAssign } from 'vest-utils';
+import { assign } from 'vest-utils';
 import { StandardSchemaV1 } from 'vest-utils/standardSchemaSpec';
 import { VestRuntime } from 'vestjs-runtime';
 
@@ -20,17 +20,41 @@ export function useCreateSuiteResult<
   F extends TFieldName,
   G extends TGroupName,
   S extends TSchema = undefined,
->(schema?: S, outputData?: any, inputData?: any): SuiteResult<F, G, S> {
-  return useSuiteResultCache<F, G, S>(() => {
+  D = unknown,
+>(
+  schema?: S,
+  outputData?: any,
+  inputData?: D,
+  runTime: Date = new Date(),
+): SuiteResult<F, G, S, D> {
+  return useSuiteResultCache<F, G, S, D>(() => {
     // @vx-allow use-use
-    const summary = useProduceSuiteSummary<F, G>();
-    const resultBody = constructSuiteResultObject<F, G, S>(summary, outputData);
-    return freezeAssign(resultBody as SuiteResult<F, G, S>, {
+    const summary = useProduceSuiteSummary<F, G, D>();
+    summary.run = {
+      data: inputData as D,
+      time: runTime,
+    };
+
+    const resultBody = constructSuiteResultObject<F, G, S, D>(
+      summary,
+      outputData,
+    );
+
+    const result = assign(resultBody as SuiteResult<F, G, S, D>, {
       dump: VestRuntime.persist(VestRuntime.useAvailableRoot<TIsolateSuite>),
       types: (schema
         ? { input: inputData, output: outputData }
-        : undefined) as SuiteResult<F, G, S>['types'],
-    }) as SuiteResult<F, G, S>;
+        : undefined) as SuiteResult<F, G, S, D>['types'],
+    }) as SuiteResult<F, G, S, D>;
+
+    Object.defineProperty(result, 'run', {
+      configurable: true,
+      enumerable: false,
+      value: summary.run,
+      writable: true,
+    });
+
+    return Object.freeze(result);
   });
 }
 
@@ -38,10 +62,11 @@ export function constructSuiteResultObject<
   F extends TFieldName,
   G extends TGroupName,
   S extends TSchema = undefined,
+  D = unknown,
 >(
-  summary: SuiteSummary<F, G>,
+  summary: SuiteSummary<F, G, D>,
   outputData?: any,
-): Omit<SuiteResult<F, G, S>, 'dump' | 'types'> {
+): Omit<SuiteResult<F, G, S, D>, 'dump' | 'types'> {
   const { valid, ...summaryWithoutValid } = summary;
   const selectors = suiteSelectors<F, G>(summary);
 

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -47,10 +47,12 @@ export function useCreateSuiteResult<
         : undefined) as SuiteResult<F, G, S, D>['types'],
     }) as SuiteResult<F, G, S, D>;
 
+    const runMeta = Object.freeze({ ...summary.run });
+
     Object.defineProperty(result, 'run', {
       configurable: true,
       enumerable: false,
-      value: summary.run,
+      value: runMeta,
       writable: true,
     });
 


### PR DESCRIPTION
### Motivation
- Record and expose per-run metadata (original/parsed data and timestamp) on suite results so callers and type-checking can access run context.
- Ensure schema-driven suites preserve strong types for the data passed into callbacks and returned in `SuiteResult.run.data`.
- Keep backwards compatibility for non-schema suites and preserve original input if schema parsing fails.

### Description
- Added a typed, non-enumerable `run` property containing `{ data, time }` to `SuiteSummary` and ensured it is present on the frozen `SuiteResult` object by setting it before freezing. (`SuiteResultTypes.ts`, `suiteResult.ts`, `useProduceSuiteSummary.ts`).
- Introduced an additional generic `D` to represent run/input data and threaded it through `SuiteResult`, `SuiteSummary`, `useCreateSuiteResult`, `useSuiteResultCache`, `useCreateSuiteRunner`, and related helpers to preserve precise types for schema and non-schema runs. (`SuiteResultTypes.ts`, `useCreateSuiteRunner.ts`, `Runtime.ts`, `SuiteTypes.ts`).
- Modified `useCreateSuiteRunner` to capture run timestamp and input (parsed or fallback), pass them to the result constructor, and retain the original `run` metadata on the returned promise-like result object. (`useCreateSuiteRunner.ts`).
- Updated result construction to set `summary.run` and to freeze the final result while keeping `run` non-enumerable. (`suiteResult.ts`, `constructSuiteResultObject`).
- Updated summary production to instantiate `SuiteSummary` with the `D` generic and ensure correct typing. (`useProduceSuiteSummary.ts`).
- Added and updated tests to cover type-compatibility and run metadata behavior and to leverage `expectTypeOf` for stronger compile-time assertions; added `runSummary.integration.test.ts` to verify run data/time and parse fallback behavior. (`suite/__tests__/runSummary.integration.test.ts`, multiple `exports` and `suite` tests). 

### Testing
- Ran the test suite with `vitest` including updated type assertions via `expectTypeOf` and the new integration tests, and all tests passed.
- Added unit/type tests that assert `SuiteResult.run.data` typing and timestamp behavior, and schema-preservation in `parser`, `classnames`, and `SuiteSerializer` tests, and those tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f6d887ad8833088055e603ccfa9ec)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Suite results now include a non-enumerable run property with execution metadata: data (run payload) and time (Date).
  * Expanded type signatures to thread run-data through suite runners and result APIs, improving schema-typed inference for run.data.

* **Tests**
  * Added type-compatibility and integration tests covering schema-typed run data, serialization/resume, parser/classnames typings, run metadata, timestamps, and parse-error fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->