### PR TITLE
Refine `createSuite` overloads and make `focus` group modifiers generic

### DIFF
--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -74,7 +74,7 @@ type FocusedMethods<
     FocusedMethods<F, G, T, S>,
     [fieldName: F | string, callback: CB]
   >;
-  focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F>]>;
+  focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F, G>]>;
   only: CB<
     FocusedMethods<F, G, T, S>,
     [onlyField: FieldExclusion<F> | FieldExclusion<string>]
@@ -99,7 +99,7 @@ type AfterMethods<
     AfterMethods<F, G, T, S>,
     [fieldName: F | string, callback: CB]
   >;
-  focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F>]>;
+  focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F, G>]>;
   only: CB<
     FocusedMethods<F, G, T, S>,
     [onlyField: FieldExclusion<F> | FieldExclusion<string>]
@@ -125,9 +125,12 @@ type AfterMethods<
  * - `onlyGroup` — Run only tests inside the named group(s). Top-level tests
  *   outside any group are also excluded.
  */
-export type SuiteModifiers<F extends TFieldName> = {
+export type SuiteModifiers<
+  F extends TFieldName,
+  G extends TGroupName = TGroupName,
+> = {
   only?: FieldExclusion<F> | FieldExclusion<string>;
-  onlyGroup?: string | string[];
+  onlyGroup?: G | G[];
   skip?: FieldExclusion<F> | FieldExclusion<string>;
-  skipGroup?: string | string[];
+  skipGroup?: G | G[];
 };

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -41,8 +41,8 @@ type SuiteMethods<
   get: CB<SuiteResult<F, G, S>>;
   resume: CB<void, [TIsolateSuite]>;
   reset: CB<void>;
-  remove: CB<void, [fieldName: F | string]>;
-  resetField: CB<void, [fieldName: F | string]>;
+  remove: CB<void, [fieldName: F]>;
+  resetField: CB<void, [fieldName: F]>;
   run: (
     ...args: S extends undefined
       ? Parameters<T>
@@ -70,15 +70,9 @@ type FocusedMethods<
   S extends TSchema,
 > = {
   afterEach: CB<FocusedMethods<F, G, T, S>, [callback: CB]>;
-  afterField: CB<
-    FocusedMethods<F, G, T, S>,
-    [fieldName: F | string, callback: CB]
-  >;
+  afterField: CB<FocusedMethods<F, G, T, S>, [fieldName: F, callback: CB]>;
   focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F, G>]>;
-  only: CB<
-    FocusedMethods<F, G, T, S>,
-    [onlyField: FieldExclusion<F> | FieldExclusion<string>]
-  >;
+  only: CB<FocusedMethods<F, G, T, S>, [onlyField: FieldExclusion<F>]>;
   // run is included but runStatic is intentionally omitted: runStatic is stateless
   // and does not carry focus modifiers, so it is not part of the focused API surface.
   run: (
@@ -95,15 +89,9 @@ type AfterMethods<
   S extends TSchema,
 > = {
   afterEach: CB<AfterMethods<F, G, T, S>, [callback: CB]>;
-  afterField: CB<
-    AfterMethods<F, G, T, S>,
-    [fieldName: F | string, callback: CB]
-  >;
+  afterField: CB<AfterMethods<F, G, T, S>, [fieldName: F, callback: CB]>;
   focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F, G>]>;
-  only: CB<
-    FocusedMethods<F, G, T, S>,
-    [onlyField: FieldExclusion<F> | FieldExclusion<string>]
-  >;
+  only: CB<FocusedMethods<F, G, T, S>, [onlyField: FieldExclusion<F>]>;
   run: (
     ...args: S extends undefined
       ? Parameters<T>
@@ -129,8 +117,8 @@ export type SuiteModifiers<
   F extends TFieldName,
   G extends TGroupName = TGroupName,
 > = {
-  only?: FieldExclusion<F> | FieldExclusion<string>;
+  only?: FieldExclusion<F>;
   onlyGroup?: G | G[];
-  skip?: FieldExclusion<F> | FieldExclusion<string>;
+  skip?: FieldExclusion<F>;
   skipGroup?: G | G[];
 };

--- a/packages/vest/src/suite/__tests__/createSuite.examples.test.ts
+++ b/packages/vest/src/suite/__tests__/createSuite.examples.test.ts
@@ -72,7 +72,7 @@ describe('createSuite examples - permutation 1: happy path schema inference', ()
       payment_token: 'token',
     });
 
-    // focus/only remain permissive for dynamic/nested field names
+    // @ts-expect-error - unknown field rejected by typed focus
     checkoutSuite.focus({ only: 'unknown_field' }).run({
       cart_items: ['sku_1'],
       billing_address: '',

--- a/packages/vest/src/suite/__tests__/createSuite.examples.test.ts
+++ b/packages/vest/src/suite/__tests__/createSuite.examples.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { create, enforce, test } from '../../vest';
+
+type AssertTrue<T extends true> = T;
+type IsEqual<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? (<T>() => T extends B ? 1 : 2) extends <T>() => T extends A ? 1 : 2
+      ? true
+      : false
+    : false;
+
+const userSchema = enforce.shape({
+  username: enforce.isString(),
+  password: enforce.isString(),
+  email: enforce.isString(),
+});
+
+const checkoutSchema = enforce.shape({
+  cart_items: enforce.isArrayOf(enforce.isString()),
+  billing_address: enforce.isString(),
+  payment_token: enforce.isString(),
+});
+
+const passwordResetSchema = enforce.shape({
+  password: enforce.isString(),
+  confirmPassword: enforce.isString(),
+});
+
+const strictSchema = enforce.shape({
+  id: enforce.isNumber(),
+  enabled: enforce.isBoolean(),
+});
+
+describe('createSuite examples - permutation 1: happy path schema inference', () => {
+  it('example 1: infers flat schema fields and supports safe destructuring inside callback', () => {
+    const suite = create(data => {
+      const { test, optional } = suite;
+
+      test('username', () => {
+        enforce(data.username).isNotBlank();
+      });
+      optional('email');
+
+      // @ts-expect-error - unknown schema key
+      test('typo_field', () => true);
+    }, userSchema);
+
+    expect(() =>
+      suite.run({
+        username: 'john',
+        password: '123456',
+        email: 'john@example.com',
+      }),
+    ).not.toThrow();
+  });
+
+  it('example 2: validates nested-ish checkout usage with inferred focus/remove keys', () => {
+    const checkoutSuite = create(data => {
+      test('cart_items', () => {
+        enforce(data.cart_items.length).greaterThan(0);
+      });
+      test('billing_address', () => {
+        enforce(data.billing_address).isNotBlank();
+      });
+    }, checkoutSchema);
+
+    checkoutSuite.remove('billing_address');
+    checkoutSuite.focus({ only: 'cart_items' }).run({
+      cart_items: ['sku_1'],
+      billing_address: '',
+      payment_token: 'token',
+    });
+
+    // focus/only remain permissive for dynamic/nested field names
+    checkoutSuite.focus({ only: 'unknown_field' }).run({
+      cart_items: ['sku_1'],
+      billing_address: '',
+      payment_token: 'token',
+    });
+  });
+
+  it('example 3: infers dependent-field context methods', () => {
+    const resetSuite = create(data => {
+      test('password', () => {
+        enforce(data.password).isNotBlank();
+      });
+
+      test('confirmPassword', () => {
+        enforce(data.confirmPassword).equals(data.password);
+      });
+    }, passwordResetSchema);
+
+    const assertIncludeField = <
+      K extends Parameters<typeof resetSuite.include>[0],
+    >(
+      field: K,
+    ) => field;
+
+    assertIncludeField('confirmPassword');
+
+    // @ts-expect-error - not in schema keys
+    assertIncludeField('confirm_password_typo');
+
+    resetSuite.afterField('password', () => {
+      expect(resetSuite.get().hasErrors('password')).toBeTypeOf('boolean');
+    });
+  });
+
+  it('example 4: supports schema-backed inferred data shape checks', () => {
+    const configSchema = enforce.shape({
+      status: enforce.isString(),
+      retries: enforce.isNumber(),
+    });
+
+    const suite = create(data => {
+      void (0 as unknown as AssertTrue<
+        IsEqual<typeof data, { status: string; retries: number }>
+      >);
+
+      test('status', () => {
+        enforce(data.status).isString();
+      });
+    }, configSchema);
+
+    expectTypeOf<Parameters<typeof suite.run>[0]>().toEqualTypeOf<{
+      status: string;
+      retries: number;
+    }>();
+  });
+});
+
+describe('createSuite examples - permutation 2: explicit config generics', () => {
+  it('example 5: restricts test/group names to explicit literal unions', () => {
+    const suite = create<{ fields: 'id' | 'role'; groups: 'auth' | 'admin' }>(
+      (_data: unknown) => {},
+    );
+
+    const assertField = <K extends Parameters<typeof suite.test>[0]>(
+      field: K,
+    ) => field;
+
+    assertField('id');
+    assertField('role');
+
+    // @ts-expect-error - invalid field literal
+    assertField('email');
+
+    suite.focus({ onlyGroup: 'admin' });
+
+    // @ts-expect-error - invalid group literal
+    suite.focus({ onlyGroup: 'payments' });
+  });
+
+  it('example 6: explicit config with domain model callback type', () => {
+    type UserModel = {
+      id: string;
+      role: 'viewer' | 'editor';
+      active: boolean;
+    };
+
+    const suite = create<
+      { fields: keyof UserModel; groups: 'API' },
+      UserModel,
+      (data: UserModel) => void
+    >(data => {
+      test('id', () => {
+        enforce(data.id).isNotBlank();
+      });
+
+      test('role', () => {
+        enforce(data.role).inside(['viewer', 'editor']);
+      });
+    });
+
+    suite.run({ id: 'u_1', role: 'viewer', active: true });
+
+    // @ts-expect-error - role union should be enforced
+    suite.run({ id: 'u_1', role: 'owner', active: true });
+  });
+
+  it('example 7: config generic overload intentionally rejects schema values', () => {
+    // @ts-expect-error - config-generic overload is schema-less by design
+    create<{ fields: 'id' | 'email' }>(() => {}, strictSchema);
+  });
+});
+
+describe('createSuite examples - permutation 3: escape hatch / untyped usage', () => {
+  it('example 8: no schema/no generic falls back to untyped callback and fields', () => {
+    const suite = create((data: any) => {
+      test('literally_anything', () => {
+        expect(data).toBeDefined();
+      });
+    });
+
+    suite.run({ random: 'value' });
+    suite.run(['x']);
+    suite.run(1);
+  });
+
+  it('example 9: using explicit any generic with schema keeps runtime schema checks while allowing loose field APIs', () => {
+    const suite = create<any>((data: any) => {
+      test('unmapped_field', () => {
+        expect(data).toBeDefined();
+      });
+    }, strictSchema);
+
+    const result = suite.run({ id: 1, enabled: false });
+    expect(result.valid).toBe(true);
+
+    // still schema-validated at runtime
+    const bad = suite.run({ id: 'oops', enabled: false } as any);
+    expect(bad.valid).toBe(false);
+  });
+
+  it('example 10: supports dynamic field generation from object keys', () => {
+    const suite = create<any>((data: Record<string, unknown>) => {
+      for (const fieldName of Object.keys(data)) {
+        test(fieldName, () => {
+          expect(data[fieldName]).toBeDefined();
+        });
+      }
+    });
+
+    suite.run({ dynamic_a: 1, dynamic_b: 2 });
+  });
+
+  it('example 11: untyped suites allow runtime-generated focus group names', () => {
+    const dynamicGroups = ['dynamic_group_1', 'dynamic_group_2'];
+
+    const suite = create<any>(() => {
+      test('field_x', () => true);
+    });
+
+    suite.focus({ skipGroup: dynamicGroups }).run({ field_x: 'ok' } as any);
+  });
+});

--- a/packages/vest/src/suite/__tests__/createSuite.examples.test.ts
+++ b/packages/vest/src/suite/__tests__/createSuite.examples.test.ts
@@ -228,9 +228,13 @@ describe('createSuite examples - permutation 3: escape hatch / untyped usage', (
       });
     });
 
-    suite.run({ random: 'value' });
-    suite.run(['x']);
-    suite.run(1);
+    const objectResult = suite.run({ random: 'value' });
+    const arrayResult = suite.run(['x']);
+    const numberResult = suite.run(1);
+
+    expect(objectResult.hasErrors()).toBe(false);
+    expect(arrayResult.hasErrors()).toBe(false);
+    expect(numberResult.hasErrors()).toBe(false);
   });
 
   it('example 9: using explicit any generic with schema keeps runtime schema checks while allowing loose field APIs', () => {

--- a/packages/vest/src/suite/__tests__/createSuite.examples.test.ts
+++ b/packages/vest/src/suite/__tests__/createSuite.examples.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { create, enforce, test } from '../../vest';
+import { create, enforce, group, only, skip, test } from '../../vest';
 
 type AssertTrue<T extends true> = T;
 type IsEqual<A, B> =
@@ -127,6 +127,41 @@ describe('createSuite examples - permutation 1: happy path schema inference', ()
       status: string;
       retries: number;
     }>();
+  });
+
+  it('example 12: API coverage checklist for field/group typing behavior', () => {
+    const suite = create(data => {
+      // context APIs
+      test('username', 'Username is required', () => {
+        enforce(data.username).isNotBlank();
+      });
+      only('username');
+      skip('email');
+      suite.include('password').when(() => true);
+      suite.optional('email');
+      group('auth', () => {
+        test('password', 'Password is required', () => {
+          enforce(data.password).isNotBlank();
+        });
+      });
+    }, userSchema);
+
+    // suite APIs
+    suite.remove('username');
+    suite.resetField('email');
+    suite.focus({ only: 'password', skipGroup: 'runtime_group' }).run({
+      username: 'john',
+      password: '123456',
+      email: 'john@example.com',
+    });
+    suite.only('username').run({
+      username: 'john',
+      password: '123456',
+      email: 'john@example.com',
+    });
+    suite.afterField('username', () => {
+      expect(suite.get().hasErrors('username')).toBeTypeOf('boolean');
+    });
   });
 });
 

