### PR TITLE
docs: clarify initial build requirement in CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,16 @@ Vest is a monorepo managed by `yarn` and a custom tooling package called `vx`.
 
 1. **Fork and Clone** the repository.
 2. **Install dependencies** by running `yarn` in the root directory.
+3. **Build the workspace once** to ensure internal package dependencies are linked correctly.
 
 ```bash
 git clone [https://github.com/ealush/vest.git](https://github.com/ealush/vest.git)
 cd vest
 yarn
+yarn build
 ```
+
+> ℹ️ `yarn` installs dependencies, but a first `yarn build` is required before working with packages that depend on built workspace artifacts.
 
 ## Repository Structure
 


### PR DESCRIPTION
### Motivation
- Running only `yarn` on a fresh clone leaves workspace packages unlinked until a build is performed, which causes onboarding friction for contributors.

### Description
- Added a third step to the Getting Started section instructing users to run `yarn build` after `yarn` and included a short note explaining that the initial build links built workspace artifacts.

### Testing
- Pre-commit hooks (including `npx lint-staged` and formatting) ran and passed during the change; this is a documentation-only update so no further automated tests were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a99413f88330af233f61b602053b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Getting Started section with instructions to build the workspace after installing dependencies, ensuring proper internal package linking for developers contributing to the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->