### PR TITLE
Refactor include() to run as transient isolate

### DIFF
--- a/packages/vest/src/hooks/include.ts
+++ b/packages/vest/src/hooks/include.ts
@@ -1,4 +1,5 @@
 import { dynamicValue, invariant, isStringValue, makeBrand } from 'vest-utils';
+import { IsolateTransient, type TIsolate } from 'vestjs-runtime';
 
 import { useInclusion } from '../core/context/SuiteContext';
 import { TIsolateTest } from '../core/isolate/IsolateTest/IsolateTest';
@@ -34,10 +35,11 @@ export function include<F extends TFieldName, G extends TGroupName>(
   when: (condition: F | string | TFieldName | TDraftCondition<F, G>) => void;
 } {
   invariant(isStringValue(fieldName));
-  const inclusion = useInclusion();
   const safeFieldName = makeBrand<TFieldName>(fieldName);
 
-  inclusion[safeFieldName] = true;
+  IsolateTransient(useSetIncluded, 'Include', {
+    fieldName: safeFieldName,
+  });
 
   return { when };
 
@@ -49,19 +51,39 @@ export function include<F extends TFieldName, G extends TGroupName>(
   ): void {
     invariant(condition !== fieldName, ErrorStrings.INCLUDE_SELF);
 
-    const inclusion = useInclusion();
-
-    // This callback will run as part of the "isExcluded" series of checks
-    inclusion[safeFieldName] = function isIncluded(
-      currentNode: TIsolateTest,
-    ): boolean {
-      if (isStringValue(condition)) {
-        return useHasOnliedTests(currentNode, makeBrand<TFieldName>(condition));
-      }
-
-      return dynamicValue(condition, () =>
-        useCreateSuiteResult(undefined, undefined),
-      );
-    };
+    IsolateTransient(useSetIncluded, 'Include', {
+      fieldName: safeFieldName,
+      condition,
+    });
   }
+}
+
+type IncludePayload<F extends TFieldName, G extends TGroupName> = {
+  fieldName: TFieldName;
+  condition?: F | string | TFieldName | TDraftCondition<F, G>;
+};
+
+function useSetIncluded<F extends TFieldName, G extends TGroupName>(
+  isolate: TIsolate<IncludePayload<F, G>>,
+): void {
+  const inclusion = useInclusion();
+  const { fieldName, condition } = isolate.data;
+
+  if (condition === undefined) {
+    inclusion[fieldName] = true;
+    return;
+  }
+
+  // This callback will run as part of the "isExcluded" series of checks
+  inclusion[fieldName] = function isIncluded(
+    currentNode: TIsolateTest,
+  ): boolean {
+    if (isStringValue(condition)) {
+      return useHasOnliedTests(currentNode, makeBrand<TFieldName>(condition));
+    }
+
+    return dynamicValue(condition, () =>
+      useCreateSuiteResult(undefined, undefined),
+    );
+  };
 }


### PR DESCRIPTION
### Motivation
- Move `include()` registration out of the hook body and into the runtime isolate system so inclusion rules are applied in a transient runtime context rather than via immediate mutation of the inclusion map.
- Ensure `include().when(...)` behavior remains identical while integrating inclusion rules with the runtime lifecycle and avoiding history persistence.

### Description
- Rewrote `packages/vest/src/hooks/include.ts` to use `IsolateTransient` from `vestjs-runtime` to register inclusion payloads instead of mutating `useInclusion()` directly in the hook body.
- Introduced an `IncludePayload` type and a runtime handler `useSetIncluded` that reads the isolate payload (`isolate.data`) and applies unconditional (`condition === undefined`) or conditional inclusion rules.
- Preserved conditional behaviors for string-based dependencies (via `useHasOnliedTests`) and dynamic conditions (via `dynamicValue` + `useCreateSuiteResult`) and explicitly distinguish `undefined` (no condition) from boolean `false`.
- Renamed the internal handler to start with `use` (`useSetIncluded`) to comply with lint rules that enforce the `use*` naming for functions that call `use*` helpers.

### Testing
- Ran `yarn vitest packages/vest/src/hooks/__tests__/include.test.ts`, and all tests passed (20 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a11c3874e08330be2ae130979839ff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to field inclusion logic architecture and isolated handling for better modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->