--- a/packages/vest/src/suite/__tests__/createSuite.examples.test.ts
+++ b/packages/vest/src/suite/__tests__/createSuite.examples.test.ts
@@ -248,7 +248,7 @@ describe('createSuite examples - permutation 3: escape hatch / untyped usage', (
     expect(result.valid).toBe(true);
 
     // still schema-validated at runtime
-    const bad = suite.run({ id: 'oops', enabled: false } as any);
+    const bad = suite.run({ id: 'oops', enabled: false });
     expect(bad.valid).toBe(false);
   });
 
@@ -271,6 +271,6 @@ describe('createSuite examples - permutation 3: escape hatch / untyped usage', (
       test('field_x', () => true);
     });
 
-    suite.focus({ skipGroup: dynamicGroups }).run({ field_x: 'ok' } as any);
+    suite.focus({ skipGroup: dynamicGroups }).run({ field_x: 'ok' });
   });
 });

--- a/packages/vest/src/suite/__tests__/createSuite.typing-examples.test.ts
+++ b/packages/vest/src/suite/__tests__/createSuite.typing-examples.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Living documentation: 4 suite-typing patterns with all typed APIs exercised.
+ *
+ * Pattern 1 — Escape hatch:   create<null>(cb)        → all names are string
+ * Pattern 2 — Config generic:  create<SuiteConfig>(cb) → fields/groups literal unions
+ * Pattern 3 — Schema inferred: create(cb, schema)      → field names from schema keys
+ * Pattern 4 — Untyped fallback: create(cb)             → all names are string
+ */
+import { describe, it } from 'vitest';
+
+import {
+  create,
+  test,
+  enforce,
+  only,
+  skip,
+  include,
+  optional,
+} from '../../vest';
+
+describe('Suite typing examples', () => {
+  describe('Pattern 1: Escape hatch — create<null>()', () => {
+    it('accepts any field and group names', () => {
+      const suite = create<null>((_data: any) => {
+        // Top-level functions inside callback — always untyped
+        test('dynamic_field', () => {});
+        only('dynamic_field');
+        skip('dynamic_field');
+        include('dynamic_field').when('other_field');
+        optional('dynamic_field');
+      });
+
+      // Suite-level APIs all accept any string
+      suite.remove('dynamic_field');
+      suite.resetField('dynamic_field');
+      suite.focus({ only: 'dynamic_field', onlyGroup: 'any_group' });
+      suite.afterField('dynamic_field', () => {});
+
+      // Type-level assertions — all accept any string
+      const assertTestField = <K extends Parameters<typeof suite.test>[0]>(
+        field: K,
+      ) => field;
+      const assertSkipField = <K extends Parameters<typeof suite.skip>[0]>(
+        field: K,
+      ) => field;
+      const assertIncludeField = <
+        K extends Parameters<typeof suite.include>[0],
+      >(
+        field: K,
+      ) => field;
+      const assertOptionalField = <
+        K extends Parameters<typeof suite.optional>[0],
+      >(
+        field: K,
+      ) => field;
+
+      assertTestField('dynamic_field');
+      assertSkipField('dynamic_field');
+      assertIncludeField('dynamic_field');
+      assertOptionalField('dynamic_field');
+
+      // Result selectors accept any string
+      const result = suite.get();
+      result.hasErrors('dynamic_field');
+      result.getErrors('dynamic_field');
+    });
+
+    it('works with a schema while keeping field names open', () => {
+      const schema = enforce.shape({
+        name: enforce.isString(),
+      });
+
+      const suite = create<null>((_data: any) => {
+        test('anything', () => {});
+        only('anything');
+      }, schema);
+
+      const assertTestField = <K extends Parameters<typeof suite.test>[0]>(
+        field: K,
+      ) => field;
+
+      assertTestField('anything');
+      suite.get().hasErrors('anything');
+    });
+  });
+
+  describe('Pattern 2: Config generic — create<{ fields; groups }>()', () => {
+    it('restricts fields and groups to declared literals', () => {
+      const suite = create<{
+        fields: 'username' | 'email' | 'password';
+        groups: 'auth' | 'profile';
+      }>((_data: unknown) => {
+        // Top-level functions inside callback — always untyped
+        test('username', () => {});
+        test('email', () => {});
+        only('username');
+        skip('email');
+        include('username').when('email');
+        optional('password');
+      });
+
+      // Suite-level APIs — positive cases
+      suite.remove('username');
+      suite.resetField('email');
+      suite.focus({ only: 'username', onlyGroup: 'auth' });
+      suite.afterField('password', () => {});
+
+      // Type-level assertions for typed methods
+      const assertTestField = <K extends Parameters<typeof suite.test>[0]>(
+        field: K,
+      ) => field;
+      const assertSkipField = <K extends Parameters<typeof suite.skip>[0]>(
+        field: K,
+      ) => field;
+      const assertIncludeField = <
+        K extends Parameters<typeof suite.include>[0],
+      >(
+        field: K,
+      ) => field;
+      const assertOptionalField = <
+        K extends Parameters<typeof suite.optional>[0],
+      >(
+        field: K,
+      ) => field;
+      const assertGroupName = <
+        K extends Exclude<Parameters<typeof suite.group>[0], () => void>,
+      >(
+        group: K,
+      ) => group;
+
+      assertTestField('username');
+      assertSkipField('email');
+      assertIncludeField('password');
+      assertOptionalField('username');
+      assertGroupName('auth');
+
+      // Reject invalid fields
+      // @ts-expect-error - invalid field for suite.test
+      assertTestField('invalid');
+
+      // @ts-expect-error - invalid field for suite.skip
+      assertSkipField('invalid');
+
+      // @ts-expect-error - invalid field for suite.include
+      assertIncludeField('invalid');
+
+      // @ts-expect-error - invalid field for suite.optional
+      assertOptionalField('invalid');
+
+      // @ts-expect-error - invalid group for suite.group
+      assertGroupName('invalid');
+
+      // Result selectors
+      const result = suite.get();
+      result.hasErrors('username');
+      result.getErrors('email');
+
+      // @ts-expect-error - invalid field for result.hasErrors
+      result.hasErrors('invalid');
+
+      // @ts-expect-error - invalid group for focus
+      suite.focus({ onlyGroup: 'invalid' });
+    });
+  });
+
+  describe('Pattern 3: Schema inferred — create(cb, schema)', () => {
+    it('derives field names from schema keys', () => {
+      const schema = enforce.shape({
+        firstName: enforce.isString(),
+        lastName: enforce.isString(),
+        age: enforce.isNumber(),
+      });
+
+      const suite = create(data => {
+        // Top-level functions inside callback — always untyped
+        test('firstName', () => {
+          enforce(data.firstName).isNotBlank();
+        });
+        test('age', () => {
+          enforce(data.age).greaterThan(0);
+        });
+        only('firstName');
+        skip('lastName');
+        include('firstName').when('lastName');
+        optional('age');
+      }, schema);
+
+      // Suite-level APIs — positive cases
+      suite.remove('firstName');
+      suite.resetField('lastName');
+      suite.focus({ only: 'age' });
+      suite.afterField('age', () => {});
+
+      // Type-level assertions for typed methods
+      const assertTestField = <K extends Parameters<typeof suite.test>[0]>(
+        field: K,
+      ) => field;
+      const assertSkipField = <K extends Parameters<typeof suite.skip>[0]>(
+        field: K,
+      ) => field;
+      const assertIncludeField = <
+        K extends Parameters<typeof suite.include>[0],
+      >(
+        field: K,
+      ) => field;
+      const assertOptionalField = <
+        K extends Parameters<typeof suite.optional>[0],
+      >(
+        field: K,
+      ) => field;
+
+      assertTestField('firstName');
+      assertSkipField('lastName');
+      assertIncludeField('age');
+      assertOptionalField('firstName');
+
+      // Reject unknown fields
+      // @ts-expect-error - unknown field for suite.test
+      assertTestField('unknown');
+
+      // @ts-expect-error - unknown field for suite.skip
+      assertSkipField('unknown');
+
+      // @ts-expect-error - unknown field for suite.include
+      assertIncludeField('unknown');
+
+      // @ts-expect-error - unknown field for suite.optional
+      assertOptionalField('unknown');
+
+      // Result selectors
+      const result = suite.run({
+        firstName: 'John',
+        lastName: 'Doe',
+        age: 30,
+      });
+      result.hasErrors('firstName');
+      result.getErrors('age');
+
+      // @ts-expect-error - unknown field for result.hasErrors
+      result.hasErrors('unknown');
+    });
+  });
+
+  describe('Pattern 4: Untyped fallback — create(cb)', () => {
+    it('accepts any field and group names', () => {
+      const suite = create((_data: any) => {
+        // Top-level functions inside callback — always untyped
+        test('whatever', () => {});
+        only('whatever');
+        skip('whatever');
+        include('whatever').when('other');
+        optional('whatever');
+      });
+
+      // Suite-level APIs all accept any string
+      suite.remove('whatever');
+      suite.resetField('whatever');
+      suite.focus({ only: 'whatever', onlyGroup: 'any_group' });
+      suite.afterField('whatever', () => {});
+
+      // Type-level assertions — all accept any string
+      const assertTestField = <K extends Parameters<typeof suite.test>[0]>(
+        field: K,
+      ) => field;
+      const assertSkipField = <K extends Parameters<typeof suite.skip>[0]>(
+        field: K,
+      ) => field;
+      const assertIncludeField = <
+        K extends Parameters<typeof suite.include>[0],
+      >(
+        field: K,
+      ) => field;
+      const assertOptionalField = <
+        K extends Parameters<typeof suite.optional>[0],
+      >(
+        field: K,
+      ) => field;
+
+      assertTestField('whatever');
+      assertSkipField('whatever');
+      assertIncludeField('whatever');
+      assertOptionalField('whatever');
+
+      // Result selectors accept any string
+      const result = suite.get();
+      result.hasErrors('whatever');
+      result.getErrors('whatever');
+    });
+  });
+});

--- a/packages/vest/src/suite/__tests__/createSuite.typing-examples.test.ts
+++ b/packages/vest/src/suite/__tests__/createSuite.typing-examples.test.ts
@@ -103,9 +103,24 @@ describe('Suite typing examples', () => {
       suite.remove('username');
       suite.resetField('email');
       suite.focus({ only: 'username', onlyGroup: 'auth' });
+      suite.only('email');
       suite.afterField('password', () => {});
 
-      // Type-level assertions for typed methods
+      // Suite-bound APIs reject invalid fields
+      // @ts-expect-error - invalid field for suite.remove
+      suite.remove('invalid');
+
+      // @ts-expect-error - invalid field for suite.resetField
+      suite.resetField('invalid');
+
+      // @ts-expect-error - invalid field for suite.afterField
+      suite.afterField('invalid', () => {});
+
+      // @ts-expect-error - invalid field for suite.focus only
+      suite.focus({ only: 'invalid' });
+
+      // @ts-expect-error - invalid group for suite.focus onlyGroup
+      suite.focus({ onlyGroup: 'invalid' });
       const assertTestField = <K extends Parameters<typeof suite.test>[0]>(
         field: K,
       ) => field;
@@ -157,9 +172,6 @@ describe('Suite typing examples', () => {
 
       // @ts-expect-error - invalid field for result.hasErrors
       result.hasErrors('invalid');
-
-      // @ts-expect-error - invalid group for focus
-      suite.focus({ onlyGroup: 'invalid' });
     });
   });
 
