### PR TITLE
Use IsolateTransient to register include() conditions and defer evaluation

### DIFF
--- a/packages/vest/src/hooks/__tests__/include.test.ts
+++ b/packages/vest/src/hooks/__tests__/include.test.ts
@@ -151,6 +151,26 @@ describe('include', () => {
             expect(res).toMatchSnapshot();
           });
         });
+
+        it('should not run the included field when condition is undefined', () => {
+          const suite = vest.create(() => {
+            vest.only('field_1');
+            // @ts-expect-error runtime safety for undefined input
+            vest.include('field_2').when(undefined);
+
+            vest.test('field_1', () => false);
+            vest.test('field_2', () => false);
+            vest.test('field_3', () => false);
+          });
+
+          const res = suite.run();
+          expect(res.hasErrors('field_1')).toBe(true);
+          expect(res.tests.field_1.testCount).toBe(1);
+          expect(res.hasErrors('field_2')).toBe(false);
+          expect(res.tests.field_2.testCount).toBe(0);
+          expect(res.hasErrors('field_3')).toBe(false);
+          expect(res.tests.field_3.testCount).toBe(0);
+        });
       });
       describe('`when` param is a function', () => {
         describe('when returning `true`', () => {

--- a/packages/vest/src/hooks/include.ts
+++ b/packages/vest/src/hooks/include.ts
@@ -10,6 +10,8 @@ import { useCreateSuiteResult } from '../suiteResult/suiteResult';
 
 import { useHasOnliedTests } from './focused/useHasOnliedTests';
 
+const INCLUDE_UNSET = Symbol('include_unset');
+
 /**
  * Conditionally includes a field for testing, based on specified criteria.
  *
@@ -37,7 +39,7 @@ export function include<F extends TFieldName, G extends TGroupName>(
   invariant(isStringValue(fieldName));
   const safeFieldName = makeBrand<TFieldName>(fieldName);
   const conditionRef: IncludeConditionRef<F, G> = {
-    current: undefined,
+    current: INCLUDE_UNSET,
   };
 
   IsolateTransient(useSetIncluded, 'Include', {
@@ -66,7 +68,7 @@ type IncludeCondition<F extends TFieldName, G extends TGroupName> =
   | TDraftCondition<F, G>;
 
 type IncludeConditionRef<F extends TFieldName, G extends TGroupName> = {
-  current: IncludeCondition<F, G> | undefined;
+  current: IncludeCondition<F, G> | typeof INCLUDE_UNSET;
 };
 
 type IncludePayload<F extends TFieldName, G extends TGroupName> = {
@@ -86,7 +88,7 @@ function useSetIncluded<F extends TFieldName, G extends TGroupName>(
   ): boolean {
     const condition = conditionRef.current;
 
-    if (condition === undefined) {
+    if (condition === INCLUDE_UNSET) {
       return true;
     }
 

--- a/packages/vest/src/hooks/include.ts
+++ b/packages/vest/src/hooks/include.ts
@@ -1,4 +1,5 @@
 import { dynamicValue, invariant, isStringValue, makeBrand } from 'vest-utils';
+import { IsolateTransient, type TIsolate } from 'vestjs-runtime';
 
 import { useInclusion } from '../core/context/SuiteContext';
 import { TIsolateTest } from '../core/isolate/IsolateTest/IsolateTest';
@@ -34,10 +35,15 @@ export function include<F extends TFieldName, G extends TGroupName>(
   when: (condition: F | string | TFieldName | TDraftCondition<F, G>) => void;
 } {
   invariant(isStringValue(fieldName));
-  const inclusion = useInclusion();
   const safeFieldName = makeBrand<TFieldName>(fieldName);
+  const conditionRef: IncludeConditionRef<F, G> = {
+    current: undefined,
+  };
 
-  inclusion[safeFieldName] = true;
+  IsolateTransient(useSetIncluded, 'Include', {
+    conditionRef,
+    fieldName: safeFieldName,
+  });
 
   return { when };
 
@@ -49,19 +55,47 @@ export function include<F extends TFieldName, G extends TGroupName>(
   ): void {
     invariant(condition !== fieldName, ErrorStrings.INCLUDE_SELF);
 
-    const inclusion = useInclusion();
-
-    // This callback will run as part of the "isExcluded" series of checks
-    inclusion[safeFieldName] = function isIncluded(
-      currentNode: TIsolateTest,
-    ): boolean {
-      if (isStringValue(condition)) {
-        return useHasOnliedTests(currentNode, makeBrand<TFieldName>(condition));
-      }
-
-      return dynamicValue(condition, () =>
-        useCreateSuiteResult(undefined, undefined),
-      );
-    };
+    conditionRef.current = condition;
   }
+}
+
+type IncludeCondition<F extends TFieldName, G extends TGroupName> =
+  | F
+  | string
+  | TFieldName
+  | TDraftCondition<F, G>;
+
+type IncludeConditionRef<F extends TFieldName, G extends TGroupName> = {
+  current: IncludeCondition<F, G> | undefined;
+};
+
+type IncludePayload<F extends TFieldName, G extends TGroupName> = {
+  conditionRef: IncludeConditionRef<F, G>;
+  fieldName: TFieldName;
+};
+
+function useSetIncluded<F extends TFieldName, G extends TGroupName>(
+  isolate: TIsolate<IncludePayload<F, G>>,
+): void {
+  const inclusion = useInclusion();
+  const { fieldName, conditionRef } = isolate.data;
+
+  // This callback will run as part of the "isExcluded" series of checks
+  inclusion[fieldName] = function isIncluded(
+    currentNode: TIsolateTest,
+  ): boolean {
+    const condition = conditionRef.current;
+
+    if (condition === undefined) {
+      return true;
+    }
+
+    if (isStringValue(condition)) {
+      return useHasOnliedTests(currentNode, makeBrand<TFieldName>(condition));
+    }
+
+    return dynamicValue(condition, () =>
+      useCreateSuiteResult(undefined, undefined),
+    );
+  };
 }


### PR DESCRIPTION
### Motivation

- Reduce direct side-effects from `include()` calls by moving inclusion registration into an isolate so evaluation can be deferred and isolated.
- Allow `include(...).when(...)` to set the condition separately from registration so the condition can be resolved at runtime inside the isolate.

### Description

- Import `IsolateTransient` and `TIsolate` and introduce an isolate-based flow that registers inclusion handlers via `useSetIncluded` instead of mutating `useInclusion()` immediately. 
- Replace the immediate `inclusion[safeFieldName] = true` and inline `isIncluded` definition with a `conditionRef` stored in the isolate payload and set by `when`.
- Add helper types `IncludeCondition`, `IncludeConditionRef`, and `IncludePayload`, and implement `useSetIncluded` to read `conditionRef.current` and compute inclusion using `useHasOnliedTests` or `dynamicValue` as before.
- Preserve prior behaviour where omitted `when` means the field is included by default and maintain the same evaluation logic for string and function conditions.

### Testing

- Ran the test suite with `yarn test`, and all tests passed. 
- Performed a TypeScript build check with `yarn build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a11c3874e08330be2ae130979839ff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of field inclusion conditions for more robust, flexible, and maintainable evaluation while preserving existing validation behavior.
* **Bug Fixes**
  * Clarified behavior when an inclusion condition is undefined: dependent fields are skipped while the primary field executes as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->