@@ -189,7 +201,21 @@ describe('Suite typing examples', () => {
       suite.remove('firstName');
       suite.resetField('lastName');
       suite.focus({ only: 'age' });
+      suite.only('firstName');
       suite.afterField('age', () => {});
+
+      // Suite-bound APIs reject unknown fields
+      // @ts-expect-error - unknown field for suite.remove
+      suite.remove('unknown');
+
+      // @ts-expect-error - unknown field for suite.resetField
+      suite.resetField('unknown');
+
+      // @ts-expect-error - unknown field for suite.afterField
+      suite.afterField('unknown', () => {});
+
+      // @ts-expect-error - unknown field for suite.focus only
+      suite.focus({ only: 'unknown' });
 
       // Type-level assertions for typed methods
       const assertTestField = <K extends Parameters<typeof suite.test>[0]>(

--- a/packages/vest/src/suite/__tests__/createWithSchema.test.ts
+++ b/packages/vest/src/suite/__tests__/createWithSchema.test.ts
@@ -68,7 +68,8 @@ describe('create accepts schema argument', () => {
       }),
     );
 
-    const fieldsToValidate: [string, string][] = [
+    type ContactField = 'firstName' | 'lastName' | 'phoneNumber' | 'email';
+    const fieldsToValidate: [ContactField, string][] = [
       ['firstName', 'John'],
       ['lastName', 'Doe'],
       ['phoneNumber', '555-1234'],
@@ -124,14 +125,15 @@ describe('create accepts schema argument', () => {
     );
 
     // Some fields will fail validation
-    const fieldsToValidate: [string, string][] = [
+    type ContactField = 'firstName' | 'lastName' | 'phoneNumber' | 'email';
+    const fieldsToValidate: [ContactField, string][] = [
       ['firstName', 'Jo'], // Too short - will fail "longerThan(3)"
       ['lastName', ''], // Blank - will fail "isNotBlank"
       ['phoneNumber', '555-1234'], // Valid
       ['email', ''], // Blank - will fail "isNotBlank"
     ];
 
-    const results: { name: string; hasError: boolean }[] = [];
+    const results: { name: ContactField; hasError: boolean }[] = [];
 
     fieldsToValidate.forEach(([name, value]) => {
       const result = contactSuite.focus({ only: name }).run({

--- a/packages/vest/src/suite/__tests__/schema.example.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.example.test.ts
@@ -85,6 +85,15 @@ create(data => {
 }, schema);
 
 // ✅ Should allow generic typing when no schema
+
+const inferredFieldSuite = create(data => {
+  test('username', () => {
+    enforce(data.username).isNotEmpty();
+  });
+}, userSchema);
+
+inferredFieldSuite.remove('username');
+inferredFieldSuite.focus({ only: 'age' });
 const suite2 = create((data: { foo: string; bar: number }) => {
   test('foo', () => {
     enforce(data.foo).isNotEmpty();

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -150,8 +150,8 @@ describe('Schema Runtime Validation', () => {
       });
 
       // Schema reports nested paths with full field specificity
-      expect(result.hasErrors('user.name')).toBe(true);
-      const errors = result.getErrors('user.name');
+      expect(result.hasErrors('user.name' as any)).toBe(true);
+      const errors = result.getErrors('user.name' as any);
 
       // The error message should be one of the nested field's custom messages
       expect(errors).toContain('User name must be a string');

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -143,15 +143,15 @@ describe('Schema Runtime Validation', () => {
         }),
       });
 
-      const nestedSuite = create(() => {}, nestedSchema);
+      const nestedSuite = create<null>(() => {}, nestedSchema);
 
       const result = nestedSuite.runStatic({
         user: { name: 123, age: 'thirty' },
       });
 
       // Schema reports nested paths with full field specificity
-      expect(result.hasErrors('user.name' as any)).toBe(true);
-      const errors = result.getErrors('user.name' as any);
+      expect(result.hasErrors('user.name')).toBe(true);
+      const errors = result.getErrors('user.name');
 
       // The error message should be one of the nested field's custom messages
       expect(errors).toContain('User name must be a string');

--- a/packages/vest/src/suite/__tests__/schema.types.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.types.test.ts
@@ -257,6 +257,14 @@ describe('schema inferred suite typing coverage', () => {
     suite.run({ username: 'john' });
   });
 
+  it('rejects passing a schema to config-only generic overload', () => {
+    const schema = enforce.shape({
+      username: enforce.isString(),
+    });
+
+    // @ts-expect-error - config generic overload is schema-less by design
+    void create<{ fields: 'username'; groups: 'auth' }>(() => {}, schema);
+  });
   it('keeps group modifiers open when groups are not explicitly typed', () => {
     const schema = enforce.shape({
       username: enforce.isString(),

--- a/packages/vest/src/suite/__tests__/schema.types.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.types.test.ts
@@ -185,6 +185,95 @@ describe('schema driven suite types', () => {
   });
 });
 
+describe('schema inferred suite typing coverage', () => {
+  it('keeps callback and run payload strongly typed while allowing dynamic field APIs', () => {
+    const accountSchema = enforce.shape({
+      username: enforce.isString(),
+      age: enforce.isNumber(),
+      profile: enforce.shape({
+        bio: enforce.isString(),
+      }),
+    });
+
+    const suite = create(data => {
+      test('username', () => {
+        enforce(data.username).isNotBlank();
+      });
+      test('age', () => {
+        enforce(data.age).greaterThan(17);
+      });
+      test('profile', () => {
+        enforce(data.profile.bio).isString();
+      });
+    }, accountSchema);
+
+    suite.remove('username');
+    suite.resetField('age');
+    suite.afterField('profile', () => {
+      const result = suite.get();
+      result.hasErrors('profile');
+      result.getErrors('profile');
+    });
+
+    suite.focus({ only: 'username' }).run({
+      username: 'john',
+      age: 20,
+      profile: { bio: 'hello' },
+    });
+
+    suite.only(['username', 'age']).run({
+      username: 'john',
+      age: 20,
+      profile: { bio: 'hello' },
+    });
+
+    const result = suite.run({
+      username: 'john',
+      age: 20,
+      profile: { bio: 'hello' },
+    });
+
+    result.hasErrors('username');
+    result.hasErrors('age');
+    result.hasErrors('profile');
+
+    // Unknown field names are still allowed for dynamic/nested suites.
+    suite.remove('email');
+    suite.resetField('email');
+    suite.afterField('email', () => {});
+    suite.focus({ only: 'email' }).run({
+      username: 'john',
+      age: 20,
+      profile: { bio: 'hello' },
+    });
+    suite.only('email').run({
+      username: 'john',
+      age: 20,
+      profile: { bio: 'hello' },
+    });
+    result.hasErrors('email');
+
+    // @ts-expect-error - schema-inferred run requires full typed payload
+    suite.run({ username: 'john' });
+  });
+
+  it('keeps group modifiers open when groups are not explicitly typed', () => {
+    const schema = enforce.shape({
+      username: enforce.isString(),
+    });
+
+    const suite = create(data => {
+      test('username', () => {
+        enforce(data.username).isNotBlank();
+      });
+    }, schema);
+
+    suite.focus({ onlyGroup: 'auth', skipGroup: ['admin', 'internal'] }).run({
+      username: 'john',
+    });
+  });
+});
+
 describe('Schema Type Safety', () => {
   it('should allow valid data that matches schema', () => {
     const schema = enforce.shape({

--- a/packages/vest/src/suite/__tests__/schema.types.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.types.test.ts
@@ -291,6 +291,68 @@ describe('schema inferred suite typing coverage', () => {
   });
 });
 
+describe('escape hatch and config overload typing', () => {
+  it('supports create<null>() as an explicit untyped escape hatch', () => {
+    const schema = enforce.shape({
+      name: enforce.isString(),
+      count: enforce.isNumber(),
+    });
+
+    const suite = create<null>((data: any) => {
+      void data.anything;
+    });
+
+    const suiteWithSchema = create<null>((data: any) => {
+      void data.whatever;
+    }, schema);
+
+    const assertEscapeField = <K extends Parameters<typeof suite.test>[0]>(
+      field: K,
+    ) => field;
+
+    assertEscapeField('dynamic_field');
+    suite.focus({ onlyGroup: 'dynamic_group', skipGroup: ['another_group'] });
+
+    suiteWithSchema.run({ anything: 'goes' });
+    suiteWithSchema.get().hasErrors('any_field_name');
+
+    expectTypeOf<
+      Parameters<typeof suiteWithSchema.run>[0]
+    >().toEqualTypeOf<any>();
+  });
+
+  it('supports explicit SuiteConfig generic typing for fields/groups', () => {
+    const suite = create<{ fields: 'id' | 'role'; groups: 'auth' | 'admin' }>(
+      (_data: unknown) => {},
+    );
+
+    const assertField = <K extends Parameters<typeof suite.test>[0]>(
+      field: K,
+    ) => field;
+
+    assertField('id');
+    assertField('role');
+
+    // @ts-expect-error - invalid field should fail for config overload
+    assertField('email');
+
+    const assertGroup = <
+      K extends Exclude<Parameters<typeof suite.group>[0], () => void>,
+    >(
+      groupName: K,
+    ) => groupName;
+
+    assertGroup('auth');
+
+    // @ts-expect-error - invalid group should fail for config overload
+    assertGroup('payments');
+
+    suite.remove('id');
+    suite.focus({ only: 'role', onlyGroup: 'admin' });
+    suite.get().hasErrors('role');
+  });
+});
+
 describe('Schema Type Safety', () => {
   it('should allow valid data that matches schema', () => {
     const schema = enforce.shape({

--- a/packages/vest/src/suite/__tests__/schema.types.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.types.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it, expectTypeOf } from 'vitest';
 
-import { create, test, enforce } from '../../vest';
+import {
+  create,
+  test,
+  enforce,
+  only,
+  skip,
+  include,
+  optional,
+} from '../../vest';
 
 type AssertTrue<T extends true> = T;
 type IsEqual<A, B> =
@@ -517,5 +525,301 @@ describe('Schema Type Safety', () => {
     const suite = create(() => {}, schema);
     const result = suite.run({ name: 'Test' });
     expect(result.types).toBeDefined();
+  });
+});
+
+describe('callback-level only() typing', () => {
+  it('types suite.only() with config-based fields', () => {
+    const suite = create<{ fields: 'a' | 'b'; groups: 'g1' }>(
+      (_data: unknown) => {
+        // Top-level only() inside callback compiles (untyped)
+        only('a');
+        only(['a', 'b']);
+      },
+    );
+
+    const assertSkipField = <K extends Parameters<typeof suite.skip>[0]>(
+      field: K,
+    ) => field;
+
+    assertSkipField('a');
+
+    // @ts-expect-error - invalid field should fail on suite.skip
+    assertSkipField('invalid');
+  });
+
+  it('types suite.only() with schema-inferred fields', () => {
+    const schema = enforce.shape({
+      username: enforce.isString(),
+      age: enforce.isNumber(),
+    });
+
+    const suite = create(data => {
+      // Top-level only() inside callback compiles (untyped)
+      only('username');
+      only(['username', 'age']);
+
+      test('username', () => {
+        enforce(data.username).isNotBlank();
+      });
+    }, schema);
+
+    const assertSkipField = <K extends Parameters<typeof suite.skip>[0]>(
+      field: K,
+    ) => field;
+
+    assertSkipField('username');
+
+    // @ts-expect-error - invalid field should fail on suite.skip
+    assertSkipField('email');
+  });
+
+  it('allows any string for only() in untyped fallback', () => {
+    const suite = create((_data: any) => {
+      only('anything');
+      only(['x', 'y', 'z']);
+    });
+
+    const assertSkipField = <K extends Parameters<typeof suite.skip>[0]>(
+      field: K,
+    ) => field;
+
+    assertSkipField('anything');
+  });
+
+  it('allows any string for only() with escape hatch', () => {
+    const suite = create<null>((_data: any) => {
+      only('dynamic');
+      only(['a', 'b']);
+    });
+
+    const assertSkipField = <K extends Parameters<typeof suite.skip>[0]>(
+      field: K,
+    ) => field;
+
+    assertSkipField('dynamic');
+  });
+});
+
+describe('comprehensive typed API coverage', () => {
+  it('config-based: all APIs accept typed fields and reject invalid ones', () => {
+    const suite = create<{ fields: 'a' | 'b'; groups: 'g1' }>(
+      (_data: unknown) => {
+        // Top-level functions inside callback are untyped — always compile
+        test('a', () => {});
+        only('a');
+        skip('b');
+        include('a').when('b');
+        optional('a');
+      },
+    );
+
+    // Suite-level APIs — positive cases (no runtime context needed)
+    suite.remove('a');
+    suite.resetField('a');
+    suite.afterField('a', () => {});
+
+    // Type-level assertions for suite typed methods
+    const assertTestField = <K extends Parameters<typeof suite.test>[0]>(
+      field: K,
+    ) => field;
+    const assertSkipField = <K extends Parameters<typeof suite.skip>[0]>(
+      field: K,
+    ) => field;
+    const assertIncludeField = <K extends Parameters<typeof suite.include>[0]>(
+      field: K,
+    ) => field;
+    const assertOptionalField = <
+      K extends Parameters<typeof suite.optional>[0],
+    >(
+      field: K,
+    ) => field;
+    const assertGroupName = <
+      K extends Exclude<Parameters<typeof suite.group>[0], () => void>,
+    >(
+      group: K,
+    ) => group;
+
+    assertTestField('a');
+    assertSkipField('b');
+    assertIncludeField('a');
+    assertOptionalField('a');
+    assertGroupName('g1');
+
+    // @ts-expect-error - invalid field for suite.test
+    assertTestField('invalid');
+
+    // @ts-expect-error - invalid field for suite.skip
+    assertSkipField('invalid');
+
+    // @ts-expect-error - invalid field for suite.include
+    assertIncludeField('invalid');
+
+    // @ts-expect-error - invalid field for suite.optional
+    assertOptionalField('invalid');
+
+    // @ts-expect-error - invalid group for suite.group
+    assertGroupName('invalid');
+
+    // Result selectors reject invalid fields
+    const result = suite.get();
+    result.hasErrors('a');
+    result.getErrors('a');
+
+    // @ts-expect-error - invalid field for result.hasErrors
+    result.hasErrors('invalid');
+
+    // @ts-expect-error - invalid field for result.getErrors
+    result.getErrors('invalid');
+
+    // @ts-expect-error - invalid group for focus
+    suite.focus({ onlyGroup: 'invalid' });
+  });
+
+  it('schema-inferred: all APIs accept schema fields and reject invalid ones', () => {
+    const schema = enforce.shape({
+      email: enforce.isString(),
+      count: enforce.isNumber(),
+    });
+
+    const suite = create(data => {
+      // Top-level functions inside callback are untyped — always compile
+      test('email', () => {
+        enforce(data.email).isNotBlank();
+      });
+      only('email');
+      skip('count');
+      include('email').when('count');
+      optional('email');
+    }, schema);
+
+    // Suite-level APIs — positive cases (no runtime context needed)
+    suite.remove('email');
+    suite.resetField('count');
+    suite.afterField('email', () => {});
+
+    // Type-level assertions for suite typed methods
+    const assertTestField = <K extends Parameters<typeof suite.test>[0]>(
+      field: K,
+    ) => field;
+    const assertSkipField = <K extends Parameters<typeof suite.skip>[0]>(
+      field: K,
+    ) => field;
+    const assertIncludeField = <K extends Parameters<typeof suite.include>[0]>(
+      field: K,
+    ) => field;
+    const assertOptionalField = <
+      K extends Parameters<typeof suite.optional>[0],
+    >(
+      field: K,
+    ) => field;
+
+    assertTestField('email');
+    assertSkipField('count');
+    assertIncludeField('email');
+    assertOptionalField('count');
+
+    // @ts-expect-error - unknown field for suite.test
+    assertTestField('unknown');
+
+    // @ts-expect-error - unknown field for suite.skip
+    assertSkipField('unknown');
+
+    // @ts-expect-error - unknown field for suite.include
+    assertIncludeField('unknown');
+
+    // @ts-expect-error - unknown field for suite.optional
+    assertOptionalField('unknown');
+
+    // Result selectors reject unknown fields
+    const result = suite.get();
+    result.hasErrors('email');
+    result.getErrors('count');
+
+    // @ts-expect-error - unknown field for result.hasErrors
+    result.hasErrors('unknown');
+
+    // @ts-expect-error - unknown field for result.getErrors
+    result.getErrors('unknown');
+  });
+
+  it('escape hatch: all APIs accept any string', () => {
+    const suite = create<null>((_data: any) => {
+      test('anything', () => {});
+      only('anything');
+      skip('anything');
+      include('anything').when('other');
+      optional('anything');
+    });
+
+    suite.remove('anything');
+    suite.resetField('anything');
+    suite.focus({ only: 'anything' });
+    suite.afterField('anything', () => {});
+
+    // Type-level assertions — all accept any string
+    const assertTestField = <K extends Parameters<typeof suite.test>[0]>(
+      field: K,
+    ) => field;
+    const assertSkipField = <K extends Parameters<typeof suite.skip>[0]>(
+      field: K,
+    ) => field;
+    const assertIncludeField = <K extends Parameters<typeof suite.include>[0]>(
+      field: K,
+    ) => field;
+    const assertOptionalField = <
+      K extends Parameters<typeof suite.optional>[0],
+    >(
+      field: K,
+    ) => field;
+
+    assertTestField('anything');
+    assertSkipField('anything');
+    assertIncludeField('anything');
+    assertOptionalField('anything');
+
+    const result = suite.get();
+    result.hasErrors('anything');
+    result.getErrors('anything');
+  });
+
+  it('untyped fallback: all APIs accept any string', () => {
+    const suite = create((_data: any) => {
+      test('anything', () => {});
+      only('anything');
+      skip('anything');
+      include('anything').when('other');
+      optional('anything');
+    });
+
+    suite.remove('anything');
+    suite.resetField('anything');
+    suite.focus({ only: 'anything' });
+    suite.afterField('anything', () => {});
+
+    // Type-level assertions — all accept any string
+    const assertTestField = <K extends Parameters<typeof suite.test>[0]>(
+      field: K,
+    ) => field;
+    const assertSkipField = <K extends Parameters<typeof suite.skip>[0]>(
+      field: K,
+    ) => field;
+    const assertIncludeField = <K extends Parameters<typeof suite.include>[0]>(
+      field: K,
+    ) => field;
+    const assertOptionalField = <
+      K extends Parameters<typeof suite.optional>[0],
+    >(
+      field: K,
+    ) => field;
+
+    assertTestField('anything');
+    assertSkipField('anything');
+    assertIncludeField('anything');
+    assertOptionalField('anything');
+
+    const result = suite.get();
+    result.hasErrors('anything');
+    result.getErrors('anything');
   });
 });

--- a/packages/vest/src/suite/__tests__/schema.types.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.types.test.ts
@@ -619,6 +619,19 @@ describe('comprehensive typed API coverage', () => {
     suite.resetField('a');
     suite.afterField('a', () => {});
 
+    // Suite-bound APIs reject invalid fields
+    // @ts-expect-error - invalid field for suite.remove
+    suite.remove('invalid');
+
+    // @ts-expect-error - invalid field for suite.resetField
+    suite.resetField('invalid');
+
+    // @ts-expect-error - invalid field for suite.afterField
+    suite.afterField('invalid', () => {});
+
+    // @ts-expect-error - invalid field for suite.focus only
+    suite.focus({ only: 'invalid' });
+
     // Type-level assertions for suite typed methods
     const assertTestField = <K extends Parameters<typeof suite.test>[0]>(
       field: K,
@@ -697,6 +710,19 @@ describe('comprehensive typed API coverage', () => {
     suite.remove('email');
     suite.resetField('count');
     suite.afterField('email', () => {});
+
+    // Suite-bound APIs reject unknown fields
+    // @ts-expect-error - unknown field for suite.remove
+    suite.remove('unknown');
+
+    // @ts-expect-error - unknown field for suite.resetField
+    suite.resetField('unknown');
+
+    // @ts-expect-error - unknown field for suite.afterField
+    suite.afterField('unknown', () => {});
+
+    // @ts-expect-error - unknown field for suite.focus only
+    suite.focus({ only: 'unknown' });
 
     // Type-level assertions for suite typed methods
     const assertTestField = <K extends Parameters<typeof suite.test>[0]>(

--- a/packages/vest/src/suite/__tests__/schema.types.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.types.test.ts
@@ -186,7 +186,7 @@ describe('schema driven suite types', () => {
 });
 
 describe('schema inferred suite typing coverage', () => {
-  it('keeps callback and run payload strongly typed while allowing dynamic field APIs', () => {
+  it('infers schema keys for typed field APIs on the happy path', () => {
     const accountSchema = enforce.shape({
       username: enforce.isString(),
       age: enforce.isNumber(),
@@ -237,21 +237,30 @@ describe('schema inferred suite typing coverage', () => {
     result.hasErrors('age');
     result.hasErrors('profile');
 
-    // Unknown field names are still allowed for dynamic/nested suites.
-    suite.remove('email');
-    suite.resetField('email');
-    suite.afterField('email', () => {});
-    suite.focus({ only: 'email' }).run({
-      username: 'john',
-      age: 20,
-      profile: { bio: 'hello' },
-    });
-    suite.only('email').run({
-      username: 'john',
-      age: 20,
-      profile: { bio: 'hello' },
-    });
-    result.hasErrors('email');
+    const assertTestField = <K extends Parameters<typeof suite.test>[0]>(
+      field: K,
+    ) => field;
+    const assertOptionalField = <
+      K extends Parameters<typeof suite.optional>[0],
+    >(
+      field: K,
+    ) => field;
+    const assertIncludeField = <K extends Parameters<typeof suite.include>[0]>(
+      field: K,
+    ) => field;
+
+    assertTestField('username');
+    assertOptionalField('age');
+    assertIncludeField('profile');
+
+    // @ts-expect-error - schema-inferred fields should reject unknown keys
+    assertTestField('email');
+
+    // @ts-expect-error - schema-inferred fields should reject unknown keys
+    assertOptionalField('email');
+
+    // @ts-expect-error - schema-inferred fields should reject unknown keys
+    assertIncludeField('email');
 
     // @ts-expect-error - schema-inferred run requires full typed payload
     suite.run({ username: 'john' });

--- a/packages/vest/src/suite/__tests__/typedSuite.test.ts
+++ b/packages/vest/src/suite/__tests__/typedSuite.test.ts
@@ -37,6 +37,15 @@ describe('typed suite', () => {
     expect(result.groups.G100?.F1).toBeUndefined();
   });
 
+  it('should type focus group modifiers based on suite group generics', () => {
+    suite.focus({ onlyGroup: 'G1', skipGroup: ['G2'] }).run();
+
+    // @ts-expect-error - invalid group name
+    suite.focus({ onlyGroup: 'G100' }).run();
+
+    // @ts-expect-error - invalid group name in skip list
+    suite.focus({ skipGroup: ['G1', 'G100'] }).run();
+  });
   it('should only support annotated group and field names in the suite methods', () => {
     const res: vest.SuiteResult<TestFields, TestGroups> = suite.get();
 

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -24,6 +24,11 @@ export type SuiteConfig = {
 };
 
 // @vx-allow use-use
+function createSuite<_Escape>(
+  suiteCallback: [_Escape] extends [null] ? CB : never,
+  schema?: any,
+): [_Escape] extends [null] ? Suite<TFieldName, TGroupName, CB, any> : never;
+// @vx-allow use-use
 function createSuite<
   C extends SuiteConfig,
   Data = any,
@@ -58,11 +63,6 @@ function createSuite<
   T extends CB = CB,
   S extends TSchema = undefined,
 >(suiteCallback: SuiteCallbackWithSchema<S, T>, schema?: S): Suite<F, G, T, S>;
-// @vx-allow use-use
-function createSuite<_Escape extends null>(
-  suiteCallback: CB,
-  schema?: any,
-): Suite<TFieldName, TGroupName, CB, any>;
 // @vx-allow use-use
 function createSuite<
   F extends TFieldName = TFieldName,

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -5,6 +5,7 @@ import { useCreateVestState } from '../core/Runtime';
 import { useInitVestBus } from '../core/VestBus/VestBus';
 import { VestReconciler } from '../core/isolate/VestReconciler';
 import {
+  InferSchemaData,
   TFieldName,
   TGroupName,
   TSchema,
@@ -17,6 +18,19 @@ import {
 } from './useCreateSuiteMethods';
 import { validateSuiteCallback } from './validateSuiteCallback/validateSuiteCallback';
 
+type SuiteConfig = {
+  fields: string;
+  groups?: string;
+};
+
+// @vx-allow use-use
+function createSuite<
+  S extends TSchema,
+  T extends (data: InferSchemaData<S>, ...args: any[]) => void = (
+    data: InferSchemaData<S>,
+    ...args: any[]
+  ) => void,
+>(suiteCallback: T, schema: S): Suite<TFieldName, TGroupName, T, S>;
 // @vx-allow use-use
 function createSuite<
   F extends TFieldName = TFieldName,
@@ -26,6 +40,23 @@ function createSuite<
 >(suiteCallback: SuiteCallbackWithSchema<S, T>, schema?: S): Suite<F, G, T, S>;
 // @vx-allow use-use
 function createSuite<
+  C extends SuiteConfig,
+  Data = any,
+  T extends (data: Data, ...args: any[]) => void = (
+    data: Data,
+    ...args: any[]
+  ) => void,
+>(
+  suiteCallback: T,
+  schema?: any,
+): Suite<
+  C['fields'],
+  C['groups'] extends string ? C['groups'] : string,
+  T,
+  undefined
+>;
+// @vx-allow use-use
+function createSuite<
   F extends TFieldName = TFieldName,
   G extends TGroupName = TGroupName,
   T extends CB = CB,
@@ -33,13 +64,8 @@ function createSuite<
 >(suiteCallback: T, schema?: S): Suite<F, G, T, S> {
   const suiteCallbackResult = validateSuiteCallback(suiteCallback).unwrap();
 
-  // Create a stateRef for the suite
-  // It holds the suite's persisted values that may remain between runs.
   const stateRef = useCreateVestState({ VestReconciler });
 
-  // Assign methods to the suite
-  // We do this within the VestRuntime so that the suite methods
-  // will be bound to the suite's stateRef and be able to access it.
   return VestRuntime.Run(stateRef, () => {
     const VestBus = useInitVestBus();
 

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -18,7 +18,7 @@ import {
 } from './useCreateSuiteMethods';
 import { validateSuiteCallback } from './validateSuiteCallback/validateSuiteCallback';
 
-type SuiteConfig = {
+export type SuiteConfig = {
   fields: string;
   groups?: string;
 };
@@ -58,6 +58,11 @@ function createSuite<
   T extends CB = CB,
   S extends TSchema = undefined,
 >(suiteCallback: SuiteCallbackWithSchema<S, T>, schema?: S): Suite<F, G, T, S>;
+// @vx-allow use-use
+function createSuite<_Escape extends null>(
+  suiteCallback: CB,
+  schema?: any,
+): Suite<TFieldName, TGroupName, CB, any>;
 // @vx-allow use-use
 function createSuite<
   F extends TFieldName = TFieldName,

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -25,6 +25,23 @@ type SuiteConfig = {
 
 // @vx-allow use-use
 function createSuite<
+  C extends SuiteConfig,
+  Data = any,
+  T extends (data: Data, ...args: any[]) => void = (
+    data: Data,
+    ...args: any[]
+  ) => void,
+>(
+  suiteCallback: T,
+  schema?: undefined,
+): Suite<
+  C['fields'],
+  C['groups'] extends string ? C['groups'] : string,
+  T,
+  undefined
+>;
+// @vx-allow use-use
+function createSuite<
   S extends TSchema,
   T extends (data: InferSchemaData<S>, ...args: any[]) => void = (
     data: InferSchemaData<S>,
@@ -38,23 +55,6 @@ function createSuite<
   T extends CB = CB,
   S extends TSchema = undefined,
 >(suiteCallback: SuiteCallbackWithSchema<S, T>, schema?: S): Suite<F, G, T, S>;
-// @vx-allow use-use
-function createSuite<
-  C extends SuiteConfig,
-  Data = any,
-  T extends (data: Data, ...args: any[]) => void = (
-    data: Data,
-    ...args: any[]
-  ) => void,
->(
-  suiteCallback: T,
-  schema?: any,
-): Suite<
-  C['fields'],
-  C['groups'] extends string ? C['groups'] : string,
-  T,
-  undefined
->;
 // @vx-allow use-use
 function createSuite<
   F extends TFieldName = TFieldName,

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -47,7 +47,10 @@ function createSuite<
     data: InferSchemaData<S>,
     ...args: any[]
   ) => void,
->(suiteCallback: T, schema: S): Suite<TFieldName, TGroupName, T, S>;
+>(
+  suiteCallback: T,
+  schema: S,
+): Suite<Extract<keyof InferSchemaData<S>, string>, TGroupName, T, S>;
 // @vx-allow use-use
 function createSuite<
   F extends TFieldName = TFieldName,

--- a/packages/vest/src/suite/getTypedMethods.ts
+++ b/packages/vest/src/suite/getTypedMethods.ts
@@ -4,7 +4,7 @@ import { TIsolate, IsolateKey } from 'vestjs-runtime';
 import { TIsolateTest } from '../core/isolate/IsolateTest/IsolateTest';
 import { TestFn } from '../core/test/TestTypes';
 import { test } from '../core/test/test';
-import { FieldExclusion, skip } from '../hooks/focused/focused';
+import { FieldExclusion, only, skip } from '../hooks/focused/focused';
 import { include } from '../hooks/include';
 import { OptionalsInput } from '../hooks/optional/OptionalTypes';
 import { optional } from '../hooks/optional/optional';
@@ -25,7 +25,7 @@ export function getTypedMethods<
     group,
     include,
     omitWhen,
-
+    only,
     optional,
     skip,
     skipWhen,
@@ -39,6 +39,9 @@ export type TTypedMethods<F extends TFieldName, G extends TGroupName> = {
   };
 
   omitWhen: (conditional: TDraftCondition<F, G>, callback: CB) => void;
+  only: {
+    (item: FieldExclusion<F>): void;
+  };
   optional: (optionals: OptionalsInput<F>) => void;
   skip: {
     (item: FieldExclusion<F>): void;

--- a/packages/vest/src/suite/useCreateSuiteMethods.ts
+++ b/packages/vest/src/suite/useCreateSuiteMethods.ts
@@ -36,7 +36,7 @@ export function useCreateSuiteMethods<
   S extends TSchema = undefined,
 >(
   suiteCallback: SuiteCallbackWithSchema<S, T>,
-  modifiers: SuiteModifiers<F>,
+  modifiers: SuiteModifiers<F, G>,
   subscribe: Subscribe,
   schema?: S,
 ) {
@@ -64,7 +64,7 @@ function useCreateSuiteMethodsHelper<
   S extends TSchema = undefined,
 >(ctx: {
   suiteCallback: SuiteCallbackWithSchema<S, T>;
-  modifiers: SuiteModifiers<F>;
+  modifiers: SuiteModifiers<F, G>;
   subscribe: Subscribe;
   schema?: S;
   persistedRun: any;
@@ -87,7 +87,7 @@ function useGetSuiteMethods<
   S extends TSchema = undefined,
 >(ctx: {
   suiteCallback: SuiteCallbackWithSchema<S, T>;
-  modifiers: SuiteModifiers<F>;
+  modifiers: SuiteModifiers<F, G>;
   subscribe: Subscribe;
   schema?: S;
   persistedRun: any;
@@ -114,11 +114,12 @@ function useGetSuiteMethods<
 
 function useGetLifecycleMethods<
   F extends TFieldName,
+  G extends TGroupName,
   T extends CB = CB,
   S extends TSchema = undefined,
 >(ctx: {
   suiteCallback: SuiteCallbackWithSchema<S, T>;
-  modifiers: SuiteModifiers<F>;
+  modifiers: SuiteModifiers<F, G>;
   subscribe: Subscribe;
   schema?: S;
   persistedRun: any;
@@ -127,9 +128,15 @@ function useGetLifecycleMethods<
   const { persistedRun, staticRunner, subscribe } = ctx;
 
   return {
-    afterEach: VestRuntime.persist((cb: CB) => useAddAfterHelper(ctx, cb)),
+    afterEach: VestRuntime.persist((cb: CB) =>
+      useAddAfterHelper<F, G, T, S>(ctx, cb),
+    ),
     afterField: VestRuntime.persist((fieldName: F | string, cb: CB) =>
-      useAddAfterHelper(ctx, cb, makeBrand<TFieldName>(fieldName) as F),
+      useAddAfterHelper<F, G, T, S>(
+        ctx,
+        cb,
+        makeBrand<TFieldName>(fieldName) as F,
+      ),
     ),
     remove: VestRuntime.persist((fieldName: F | string) =>
       useEmit('REMOVE_FIELD', makeBrand<TFieldName>(fieldName)),
@@ -148,12 +155,13 @@ function useGetLifecycleMethods<
 
 function useAddAfterHelper<
   F extends TFieldName,
+  G extends TGroupName,
   T extends CB = CB,
   S extends TSchema = undefined,
 >(
   ctx: {
     suiteCallback: SuiteCallbackWithSchema<S, T>;
-    modifiers: SuiteModifiers<F>;
+    modifiers: SuiteModifiers<F, G>;
     subscribe: Subscribe;
     schema?: S;
     persistedRun: any;
@@ -205,11 +213,11 @@ function useCreateFocus<
   S extends TSchema = undefined,
 >(
   suiteCallback: SuiteCallbackWithSchema<S, T>,
-  modifiers: SuiteModifiers<F>,
+  modifiers: SuiteModifiers<F, G>,
   subscribe: Subscribe,
   schema?: S,
 ) {
-  return function focus(config: SuiteModifiers<F>) {
+  return function focus(config: SuiteModifiers<F, G>) {
     return useCreateSuiteMethods<F, G, T, S>(
       suiteCallback,
       { ...modifiers, ...config },
@@ -236,7 +244,7 @@ function useCreateOnly<
   S extends TSchema = undefined,
 >(
   suiteCallback: SuiteCallbackWithSchema<S, T>,
-  modifiers: SuiteModifiers<F>,
+  modifiers: SuiteModifiers<F, G>,
   subscribe: Subscribe,
   schema?: S,
 ) {
@@ -246,7 +254,7 @@ function useCreateOnly<
     subscribe,
     schema,
   );
-  return function only(onlyField: NonNullable<SuiteModifiers<F>['only']>) {
+  return function only(onlyField: NonNullable<SuiteModifiers<F, G>['only']>) {
     return focus({ only: onlyField });
   };
 }

--- a/packages/vest/src/vest.ts
+++ b/packages/vest/src/vest.ts
@@ -15,6 +15,7 @@ import { omitWhen } from './isolates/omitWhen';
 import { skipWhen } from './isolates/skipWhen';
 import type { Suite } from './suite/SuiteTypes';
 import { createSuite } from './suite/createSuite';
+import type { SuiteConfig } from './suite/createSuite';
 import type { SuiteResult, SuiteSummary } from './suiteResult/SuiteResultTypes';
 import { suiteSelectors } from './suiteResult/selectors/suiteSelectors';
 
@@ -38,4 +39,4 @@ export {
   registerReconciler,
 };
 
-export type { SuiteResult, SuiteSummary, Suite };
+export type { SuiteResult, SuiteSummary, Suite, SuiteConfig };

--- a/website/docs/typescript_support.md
+++ b/website/docs/typescript_support.md
@@ -5,6 +5,8 @@ description: Use Vest with the safety Typescript Provides you.
 keywords: [Vest, Typescript, Typescript support]
 ---
 
+import { SchemaTypedSandpack, ConfigTypedSandpack } from '@site/src/components/Sandpack/TypedSuites';
+
 # TypeScript Support
 
 Vest is written fully in TypeScript and provides first-class typing for suites, schemas, and custom rules. There are four ways to create a typed suite, each offering a different level of control.
@@ -50,6 +52,10 @@ result.hasErrors('username'); // ✅
 
 Works with `enforce.shape`, `enforce.loose`, and `enforce.partial`.
 
+### Try it
+
+<SchemaTypedSandpack />
+
 ## Config Generic
 
 Use `create<SuiteConfig>` when you want to declare field and group names explicitly without a schema. This gives you full type safety over all suite APIs.
@@ -86,6 +92,10 @@ The `SuiteConfig` type is exported from Vest for reuse:
 ```typescript
 import type { SuiteConfig } from 'vest';
 ```
+
+### Try it
+
+<ConfigTypedSandpack />
 
 ## Escape Hatch
 

--- a/website/docs/typescript_support.md
+++ b/website/docs/typescript_support.md
@@ -7,11 +7,11 @@ keywords: [Vest, Typescript, Typescript support]
 
 # TypeScript Support
 
-Vest is written fully in TypeScript and provides first-class typing for suites, schemas, and custom rules.
+Vest is written fully in TypeScript and provides first-class typing for suites, schemas, and custom rules. There are four ways to create a typed suite, each offering a different level of control.
 
 ## Schema-Aware Suite Creation
 
-Passing an `n4s` schema as the second argument to `create` automatically types your suite callback and `.run()` calls. The schema is enforced at runtime and the suite result records the validated `input` and `output` in `result.types`.
+Passing an `n4s` schema as the second argument to `create` automatically types your suite callback, `.run()` calls, and all suite-level APIs. The schema is enforced at runtime and the suite result records the validated `input` and `output` in `result.types`.
 
 ```typescript
 import { create, test, enforce } from 'vest';
@@ -32,49 +32,130 @@ const suite = create(data => {
 suite.run({ username: 'alice', age: 30, tags: [] }); // ✅
 // suite.run({ username: 'alice' }); // ❌ Property 'age' is missing
 // suite.run({ username: 42, age: 30, tags: [] }); // ❌ Type mismatch
+
+// Field names are inferred from schema keys
+suite.remove('username'); // ✅
+suite.resetField('age'); // ✅
+suite.focus({ only: 'username' }); // ✅
+suite.only('tags'); // ✅
+suite.afterField('username', () => {}); // ✅
+
+// suite.remove('email'); // ❌ compile-time error
+// suite.focus({ only: 'email' }); // ❌ compile-time error
+
+const result = suite.get();
+result.hasErrors('username'); // ✅
+// result.hasErrors('email'); // ❌ compile-time error
 ```
 
 Works with `enforce.shape`, `enforce.loose`, and `enforce.partial`.
 
-## Suite Generics
+## Config Generic
 
-`create` also accepts generic parameters when you want explicit control over field names, group names, or the callback signature.
+Use `create<SuiteConfig>` when you want to declare field and group names explicitly without a schema. This gives you full type safety over all suite APIs.
 
 ```typescript
-import { create } from 'vest';
+import { create, test, enforce } from 'vest';
 
-type FieldName = 'username' | 'password';
-type GroupName = 'SignIn' | 'ChangePassword';
-type Callback = (data: { username: string; password: string }) => void;
-
-const suite = create<FieldName, GroupName, Callback>(data => {
-  // data is typed
+const suite = create<{
+  fields: 'username' | 'email' | 'password';
+  groups: 'auth' | 'profile';
+}>(data => {
+  test('username', () => {}); // ✅
+  test('email', () => {}); // ✅
+  // test('phone', () => {}); // ❌ compile-time error
 });
 
-const result = suite.run();
-result.getErrors('username'); // typed
-// result.getErrors('full_name'); // 🚨 compile-time error
+// All suite-level APIs are typed
+suite.remove('username'); // ✅
+suite.resetField('email'); // ✅
+suite.focus({ only: 'password', onlyGroup: 'auth' }); // ✅
+suite.only('username'); // ✅
+suite.afterField('email', () => {}); // ✅
+
+// suite.remove('phone'); // ❌ compile-time error
+// suite.focus({ onlyGroup: 'billing' }); // ❌ compile-time error
+
+const result = suite.get();
+result.getErrors('username'); // ✅
+// result.getErrors('phone'); // ❌ compile-time error
 ```
 
-The typed selectors include `getError`, `getErrors`, `getWarnings`, `hasErrors`, `hasWarnings`, `isValid`, `isValidByGroup`, and `suite.afterEach`.
-
-## Typing Runtime Functions
-
-When you destructure helpers from the suite, they inherit the suite's types. This keeps runtime calls like `test`, `only`, and `group` aligned with your field and group unions.
+The `SuiteConfig` type is exported from Vest for reuse:
 
 ```typescript
-import { create } from 'vest';
+import type { SuiteConfig } from 'vest';
+```
 
-type Data = { username: string; password: string };
-type FieldName = keyof Data;
-type GroupName = 'SignIn' | 'ChangePassword';
+## Escape Hatch
 
-const suite = create<FieldName, GroupName, (data: Data) => void>(data => {
-  only('username');
-  test('username', 'Username required', () => {});
+Use `create<null>()` when you need to opt out of field typing entirely. All APIs accept any string, which is useful for dynamic field generation or migration scenarios.
+
+```typescript
+import { create, test } from 'vest';
+
+const suite = create<null>((data: any) => {
+  test('dynamic_field', () => {});
 });
 
-const { test, group, only } = suite; // typed helpers
+// All APIs accept any string
+suite.remove('anything');
+suite.focus({ only: 'anything', onlyGroup: 'any_group' });
+suite.only('anything');
+suite.get().hasErrors('anything');
+```
+
+The escape hatch also works with a schema for runtime validation while keeping field names open:
+
+```typescript
+const suite = create<null>((data: any) => {
+  test('anything', () => {});
+}, schema);
+```
+
+## Untyped Fallback
+
+When no generic is provided and no schema is passed, the suite accepts any string for field and group names. This is the default behavior and matches pre-typed Vest usage.
+
+```typescript
+import { create, test } from 'vest';
+
+const suite = create((data: any) => {
+  test('whatever', () => {});
+});
+
+suite.remove('whatever'); // any string accepted
+suite.focus({ only: 'whatever' }); // any string accepted
+```
+
+## Typed Suite-Level APIs
+
+When a suite is typed (via schema or config generic), the following APIs all enforce field and group names at compile time:
+
+| API                                                 | Accepts               |
+| --------------------------------------------------- | --------------------- |
+| `suite.test(fieldName, ...)`                        | Field names           |
+| `suite.only(field)`                                 | Field names           |
+| `suite.skip(field)`                                 | Field names           |
+| `suite.include(field)`                              | Field names           |
+| `suite.optional(field)`                             | Field names           |
+| `suite.group(groupName, cb)`                        | Group names           |
+| `suite.remove(field)`                               | Field names           |
+| `suite.resetField(field)`                           | Field names           |
+| `suite.afterField(field, cb)`                       | Field names           |
+| `suite.focus({ only, skip, onlyGroup, skipGroup })` | Field and group names |
+| `result.hasErrors(field)`                           | Field names           |
+| `result.getErrors(field)`                           | Field names           |
+| `result.hasWarnings(field)`                         | Field names           |
+| `result.getWarnings(field)`                         | Field names           |
+| `result.isValid(field)`                             | Field names           |
+| `result.isTested(field)`                            | Field names           |
+
+You can also destructure typed helpers from the suite:
+
+```typescript
+const { test, group, only, skip, include, optional } = suite;
+// These inherit the suite's field/group types
 ```
 
 ## Suite Result Types
@@ -84,7 +165,6 @@ Use exported types to annotate variables and APIs:
 - `Suite<FieldName, GroupName, Callback>` - a suite instance.
 - `SuiteResult<FieldName, GroupName>` - the result returned from `run`, `runStatic`, or `get`.
 - `SuiteSummary<FieldName, GroupName>` - the static snapshot of all test results.
-- `IsolateTest<FieldName, GroupName>` - represents a Vest test.
 
 `SuiteResult` also carries `types.input` and `types.output` when a schema is present.
 

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -64,13 +64,13 @@ const suite = create(data => {
   test('username', () => {
     enforce(data.username).isNotBlank();
   });
-
-  // `run` payload is typed from schema
-  suite.run({ username: 'john', age: 42 });
-
-  // TypeScript error: `age` must be a number
-  // suite.run({ username: 'john', age: '42' });
 }, userSchema);
+
+// `run` payload is typed from schema
+suite.run({ username: 'john', age: 42 });
+
+// TypeScript error: `age` must be a number
+// suite.run({ username: 'john', age: '42' });
 ```
 
 ### What becomes typed from the schema

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -49,6 +49,56 @@ When you pass a schema to `create`:
 2.  If the data structure doesn't match the schema (e.g., `age` is a string instead of a number), the suite run fails immediately for those fields.
 3.  Your tests run assuming the data types are correct.
 
+## TypeScript Inference for `create`
+
+When a schema is passed as the second argument to `create`, Vest infers the suite callback data type and `run(...)` payload type directly from that schema.
+
+```typescript
+const userSchema = enforce.shape({
+  username: enforce.isString(),
+  age: enforce.isNumber(),
+});
+
+const suite = create(data => {
+  // data is inferred as: { username: string; age: number }
+  test('username', () => {
+    enforce(data.username).isNotBlank();
+  });
+
+  // `run` payload is typed from schema
+  suite.run({ username: 'john', age: 42 });
+
+  // TypeScript error: `age` must be a number
+  // suite.run({ username: 'john', age: '42' });
+}, userSchema);
+```
+
+### What becomes typed from the schema
+
+With `create(callback, schema)`, TypeScript narrows:
+
+- callback data (`data`) to the schema input shape.
+- `suite.run(...)` / `suite.validate(...)` first argument to the schema input shape.
+- `result.types.input` and `result.types.output` to schema input/output types.
+
+Field-name APIs (`remove`, `resetField`, `only`, `focus.only`, selectors) intentionally stay open to `string` to support dynamic keys and nested field naming patterns.
+
+Group modifiers (`onlyGroup` / `skipGroup`) remain `string` unless you explicitly provide group generics to `create`.
+
+### Explicit generic override (advanced)
+
+If needed, you can still provide explicit suite generics to fully control field/group names:
+
+```typescript
+const suite = create<'username' | 'age', 'account'>(data => {
+  test('username', () => {
+    enforce(data.username).isNotBlank();
+  });
+});
+
+suite.focus({ onlyGroup: 'account' }); // typed group name
+```
+
 :::note Focused runs
 When you focus the suite with `suite.only()` or `suite.focus({ only })`, schema validation is skipped for fields outside the focus scope. This allows you to validate a single field even if the full payload does not satisfy the schema.
 

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -86,6 +86,24 @@ Some lifecycle/focus helpers (`remove`, `resetField`, `afterField`, `only`, `foc
 
 Group modifiers (`onlyGroup` / `skipGroup`) remain `string` unless you explicitly provide group generics to `create`.
 
+### API coverage (current typing standard)
+
+When using `create(callback, schema)`, the current TypeScript standard is:
+
+- Field-key inferred from schema for:
+  - `test(fieldName, message?, callback)`
+  - `include(fieldName).when(condition)`
+  - `optional(fieldName)`
+- Group generic-aware (when explicitly provided):
+  - `group(groupName, callback)`
+  - `suite.focus({ onlyGroup / skipGroup })`
+- Intentionally dynamic string-friendly:
+  - `suite.remove(fieldName)`
+  - `suite.resetField(fieldName)`
+  - `suite.only(fieldName)`
+  - `suite.afterField(fieldName, callback)`
+  - `only(fieldName)` / `skip(fieldName)` hooks
+
 ### Explicit generic override (advanced)
 
 If needed, you can still provide explicit suite generics to fully control field/group names:

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -110,6 +110,7 @@ If needed, you can still provide explicit suite generics to fully control field/
 
 ```typescript
 const suite = create<'username' | 'age', 'account'>(data => {
+  // Without a schema, `data` is intentionally untyped (effectively `any`).
   test('username', () => {
     enforce(data.username).isNotBlank();
   });

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -79,9 +79,10 @@ With `create(callback, schema)`, TypeScript narrows:
 
 - callback data (`data`) to the schema input shape.
 - `suite.run(...)` / `suite.validate(...)` first argument to the schema input shape.
+- field-oriented happy-path APIs (`test`, `optional`, `include`) to schema keys.
 - `result.types.input` and `result.types.output` to schema input/output types.
 
-Field-name APIs (`remove`, `resetField`, `only`, `focus.only`, selectors) intentionally stay open to `string` to support dynamic keys and nested field naming patterns.
+Some lifecycle/focus helpers (`remove`, `resetField`, `afterField`, `only`, `focus.only`) intentionally still accept dynamic strings for nested/dynamic runtime workflows.
 
 Group modifiers (`onlyGroup` / `skipGroup`) remain `string` unless you explicitly provide group generics to `create`.
 

--- a/website/src/components/RawExample.js
+++ b/website/src/components/RawExample.js
@@ -197,7 +197,7 @@ export default function RawExample() {
           }}
           customSetup={{
             dependencies: {
-              vest: 'next',
+              vest: 'latest',
             },
           }}
           options={{

--- a/website/src/components/Sandpack/AccessingResult.js
+++ b/website/src/components/Sandpack/AccessingResult.js
@@ -148,7 +148,7 @@ export default function AccessingResultSandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/AnyTestRecipe.js
+++ b/website/src/components/Sandpack/AnyTestRecipe.js
@@ -84,7 +84,7 @@ export default function AnyTestRecipeSandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/AsyncTests.js
+++ b/website/src/components/Sandpack/AsyncTests.js
@@ -144,7 +144,7 @@ export default function AsyncTestsSandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/ComposingRules.js
+++ b/website/src/components/Sandpack/ComposingRules.js
@@ -107,7 +107,7 @@ export default function ComposingRulesSandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/CustomRules.js
+++ b/website/src/components/Sandpack/CustomRules.js
@@ -110,7 +110,7 @@ export default function CustomRulesSandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/EnforcePlayground.js
+++ b/website/src/components/Sandpack/EnforcePlayground.js
@@ -106,7 +106,7 @@ export default function EnforcePlayground() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/ExecutionModes.js
+++ b/website/src/components/Sandpack/ExecutionModes.js
@@ -156,7 +156,7 @@ export default function ExecutionModesSandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/FocusedUpdates.js
+++ b/website/src/components/Sandpack/FocusedUpdates.js
@@ -166,7 +166,7 @@ export default function FocusedUpdatesSandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/GetStarted.js
+++ b/website/src/components/Sandpack/GetStarted.js
@@ -141,7 +141,7 @@ export default function GetStartedSandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/OptionalFields.js
+++ b/website/src/components/Sandpack/OptionalFields.js
@@ -73,7 +73,7 @@ export default function OptionalFieldsSandpack() {
           '/App.js': AppCode,
           '/styles.css': StylesCode,
         }}
-        customSetup={{ dependencies: { vest: 'next' } }}
+        customSetup={{ dependencies: { vest: 'latest' } }}
         options={{
           activeFile: '/suite.js',
           showCommonFiles: false,

--- a/website/src/components/Sandpack/ReactIntegration.js
+++ b/website/src/components/Sandpack/ReactIntegration.js
@@ -191,7 +191,7 @@ export default function ReactIntegrationSandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/SkipAndOnly.js
+++ b/website/src/components/Sandpack/SkipAndOnly.js
@@ -92,7 +92,7 @@ export default function SkipAndOnlySandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/SuiteMethods.js
+++ b/website/src/components/Sandpack/SuiteMethods.js
@@ -160,7 +160,7 @@ export default function SuiteMethodsSandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/TypedSuites.js
+++ b/website/src/components/Sandpack/TypedSuites.js
@@ -1,8 +1,192 @@
-import React from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import commonStyles from '../RawExample.module.css';
 
-const SchemaSuiteCode = `import { create, test, enforce } from 'vest';
+const vestDts = `
+declare module 'vest' {
+  type TestFn = () => void | boolean | Promise<void>;
+  type FieldExclusion<F extends string> = F | F[] | undefined;
+  type OptionalsInput<F extends string> = F | F[] | Partial<Record<F, any>>;
+
+  type SuiteConfig = { fields: string; groups?: string };
+
+  interface SuiteModifiers<F extends string, G extends string = string> {
+    only?: FieldExclusion<F>;
+    onlyGroup?: G | G[];
+    skip?: FieldExclusion<F>;
+    skipGroup?: G | G[];
+  }
+
+  interface SuiteSelectors<F extends string, G extends string = string> {
+    hasErrors(fieldName?: F): boolean;
+    hasWarnings(fieldName?: F): boolean;
+    getErrors(): Record<string, string[]>;
+    getErrors(fieldName: F): string[];
+    getWarnings(): Record<string, string[]>;
+    getWarnings(fieldName: F): string[];
+    getError(): { fieldName: F; message?: string } | undefined;
+    getError(fieldName: F): string | undefined;
+    getWarning(): { fieldName: F; message?: string } | undefined;
+    getWarning(fieldName: F): string | undefined;
+    getMessage(fieldName: F): string | undefined;
+    isValid(fieldName?: F): boolean;
+    isTested(fieldName: F): boolean;
+    isPending(fieldName?: F): boolean;
+    hasErrorsByGroup(groupName: G, fieldName?: F): boolean;
+    hasWarningsByGroup(groupName: G, fieldName?: F): boolean;
+    getErrorsByGroup(groupName: G): Record<string, string[]>;
+    getErrorsByGroup(groupName: G, fieldName: F): string[];
+    getWarningsByGroup(groupName: G): Record<string, string[]>;
+    getWarningsByGroup(groupName: G, fieldName: F): string[];
+    isValidByGroup(groupName: G, fieldName?: F): boolean;
+  }
+
+  interface SuiteResult<F extends string = string, G extends string = string>
+    extends SuiteSelectors<F, G> {
+    errorCount: number;
+    warnCount: number;
+    testCount: number;
+    pendingCount: number;
+    valid: boolean | null;
+    tests: Record<string, { errorCount: number; warnCount: number; errors: string[]; warnings: string[]; valid: boolean | null }>;
+  }
+
+  interface FocusedSuite<F extends string, G extends string, T, S> {
+    afterEach(callback: () => void): FocusedSuite<F, G, T, S>;
+    afterField(fieldName: F, callback: () => void): FocusedSuite<F, G, T, S>;
+    focus(config: SuiteModifiers<F, G>): FocusedSuite<F, G, T, S>;
+    only(onlyField: FieldExclusion<F>): FocusedSuite<F, G, T, S>;
+    run(...args: any[]): SuiteResult<F, G>;
+  }
+
+  interface Suite<F extends string, G extends string, T = any, S = undefined> {
+    get(): SuiteResult<F, G>;
+    reset(): void;
+    remove(fieldName: F): void;
+    resetField(fieldName: F): void;
+    run(...args: any[]): SuiteResult<F, G>;
+    runStatic(...args: any[]): SuiteResult<F, G>;
+    subscribe(callback: () => void): () => void;
+
+    // After/focus methods
+    afterEach(callback: () => void): Suite<F, G, T, S>;
+    afterField(fieldName: F, callback: () => void): Suite<F, G, T, S>;
+    focus(config: SuiteModifiers<F, G>): FocusedSuite<F, G, T, S>;
+    only(onlyField: FieldExclusion<F>): FocusedSuite<F, G, T, S>;
+
+    // Typed callback methods (destructurable)
+    test: {
+      (fieldName: F, message: string, cb: TestFn): any;
+      (fieldName: F, cb: TestFn): any;
+    };
+    group: {
+      (callback: () => void): any;
+      (groupName: G, callback: () => void): any;
+    };
+    skip(item: FieldExclusion<F>): void;
+    include(fieldName: F): { when(condition: any): void };
+    optional(optionals: OptionalsInput<F>): void;
+    omitWhen(conditional: any, callback: () => void): void;
+    skipWhen(condition: any, callback: () => void): void;
+
+    // Selectors (also on suite directly)
+    hasErrors(fieldName?: F): boolean;
+    hasWarnings(fieldName?: F): boolean;
+    getErrors(): Record<string, string[]>;
+    getErrors(fieldName: F): string[];
+    getWarnings(): Record<string, string[]>;
+    getWarnings(fieldName: F): string[];
+    isValid(fieldName?: F): boolean;
+    isTested(fieldName: F): boolean;
+  }
+
+  // --- enforce ---
+
+  interface RuleInstance<T = any> {
+    test(value: any): boolean;
+    run(value: any): { pass: boolean; type: T };
+    message(msg: string): RuleInstance<T>;
+  }
+
+  interface ShapeSchema<T extends Record<string, any>> extends RuleInstance<T> {}
+
+  interface EnforceChain<T = any> {
+    isString(): EnforceChain<T>;
+    isNumber(): EnforceChain<T>;
+    isBoolean(): EnforceChain<T>;
+    isArray(): EnforceChain<T>;
+    isNotBlank(): EnforceChain<T>;
+    isNotEmpty(): EnforceChain<T>;
+    longerThan(length: number): EnforceChain<T>;
+    shorterThan(length: number): EnforceChain<T>;
+    greaterThan(value: number): EnforceChain<T>;
+    lessThan(value: number): EnforceChain<T>;
+    equals(value: any): EnforceChain<T>;
+    inside(list: any[]): EnforceChain<T>;
+    matches(pattern: RegExp | string): EnforceChain<T>;
+  }
+
+  interface EnforceLazy {
+    isString(): RuleInstance<string>;
+    isNumber(): RuleInstance<number>;
+    isBoolean(): RuleInstance<boolean>;
+    isArray(): RuleInstance<any[]>;
+    isArrayOf<R>(rule: RuleInstance<R>): RuleInstance<R[]>;
+    optional<R>(rule: RuleInstance<R>): RuleInstance<R | undefined>;
+
+    shape<S extends Record<string, RuleInstance<any>>>(
+      schema: S
+    ): ShapeSchema<{ [K in keyof S]: S[K] extends RuleInstance<infer T> ? T : any }>;
+
+    loose<S extends Record<string, RuleInstance<any>>>(
+      schema: S
+    ): ShapeSchema<{ [K in keyof S]: S[K] extends RuleInstance<infer T> ? T : any }>;
+
+    partial<S extends Record<string, RuleInstance<any>>>(
+      schema: S
+    ): ShapeSchema<{ [K in keyof S]?: S[K] extends RuleInstance<infer T> ? T | undefined : any }>;
+  }
+
+  type Enforce = ((value: any) => EnforceChain) & EnforceLazy & { extend(rules: Record<string, Function>): void };
+  export const enforce: Enforce;
+
+  // --- create overloads ---
+
+  // Config generic: explicit field/group names
+  export function create<C extends SuiteConfig>(
+    suiteCallback: (...args: any[]) => void,
+  ): Suite<C['fields'], C['groups'] extends string ? C['groups'] : string>;
+
+  // Schema-based: infer fields from enforce.shape
+  export function create<S extends ShapeSchema<any>>(
+    suiteCallback: (data: S extends ShapeSchema<infer T> ? T : any, ...args: any[]) => void,
+    schema: S,
+  ): Suite<
+    S extends ShapeSchema<infer T> ? Extract<keyof T, string> : string,
+    string,
+    any,
+    S
+  >;
+
+  // Untyped fallback
+  export function create(
+    suiteCallback: (...args: any[]) => void,
+  ): Suite<string, string>;
+
+  // --- other exports ---
+  export function test(fieldName: string, message: string, cb: TestFn): any;
+  export function test(fieldName: string, cb: TestFn): any;
+  export function group(callback: () => void): any;
+  export function group(groupName: string, callback: () => void): any;
+  export function only(item: string | string[]): void;
+  export function skip(item: string | string[]): void;
+  export function include(fieldName: string): { when(condition: any): void };
+  export function optional(optionals: string | string[] | Record<string, any>): void;
+  export function warn(): void;
+}
+`;
+
+const SchemaSuiteCode = `import { create, enforce } from 'vest';
 
 // Define a schema — field names and data types
 // are inferred automatically.
@@ -16,6 +200,9 @@ const suite = create(data => {
   // \`data\` is typed as:
   // { username: string; email: string; age: number }
 
+  // Destructure typed helpers from the suite:
+  const { test, only, skip, optional } = suite;
+
   test('username', 'Username is required', () => {
     enforce(data.username).isNotBlank();
   });
@@ -24,8 +211,6 @@ const suite = create(data => {
     enforce(data.email).isNotBlank();
   });
 
-  // Destructured helpers are also typed:
-  const { only, skip, optional } = suite;
   optional('email');
 }, userSchema);
 
@@ -50,11 +235,9 @@ suite.run({
   email: 'alice@example.com',
   age: 30,
 });
-
-export default suite;
 `;
 
-const ConfigSuiteCode = `import { create, test, enforce, group } from 'vest';
+const ConfigSuiteCode = `import { create, enforce } from 'vest';
 
 // Declare field and group names explicitly
 // via the config generic.
@@ -62,6 +245,9 @@ const suite = create<{
   fields: 'username' | 'email' | 'password';
   groups: 'auth' | 'profile';
 }>(data => {
+
+  // Destructure typed helpers from the suite:
+  const { test, group, only, skip, include, optional } = suite;
 
   test('username', 'Username is required', () => {
     enforce(data.username).isNotBlank();
@@ -73,8 +259,6 @@ const suite = create<{
     });
   });
 
-  // Destructured helpers are typed:
-  const { only, skip, include, optional } = suite;
   optional('email');
 });
 
@@ -92,30 +276,101 @@ const result = suite.get();
 result.hasErrors('username');
 result.getErrors('email');
 result.isValid('password');
-
-export default suite;
 `;
 
-function EditorOnly({ code }) {
+const MONACO_VERSION = '0.52.2';
+const MONACO_CDN = `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min`;
+
+let monacoPromise = null;
+
+function loadMonaco() {
+  if (monacoPromise) return monacoPromise;
+
+  monacoPromise = new Promise(resolve => {
+    if (window.monaco) {
+      resolve(window.monaco);
+      return;
+    }
+
+    window.require = window.require || { paths: {} };
+    window.require.paths = { vs: `${MONACO_CDN}/vs` };
+
+    const script = document.createElement('script');
+    script.src = `${MONACO_CDN}/vs/loader.js`;
+    script.onload = () => {
+      window.require(['vs/editor/editor.main'], () => {
+        resolve(window.monaco);
+      });
+    };
+    document.head.appendChild(script);
+  });
+
+  return monacoPromise;
+}
+
+function configureMonaco(monaco) {
+  monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+    target: monaco.languages.typescript.ScriptTarget.ESNext,
+    module: monaco.languages.typescript.ModuleKind.ESNext,
+    moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+    strict: true,
+    esModuleInterop: true,
+    jsx: monaco.languages.typescript.JsxEmit.React,
+    allowNonTsExtensions: true,
+  });
+
+  monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+    noSemanticValidation: false,
+    noSyntaxValidation: false,
+  });
+
+  monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    vestDts,
+    'file:///node_modules/vest/index.d.ts',
+  );
+}
+
+function MonacoEditorInner({ code }) {
+  const containerRef = useRef(null);
+  const editorRef = useRef(null);
+
+  useEffect(() => {
+    let disposed = false;
+
+    loadMonaco().then(monaco => {
+      if (disposed || !containerRef.current) return;
+
+      configureMonaco(monaco);
+
+      editorRef.current = monaco.editor.create(containerRef.current, {
+        value: code,
+        language: 'typescript',
+        theme: 'vs-dark',
+        minimap: { enabled: false },
+        fontSize: 14,
+        lineNumbers: 'on',
+        scrollBeyondLastLine: false,
+        readOnly: false,
+        automaticLayout: true,
+        tabSize: 2,
+      });
+    });
+
+    return () => {
+      disposed = true;
+      if (editorRef.current) {
+        editorRef.current.dispose();
+      }
+    };
+  }, [code]);
+
+  return <div ref={containerRef} style={{ height: 500 }} />;
+}
+
+function MonacoEditor({ code }) {
   return (
     <BrowserOnly fallback={<div>Loading Editor...</div>}>
-      {() => {
-        const {
-          SandpackProvider,
-          SandpackCodeEditor,
-        } = require('@codesandbox/sandpack-react');
-        return (
-          <SandpackProvider
-            template="react-ts"
-            theme="dark"
-            files={{ '/suite.ts': code }}
-            customSetup={{ dependencies: { vest: 'next' } }}
-            options={{ activeFile: '/suite.ts' }}
-          >
-            <SandpackCodeEditor style={{ height: 500 }} />
-          </SandpackProvider>
-        );
-      }}
+      {() => <MonacoEditorInner code={code} />}
     </BrowserOnly>
   );
 }
@@ -123,7 +378,7 @@ function EditorOnly({ code }) {
 export function SchemaTypedSandpack() {
   return (
     <div className={commonStyles.codeWindow}>
-      <EditorOnly code={SchemaSuiteCode} />
+      <MonacoEditor code={SchemaSuiteCode} />
     </div>
   );
 }
@@ -131,7 +386,7 @@ export function SchemaTypedSandpack() {
 export function ConfigTypedSandpack() {
   return (
     <div className={commonStyles.codeWindow}>
-      <EditorOnly code={ConfigSuiteCode} />
+      <MonacoEditor code={ConfigSuiteCode} />
     </div>
   );
 }

--- a/website/src/components/Sandpack/TypedSuites.js
+++ b/website/src/components/Sandpack/TypedSuites.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Sandpack from './index';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import commonStyles from '../RawExample.module.css';
 
 const SchemaSuiteCode = `import { create, test, enforce } from 'vest';
@@ -96,27 +96,34 @@ result.isValid('password');
 export default suite;
 `;
 
+function EditorOnly({ code }) {
+  return (
+    <BrowserOnly fallback={<div>Loading Editor...</div>}>
+      {() => {
+        const {
+          SandpackProvider,
+          SandpackCodeEditor,
+        } = require('@codesandbox/sandpack-react');
+        return (
+          <SandpackProvider
+            template="react-ts"
+            theme="dark"
+            files={{ '/suite.ts': code }}
+            customSetup={{ dependencies: { vest: 'next' } }}
+            options={{ activeFile: '/suite.ts' }}
+          >
+            <SandpackCodeEditor style={{ height: 500 }} />
+          </SandpackProvider>
+        );
+      }}
+    </BrowserOnly>
+  );
+}
+
 export function SchemaTypedSandpack() {
   return (
     <div className={commonStyles.codeWindow}>
-      <Sandpack
-        template="react-ts"
-        theme="dark"
-        files={{
-          '/suite.ts': SchemaSuiteCode,
-        }}
-        customSetup={{
-          dependencies: {
-            vest: 'next',
-          },
-        }}
-        options={{
-          activeFile: '/suite.ts',
-          showCommonFiles: false,
-          visibleFiles: ['/suite.ts'],
-          editorHeight: 500,
-        }}
-      />
+      <EditorOnly code={SchemaSuiteCode} />
     </div>
   );
 }
@@ -124,24 +131,7 @@ export function SchemaTypedSandpack() {
 export function ConfigTypedSandpack() {
   return (
     <div className={commonStyles.codeWindow}>
-      <Sandpack
-        template="react-ts"
-        theme="dark"
-        files={{
-          '/suite.ts': ConfigSuiteCode,
-        }}
-        customSetup={{
-          dependencies: {
-            vest: 'next',
-          },
-        }}
-        options={{
-          activeFile: '/suite.ts',
-          showCommonFiles: false,
-          visibleFiles: ['/suite.ts'],
-          editorHeight: 500,
-        }}
-      />
+      <EditorOnly code={ConfigSuiteCode} />
     </div>
   );
 }

--- a/website/src/components/Sandpack/TypedSuites.js
+++ b/website/src/components/Sandpack/TypedSuites.js
@@ -1,0 +1,147 @@
+import React from 'react';
+import Sandpack from './index';
+import commonStyles from '../RawExample.module.css';
+
+const SchemaSuiteCode = `import { create, test, enforce } from 'vest';
+
+// Define a schema — field names and data types
+// are inferred automatically.
+const userSchema = enforce.shape({
+  username: enforce.isString(),
+  email: enforce.isString(),
+  age: enforce.isNumber(),
+});
+
+const suite = create(data => {
+  // \`data\` is typed as:
+  // { username: string; email: string; age: number }
+
+  test('username', 'Username is required', () => {
+    enforce(data.username).isNotBlank();
+  });
+
+  test('email', 'Email is required', () => {
+    enforce(data.email).isNotBlank();
+  });
+
+  // Destructured helpers are also typed:
+  const { only, skip, optional } = suite;
+  optional('email');
+}, userSchema);
+
+// All suite APIs are typed to schema keys.
+// Try changing 'username' to an invalid field name
+// to see a type error.
+suite.remove('username');
+suite.resetField('email');
+suite.focus({ only: 'username' });
+suite.only('age');
+suite.afterField('email', () => {});
+
+// Result selectors are typed too:
+const result = suite.get();
+result.hasErrors('username');
+result.getErrors('email');
+result.isValid('age');
+
+// .run() enforces the schema data shape:
+suite.run({
+  username: 'alice',
+  email: 'alice@example.com',
+  age: 30,
+});
+
+export default suite;
+`;
+
+const ConfigSuiteCode = `import { create, test, enforce, group } from 'vest';
+
+// Declare field and group names explicitly
+// via the config generic.
+const suite = create<{
+  fields: 'username' | 'email' | 'password';
+  groups: 'auth' | 'profile';
+}>(data => {
+
+  test('username', 'Username is required', () => {
+    enforce(data.username).isNotBlank();
+  });
+
+  group('auth', () => {
+    test('password', 'Password is required', () => {
+      enforce(data.password).isNotBlank();
+    });
+  });
+
+  // Destructured helpers are typed:
+  const { only, skip, include, optional } = suite;
+  optional('email');
+});
+
+// All suite APIs enforce the declared names.
+// Try changing 'username' to 'phone' to see a
+// type error.
+suite.remove('username');
+suite.resetField('email');
+suite.focus({ only: 'password', onlyGroup: 'auth' });
+suite.only('username');
+suite.afterField('email', () => {});
+
+// Result selectors are typed:
+const result = suite.get();
+result.hasErrors('username');
+result.getErrors('email');
+result.isValid('password');
+
+export default suite;
+`;
+
+export function SchemaTypedSandpack() {
+  return (
+    <div className={commonStyles.codeWindow}>
+      <Sandpack
+        template="react-ts"
+        theme="dark"
+        files={{
+          '/suite.ts': SchemaSuiteCode,
+        }}
+        customSetup={{
+          dependencies: {
+            vest: 'next',
+          },
+        }}
+        options={{
+          activeFile: '/suite.ts',
+          showCommonFiles: false,
+          visibleFiles: ['/suite.ts'],
+          editorHeight: 500,
+        }}
+      />
+    </div>
+  );
+}
+
+export function ConfigTypedSandpack() {
+  return (
+    <div className={commonStyles.codeWindow}>
+      <Sandpack
+        template="react-ts"
+        theme="dark"
+        files={{
+          '/suite.ts': ConfigSuiteCode,
+        }}
+        customSetup={{
+          dependencies: {
+            vest: 'next',
+          },
+        }}
+        options={{
+          activeFile: '/suite.ts',
+          showCommonFiles: false,
+          visibleFiles: ['/suite.ts'],
+          editorHeight: 500,
+        }}
+      />
+    </div>
+  );
+}

--- a/website/src/components/Sandpack/VueIntegration.js
+++ b/website/src/components/Sandpack/VueIntegration.js
@@ -182,7 +182,7 @@ export default function VueIntegrationSandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/src/components/Sandpack/WarnOnlyTests.js
+++ b/website/src/components/Sandpack/WarnOnlyTests.js
@@ -142,7 +142,7 @@ export default function WarnOnlyTestsSandpack() {
         }}
         customSetup={{
           dependencies: {
-            vest: 'next',
+            vest: 'latest',
           },
         }}
         options={{

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6993,6 +6993,76 @@ When you pass a schema to `create`:
 2.  If the data structure doesn't match the schema (e.g., `age` is a string instead of a number), the suite run fails immediately for those fields.
 3.  Your tests run assuming the data types are correct.
 
+## TypeScript Inference for `create`
+
+When a schema is passed as the second argument to `create`, Vest infers the suite callback data type and `run(...)` payload type directly from that schema.
+
+```typescript
+const userSchema = enforce.shape({
+  username: enforce.isString(),
+  age: enforce.isNumber(),
+});
+
+const suite = create(data => {
+  // data is inferred as: { username: string; age: number }
+  test('username', () => {
+    enforce(data.username).isNotBlank();
+  });
+}, userSchema);
+
+// `run` payload is typed from schema
+suite.run({ username: 'john', age: 42 });
+
+// TypeScript error: `age` must be a number
+// suite.run({ username: 'john', age: '42' });
+```
+
+### What becomes typed from the schema
+
+With `create(callback, schema)`, TypeScript narrows:
+
+- callback data (`data`) to the schema input shape.
+- `suite.run(...)` / `suite.validate(...)` first argument to the schema input shape.
+- field-oriented happy-path APIs (`test`, `optional`, `include`) to schema keys.
+- `result.types.input` and `result.types.output` to schema input/output types.
+
+Some lifecycle/focus helpers (`remove`, `resetField`, `afterField`, `only`, `focus.only`) intentionally still accept dynamic strings for nested/dynamic runtime workflows.
+
+Group modifiers (`onlyGroup` / `skipGroup`) remain `string` unless you explicitly provide group generics to `create`.
+
+### API coverage (current typing standard)
+
+When using `create(callback, schema)`, the current TypeScript standard is:
+
+- Field-key inferred from schema for:
+  - `test(fieldName, message?, callback)`
+  - `include(fieldName).when(condition)`
+  - `optional(fieldName)`
+- Group generic-aware (when explicitly provided):
+  - `group(groupName, callback)`
+  - `suite.focus({ onlyGroup / skipGroup })`
+- Intentionally dynamic string-friendly:
+  - `suite.remove(fieldName)`
+  - `suite.resetField(fieldName)`
+  - `suite.only(fieldName)`
+  - `suite.afterField(fieldName, callback)`
+  - `only(fieldName)` / `skip(fieldName)` hooks
+
+### Explicit generic override (advanced)
+
+If needed, you can still provide explicit suite generics to fully control field/group names:
+
+```typescript
+const suite = create<'username' | 'age', 'account'>(data => {
+  // Without a schema, `data` is intentionally untyped (effectively `any`).
+  test('username', () => {
+    enforce(data.username).isNotBlank();
+  });
+});
+
+suite.focus({ onlyGroup: 'account' }); // typed group name
+```
+
 :::note Focused runs
 When you focus the suite with `suite.only()` or `suite.focus({ only })`, schema validation is skipped for fields outside the focus scope. This allows you to validate a single field even if the full payload does not satisfy the schema.
 


### PR DESCRIPTION
### Motivation
- Improve DX by ensuring `create`/`createSuite` provides accurate typing for schema-inferred callbacks, explicit generic overrides, and explicit `{ fields, groups }` config cases. 
- Allow `focus({ onlyGroup, skipGroup })` to be strongly typed when the suite is instantiated with a group generic so invalid group literals are caught at compile time.

### Description
- Reworked `createSuite` overloads to better model schema-aware callbacks, explicit config generics, and the escape-hatch/untyped variants while preserving runtime behavior where the suite instance is created before callback execution (`packages/vest/src/suite/createSuite.ts`).
- Made `SuiteModifiers` carry both field and group generics (`SuiteModifiers<F, G>`) and tightened `onlyGroup`/`skipGroup` to `G | G[]` instead of `string | string[]` (`packages/vest/src/suite/SuiteTypes.ts`).
- Propagated the new `SuiteModifiers<F, G>` shape through suite method factories and helpers (`useCreateSuiteMethods`, `useCreateFocus`, `useCreateOnly`) so `focus`/`only` and lifecycle helpers remain type-consistent (`packages/vest/src/suite/useCreateSuiteMethods.ts`).
- Added/adjusted type-focused tests/examples to validate group-generic `focus` arguments and schema-inferred callback data in the test suite (`packages/vest/src/suite/__tests__/typedSuite.test.ts`, `packages/vest/src/suite/__tests__/schema.example.test.ts`).

### Testing
- Ran full unit test suite with Vitest (`yarn vx test` / `yarn vitest`) and observed all tests pass (existing test run completed with 1296 tests passing).
- Performed focused test runs for the modified tests via `yarn vitest run packages/vest/src/suite/__tests__/typedSuite.test.ts packages/vest/src/suite/__tests__/schema.example.test.ts` and they passed. 
- Ran type checking via `yarn vx typecheck` which passed for application code only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2968ed2708330a7e4a6bf91506f4c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger TypeScript inference for suite creation: schema- and config-based overloads yield tighter types for callback data, fields, and groups; group modifiers (only/skip) accept user-defined group names.

* **Tests**
  * Added extensive type-safety and example tests covering schema-inferred suites, typed group modifiers, focus/remove semantics, and many runtime/type permutations.

* **Documentation**
  * New guide on schema-driven type inference, explicit generics, and using typed modifiers with focused runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->