### PR TITLE
Add built-in lazy parsers and wire them into type rules with tests

### DIFF
--- a/packages/n4s/src/__tests__/lazyParsers.test.ts
+++ b/packages/n4s/src/__tests__/lazyParsers.test.ts
@@ -11,7 +11,7 @@ describe('built-in lazy parsers', () => {
       .prepend('HELLO ')
       .run('  world  ');
 
-    expect(transformed).toEqual({ pass: true, type: 'HELLO WORLD' });
+    expect(transformed).toMatchObject({ pass: true, type: 'HELLO WORLD' });
   });
 
   it('supports numeric parser chains after numeric rules', () => {
@@ -22,7 +22,7 @@ describe('built-in lazy parsers', () => {
       .round()
       .run('101.49');
 
-    expect(transformed).toEqual({ pass: true, type: 100 });
+    expect(transformed).toMatchObject({ pass: true, type: 100 });
   });
 
   it('fails parse-oriented chains when parser coercion fails', () => {

--- a/packages/n4s/src/__tests__/lazyParsers.test.ts
+++ b/packages/n4s/src/__tests__/lazyParsers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { enforce } from '../n4s';
+
+describe('built-in lazy parsers', () => {
+  it('applies lazy parser chains on top of type checks', () => {
+    const transformed = enforce
+      .isString()
+      .trim()
+      .toUpper()
+      .prepend('HELLO ')
+      .run('  world  ');
+
+    expect(transformed).toEqual({ pass: true, type: 'HELLO WORLD' });
+  });
+
+  it('supports numeric parser chains after numeric rules', () => {
+    const transformed = enforce
+      .isNumeric()
+      .toNumber()
+      .clamp(0, 100)
+      .round()
+      .run('101.49');
+
+    expect(transformed).toEqual({ pass: true, type: 100 });
+  });
+
+  it('fails parse-oriented chains when parser coercion fails', () => {
+    const toBooleanRule = enforce.isString().trim().toBoolean();
+
+    expect(toBooleanRule.run('unknown')).toEqual({
+      pass: false,
+      type: false,
+      message: 'Could not parse to boolean',
+    });
+
+    expect(() => toBooleanRule.parse('unknown')).toThrow(
+      'Could not parse to boolean',
+    );
+  });
+
+  it('keeps parser methods lazy-only and unavailable in eager chains', () => {
+    expect(() =>
+      (enforce('  hi  ') as Record<string, () => unknown>).trim(),
+    ).toThrow();
+  });
+});

--- a/packages/n4s/src/lazy/typeRules.ts
+++ b/packages/n4s/src/lazy/typeRules.ts
@@ -1,5 +1,8 @@
 import { isArray } from '../rules/array/isArrayRule';
-import type { ArrayRuleInstance } from '../rules/arrayRules';
+import {
+  BuildRuleInstance,
+  ExtractRuleFunctions,
+} from '../rules/RuleInstanceBuilder';
 import * as arrayRules from '../rules/arrayRules';
 import { isBoolean, type BooleanRuleInstance } from '../rules/booleanRules';
 import * as booleanRules from '../rules/booleanRules';
@@ -12,24 +15,69 @@ import {
   type UndefinedRuleInstance,
   type NullishRuleInstance,
 } from '../rules/nullishRules';
-import {
-  isNumber,
-  type NumberRuleInstance,
-  type NumericRuleInstance,
-} from '../rules/numberRules';
+import { isNumber } from '../rules/numberRules';
 import * as numberRules from '../rules/numberRules';
 import { isNumeric } from '../rules/numeric/isNumeric';
-import { isString, type StringRuleInstance } from '../rules/stringRules';
+import { arrayParsers } from '../rules/parsers/arrayParsers';
+import { generalParsers } from '../rules/parsers/generalParsers';
+import { numberParsers } from '../rules/parsers/numberParsers';
+import { stringParsers } from '../rules/parsers/stringParsers';
+import { isString } from '../rules/stringRules';
 import * as stringRules from '../rules/stringRules';
 
+const lazyArrayRules = {
+  ...arrayRules,
+  ...arrayParsers,
+  ...generalParsers,
+} as const;
+
+const lazyNumberRules = {
+  ...numberRules,
+  ...numberParsers,
+  ...generalParsers,
+} as const;
+
+const lazyStringRules = {
+  ...stringRules,
+  ...stringParsers,
+  ...generalParsers,
+} as const;
+
+type LazyArrayRuleInstance<T = any> = BuildRuleInstance<
+  T[],
+  [T[]],
+  ExtractRuleFunctions<typeof lazyArrayRules>
+>;
+
+type LazyNumberRuleInstance = BuildRuleInstance<
+  number,
+  [number],
+  ExtractRuleFunctions<typeof lazyNumberRules>
+>;
+
+type LazyNumericRuleInstance = BuildRuleInstance<
+  string | number,
+  [string | number],
+  ExtractRuleFunctions<typeof lazyNumberRules>
+>;
+
+type LazyStringRuleInstance = BuildRuleInstance<
+  string,
+  [string],
+  ExtractRuleFunctions<typeof lazyStringRules>
+>;
+
 export const typeRules = {
-  isArray: <T = any>(): ArrayRuleInstance<T> =>
-    addToChain<ArrayRuleInstance<T>>(arrayRules, isArray),
+  isArray: <T = any>(): LazyArrayRuleInstance<T> =>
+    addToChain<LazyArrayRuleInstance<T>>(lazyArrayRules, isArray),
   isBoolean: (): BooleanRuleInstance => addToChain(booleanRules, isBoolean),
   isNull: (): NullRuleInstance => addToChain({}, isNull),
   isNullish: (): NullishRuleInstance => addToChain({}, isNullish),
-  isNumber: (): NumberRuleInstance => addToChain(numberRules, isNumber),
-  isNumeric: (): NumericRuleInstance => addToChain(numberRules, isNumeric),
-  isString: (): StringRuleInstance => addToChain(stringRules, isString),
+  isNumber: (): LazyNumberRuleInstance =>
+    addToChain<LazyNumberRuleInstance>(lazyNumberRules, isNumber),
+  isNumeric: (): LazyNumericRuleInstance =>
+    addToChain<LazyNumericRuleInstance>(lazyNumberRules, isNumeric),
+  isString: (): LazyStringRuleInstance =>
+    addToChain<LazyStringRuleInstance>(lazyStringRules, isString),
   isUndefined: (): UndefinedRuleInstance => addToChain({}, isUndefined),
 };

--- a/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
+++ b/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
@@ -40,6 +40,11 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
     return proxy;
   };
 
+  const prepend = (p: Predicate): T => {
+    chain.unshift(p);
+    return proxy;
+  };
+
   const resolveMessage = (
     result: ReturnType<typeof executeChain>,
     value: unknown,
@@ -117,6 +122,7 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
       add,
       message,
       parse,
+      prepend,
       run,
       test,
       validate,

--- a/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
+++ b/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
@@ -15,6 +15,7 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
     run,
     parse,
     message,
+    prepend,
     '~standard': standard,
   }: {
     add: (p: Predicate) => T;
@@ -23,6 +24,7 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
     run: T['run'];
     parse: T['parse'];
     message: (msg: any) => T;
+    prepend: (p: Predicate) => T;
     '~standard': StandardSchemaV1.Props<any, any>;
   },
 ) {
@@ -44,34 +46,44 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
     '~standard',
   ]);
 
-  return createProxyHandlersHelper(rules, methods, methodKeys, add);
+  return createProxyHandlersHelper(rules, methods, methodKeys, {
+    add,
+    prepend,
+  });
 }
 
 function createProxyHandlersHelper<T extends RuleInstance<any, any>>(
   rules: Record<string, any>,
   methods: Record<string, any>,
   methodKeys: Set<string>,
-  add: (p: Predicate) => T,
+  inserters: { add: (p: Predicate) => T; prepend: (p: Predicate) => T },
 ) {
+  function getRuleHandler(prop: string | symbol) {
+    if (hasOwnProperty(rules, prop)) {
+      const insert = prop === 'defaultTo' ? inserters.prepend : inserters.add;
+      return (...args: any[]) =>
+        insert((value: any) => rules[prop](value, ...args));
+    }
+
+    if (typeof prop === 'string') {
+      const lazyRule = getLazyRule(prop);
+      if (lazyRule) {
+        return (...args: any[]) => inserters.add(lazyRule(...args));
+      }
+    }
+
+    return undefined;
+  }
+
   return {
     get(_target: T, prop: string | symbol, receiver: any) {
       if (hasOwnProperty(methods, prop)) {
         return methods[prop];
       }
 
-      if (hasOwnProperty(rules, prop)) {
-        return (...args: any[]) =>
-          add((value: any) => rules[prop](value, ...args));
-      }
-
-      if (typeof prop === 'string') {
-        const lazyRule = getLazyRule(prop);
-        if (lazyRule) {
-          return (...args: any[]) => add(lazyRule(...args));
-        }
-      }
-
-      return Reflect.get(_target as object, prop, receiver);
+      return (
+        getRuleHandler(prop) ?? Reflect.get(_target as object, prop, receiver)
+      );
     },
     has(_target: T, prop: string | symbol) {
       if (typeof prop === 'string') {

--- a/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
+++ b/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
@@ -2,6 +2,7 @@ import { hasOwnProperty } from 'vest-utils';
 import { StandardSchemaV1 } from 'vest-utils/standardSchemaSpec';
 
 import { RuleInstance } from '../../utils/RuleInstance';
+import { CHAIN_PREPEND } from '../parsers/parserUtils';
 
 import type { Predicate } from './chainExecutor';
 import { getLazyRule } from './lazyRegistry';
@@ -60,7 +61,9 @@ function createProxyHandlersHelper<T extends RuleInstance<any, any>>(
 ) {
   function getRuleHandler(prop: string | symbol) {
     if (hasOwnProperty(rules, prop)) {
-      const insert = prop === 'defaultTo' ? inserters.prepend : inserters.add;
+      const insert = rules[prop][CHAIN_PREPEND]
+        ? inserters.prepend
+        : inserters.add;
       return (...args: any[]) =>
         insert((value: any) => rules[prop](value, ...args));
     }

--- a/packages/n4s/src/rules/parsers/__tests__/arrayParsers.test.ts
+++ b/packages/n4s/src/rules/parsers/__tests__/arrayParsers.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { arrayParsers, join, uniq } from '../arrayParsers';
+
+describe('array parsers', () => {
+  it('exports all array parser functions', () => {
+    expect(Object.keys(arrayParsers).sort()).toEqual(['join', 'uniq']);
+  });
+
+  it('join', () => {
+    expect(join(['a', 'b', 'c'], '-').type).toBe('a-b-c');
+  });
+
+  it('uniq', () => {
+    expect(uniq(['a', 'a', 'b']).type).toEqual(['a', 'b']);
+  });
+});

--- a/packages/n4s/src/rules/parsers/__tests__/arrayParsers.test.ts
+++ b/packages/n4s/src/rules/parsers/__tests__/arrayParsers.test.ts
@@ -9,9 +9,11 @@ describe('array parsers', () => {
 
   it('join', () => {
     expect(join(['a', 'b', 'c'], '-').type).toBe('a-b-c');
+    expect(join(['a', 'b', 'c'], '-').pass).toBe(true);
   });
 
   it('uniq', () => {
     expect(uniq(['a', 'a', 'b']).type).toEqual(['a', 'b']);
+    expect(uniq(['a', 'a', 'b']).pass).toBe(true);
   });
 });

--- a/packages/n4s/src/rules/parsers/__tests__/generalParsers.test.ts
+++ b/packages/n4s/src/rules/parsers/__tests__/generalParsers.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { defaultTo, generalParsers, toJSON } from '../generalParsers';
+
+describe('general parsers', () => {
+  it('exports all general parser functions', () => {
+    expect(Object.keys(generalParsers).sort()).toEqual([
+      'defaultTo',
+      'toBoolean',
+      'toJSON',
+    ]);
+  });
+
+  it('defaultTo returns fallback for nullish values', () => {
+    expect(defaultTo<string | null>(null, 'fallback').type).toBe('fallback');
+    expect(defaultTo<number | undefined>(undefined, 42).type).toBe(42);
+  });
+
+  it('defaultTo keeps non-nullish values', () => {
+    expect(defaultTo('value', 'fallback').type).toBe('value');
+  });
+
+  it('toJSON passes for valid JSON', () => {
+    expect(toJSON('{"name":"vest"}')).toEqual({
+      pass: true,
+      type: { name: 'vest' },
+      message: undefined,
+      path: undefined,
+    });
+  });
+
+  it('toJSON fails for invalid JSON', () => {
+    const result = toJSON('not-json');
+
+    expect(result.pass).toBe(false);
+    expect(result.type).toBe('not-json');
+    expect(result.message).toBe('Could not parse JSON');
+  });
+});

--- a/packages/n4s/src/rules/parsers/__tests__/generalParsers.test.ts
+++ b/packages/n4s/src/rules/parsers/__tests__/generalParsers.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { defaultTo, generalParsers, toJSON } from '../generalParsers';
+import { defaultTo, generalParsers, parseJSON } from '../generalParsers';
 
 describe('general parsers', () => {
   it('exports all general parser functions', () => {
     expect(Object.keys(generalParsers).sort()).toEqual([
       'defaultTo',
+      'parseJSON',
       'toBoolean',
-      'toJSON',
     ]);
   });
 
@@ -20,8 +20,8 @@ describe('general parsers', () => {
     expect(defaultTo('value', 'fallback').type).toBe('value');
   });
 
-  it('toJSON passes for valid JSON', () => {
-    expect(toJSON('{"name":"vest"}')).toEqual({
+  it('parseJSON passes for valid JSON', () => {
+    expect(parseJSON('{"name":"vest"}')).toEqual({
       pass: true,
       type: { name: 'vest' },
       message: undefined,
@@ -29,8 +29,8 @@ describe('general parsers', () => {
     });
   });
 
-  it('toJSON fails for invalid JSON', () => {
-    const result = toJSON('not-json');
+  it('parseJSON fails for invalid JSON', () => {
+    const result = parseJSON('not-json');
 
     expect(result.pass).toBe(false);
     expect(result.type).toBe('not-json');

--- a/packages/n4s/src/rules/parsers/__tests__/numberParsers.test.ts
+++ b/packages/n4s/src/rules/parsers/__tests__/numberParsers.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ceil,
+  clamp,
+  floor,
+  numberParsers,
+  round,
+  toAbsolute,
+  toDate,
+  toFloat,
+  toInteger,
+} from '../numberParsers';
+
+describe('number parsers', () => {
+  it('exports all number parser functions', () => {
+    expect(Object.keys(numberParsers).sort()).toEqual([
+      'ceil',
+      'clamp',
+      'floor',
+      'round',
+      'toAbsolute',
+      'toDate',
+      'toFloat',
+      'toInteger',
+    ]);
+  });
+
+  it('ceil', () => {
+    expect(ceil(2.1).type).toBe(3);
+  });
+
+  it('clamp', () => {
+    expect(clamp(120, 0, 100).type).toBe(100);
+  });
+
+  it('floor', () => {
+    expect(floor(2.9).type).toBe(2);
+  });
+
+  it('round', () => {
+    expect(round(2.5).type).toBe(3);
+  });
+
+  it('toAbsolute', () => {
+    expect(toAbsolute(-15).type).toBe(15);
+  });
+
+  it('toDate passes for date-like values', () => {
+    const result = toDate('2024-01-01T00:00:00.000Z');
+
+    expect(result.pass).toBe(true);
+    expect(result.type instanceof Date).toBe(true);
+  });
+
+  it('toDate fails for invalid values', () => {
+    const result = toDate('not-a-date');
+
+    expect(result.pass).toBe(false);
+    expect(Number.isNaN(result.type.getTime())).toBe(true);
+    expect(result.message).toBe('Could not parse to Date');
+  });
+
+  it('toFloat passes', () => {
+    expect(toFloat('10.5')).toEqual({
+      pass: true,
+      type: 10.5,
+      message: undefined,
+      path: undefined,
+    });
+  });
+
+  it('toFloat fails', () => {
+    const result = toFloat('abc');
+
+    expect(result.pass).toBe(false);
+    expect(Number.isNaN(result.type)).toBe(true);
+    expect(result.message).toBe('Could not parse to float');
+  });
+
+  it('toInteger passes', () => {
+    expect(toInteger('11.8').type).toBe(11);
+  });
+
+  it('toInteger fails', () => {
+    const result = toInteger('abc');
+
+    expect(result.pass).toBe(false);
+    expect(Number.isNaN(result.type)).toBe(true);
+    expect(result.message).toBe('Could not parse to integer');
+  });
+});

--- a/packages/n4s/src/rules/parsers/__tests__/numberParsers.test.ts
+++ b/packages/n4s/src/rules/parsers/__tests__/numberParsers.test.ts
@@ -34,6 +34,14 @@ describe('number parsers', () => {
     expect(clamp(120, 0, 100).type).toBe(100);
   });
 
+  it('clamp when min equals max', () => {
+    expect(clamp(50, 10, 10).type).toBe(10);
+  });
+
+  it('clamp when min > max', () => {
+    expect(clamp(50, 100, 0).type).toBe(0);
+  });
+
   it('floor', () => {
     expect(floor(2.9).type).toBe(2);
   });
@@ -61,6 +69,15 @@ describe('number parsers', () => {
     expect(result.message).toBe('Could not parse to Date');
   });
 
+  it('toDate fails for non-string/number/Date types', () => {
+    const result = toDate({ year: 2024 });
+
+    expect(result.pass).toBe(false);
+    expect(result.message).toBe(
+      'Could not parse to Date: expected string, number, or Date',
+    );
+  });
+
   it('toFloat passes', () => {
     expect(toFloat('10.5')).toEqual({
       pass: true,
@@ -68,6 +85,11 @@ describe('number parsers', () => {
       message: undefined,
       path: undefined,
     });
+  });
+
+  it('toFloat passes for number input', () => {
+    expect(toFloat(10.5).type).toBe(10.5);
+    expect(toFloat(10.5).pass).toBe(true);
   });
 
   it('toFloat fails', () => {
@@ -82,11 +104,30 @@ describe('number parsers', () => {
     expect(toInteger('11.8').type).toBe(11);
   });
 
+  it('toInteger passes for number input', () => {
+    expect(toInteger(11.8).type).toBe(11);
+    expect(toInteger(11.8).pass).toBe(true);
+  });
+
+  it('toInteger with binary radix', () => {
+    expect(toInteger('1011', 2).type).toBe(11);
+    expect(toInteger('1011', 2).pass).toBe(true);
+  });
+
   it('toInteger fails', () => {
     const result = toInteger('abc');
 
     expect(result.pass).toBe(false);
     expect(Number.isNaN(result.type)).toBe(true);
     expect(result.message).toBe('Could not parse to integer');
+  });
+
+  it('toInteger fails for invalid radix', () => {
+    const result = toInteger('10', 1);
+
+    expect(result.pass).toBe(false);
+    expect(result.message).toBe(
+      'Invalid radix: must be an integer between 2 and 36',
+    );
   });
 });

--- a/packages/n4s/src/rules/parsers/__tests__/numberParsers.test.ts
+++ b/packages/n4s/src/rules/parsers/__tests__/numberParsers.test.ts
@@ -38,7 +38,7 @@ describe('number parsers', () => {
     expect(clamp(50, 10, 10).type).toBe(10);
   });
 
-  it('clamp when min > max', () => {
+  it('clamp does not validate min <= max', () => {
     expect(clamp(50, 100, 0).type).toBe(0);
   });
 

--- a/packages/n4s/src/rules/parsers/__tests__/numberParsers.test.ts
+++ b/packages/n4s/src/rules/parsers/__tests__/numberParsers.test.ts
@@ -61,6 +61,23 @@ describe('number parsers', () => {
     expect(result.type instanceof Date).toBe(true);
   });
 
+  it('toDate passes for numeric timestamp', () => {
+    const result = toDate(1704067200000);
+
+    expect(result.pass).toBe(true);
+    expect(result.type instanceof Date).toBe(true);
+    expect(result.type.toISOString()).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('toDate passes for Date instance', () => {
+    const input = new Date('2024-01-01T00:00:00.000Z');
+    const result = toDate(input);
+
+    expect(result.pass).toBe(true);
+    expect(result.type instanceof Date).toBe(true);
+    expect(result.type.getTime()).toBe(input.getTime());
+  });
+
   it('toDate fails for invalid values', () => {
     const result = toDate('not-a-date');
 
@@ -79,12 +96,10 @@ describe('number parsers', () => {
   });
 
   it('toFloat passes', () => {
-    expect(toFloat('10.5')).toEqual({
-      pass: true,
-      type: 10.5,
-      message: undefined,
-      path: undefined,
-    });
+    const result = toFloat('10.5');
+
+    expect(result.pass).toBe(true);
+    expect(result.type).toBe(10.5);
   });
 
   it('toFloat passes for number input', () => {

--- a/packages/n4s/src/rules/parsers/__tests__/parserUtils.test.ts
+++ b/packages/n4s/src/rules/parsers/__tests__/parserUtils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { mapPassing } from '../parserUtils';
+
+describe('mapPassing', () => {
+  it('wraps transformed output in a passing RuleRunReturn', () => {
+    const parser = mapPassing((value: string) => value.trim().toUpperCase());
+
+    expect(parser('  vest  ')).toEqual({
+      pass: true,
+      type: 'VEST',
+      message: undefined,
+      path: undefined,
+    });
+  });
+});

--- a/packages/n4s/src/rules/parsers/__tests__/stringParsers.test.ts
+++ b/packages/n4s/src/rules/parsers/__tests__/stringParsers.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  append,
+  normalizeWhitespace,
+  prepend,
+  removeNonAlphanumeric,
+  removeNonDigits,
+  removeNonLetters,
+  replace,
+  split,
+  stringParsers,
+  stripWhitespace,
+  toCamel,
+  toCapitalized,
+  toKebab,
+  toLower,
+  toPascal,
+  toSnake,
+  toTitle,
+  toUpper,
+  trim,
+  trimEnd,
+  trimStart,
+} from '../stringParsers';
+
+describe('string parsers', () => {
+  it('exports all string parser functions', () => {
+    expect(Object.keys(stringParsers).sort()).toEqual([
+      'append',
+      'normalizeWhitespace',
+      'prepend',
+      'removeNonAlphanumeric',
+      'removeNonDigits',
+      'removeNonLetters',
+      'replace',
+      'split',
+      'stripWhitespace',
+      'toCamel',
+      'toCapitalized',
+      'toKebab',
+      'toLower',
+      'toPascal',
+      'toSnake',
+      'toTitle',
+      'toUpper',
+      'trim',
+      'trimEnd',
+      'trimStart',
+    ]);
+  });
+
+  it('append', () => {
+    expect(append('vest', '-js').type).toBe('vest-js');
+  });
+
+  it('normalizeWhitespace', () => {
+    expect(normalizeWhitespace('  v   e   s t  ').type).toBe('v e s t');
+  });
+
+  it('prepend', () => {
+    expect(prepend('vest', 'hello-').type).toBe('hello-vest');
+  });
+
+  it('removeNonAlphanumeric', () => {
+    expect(removeNonAlphanumeric('v-e_s t!42').type).toBe('vest42');
+  });
+
+  it('removeNonDigits', () => {
+    expect(removeNonDigits('v1e2s3t').type).toBe('123');
+  });
+
+  it('removeNonLetters', () => {
+    expect(removeNonLetters('v1e_2s-3t!').type).toBe('vest');
+  });
+
+  it('replace', () => {
+    expect(replace('vest rocks', 'rocks', 'rules').type).toBe('vest rules');
+  });
+
+  it('split', () => {
+    expect(split('a,b,c', ',', 2).type).toEqual(['a', 'b']);
+  });
+
+  it('stripWhitespace', () => {
+    expect(stripWhitespace(' v e s t ').type).toBe('vest');
+  });
+
+  it('toCamel', () => {
+    expect(toCamel('hello_world-test').type).toBe('helloWorldTest');
+  });
+
+  it('toCapitalized', () => {
+    expect(toCapitalized('vEST').type).toBe('Vest');
+  });
+
+  it('toKebab', () => {
+    expect(toKebab('helloWorld Test').type).toBe('hello-world-test');
+  });
+
+  it('toLower', () => {
+    expect(toLower('VeSt').type).toBe('vest');
+  });
+
+  it('toPascal', () => {
+    expect(toPascal('hello_world-test').type).toBe('HelloWorldTest');
+  });
+
+  it('toSnake', () => {
+    expect(toSnake('helloWorld Test').type).toBe('hello_world_test');
+  });
+
+  it('toTitle', () => {
+    expect(toTitle('hELLO woRLD').type).toBe('Hello World');
+  });
+
+  it('toUpper', () => {
+    expect(toUpper('VeSt').type).toBe('VEST');
+  });
+
+  it('trim', () => {
+    expect(trim('  vest  ').type).toBe('vest');
+  });
+
+  it('trimEnd', () => {
+    expect(trimEnd('vest  ').type).toBe('vest');
+  });
+
+  it('trimStart', () => {
+    expect(trimStart('  vest').type).toBe('vest');
+  });
+});

--- a/packages/n4s/src/rules/parsers/__tests__/stringParsers.test.ts
+++ b/packages/n4s/src/rules/parsers/__tests__/stringParsers.test.ts
@@ -8,6 +8,7 @@ import {
   removeNonDigits,
   removeNonLetters,
   replace,
+  replaceAll,
   split,
   stringParsers,
   stripWhitespace,
@@ -34,6 +35,7 @@ describe('string parsers', () => {
       'removeNonDigits',
       'removeNonLetters',
       'replace',
+      'replaceAll',
       'split',
       'stripWhitespace',
       'toCamel',
@@ -78,6 +80,12 @@ describe('string parsers', () => {
     expect(replace('vest rocks', 'rocks', 'rules').type).toBe('vest rules');
   });
 
+  it('replaceAll', () => {
+    expect(replaceAll('vest vest vest', 'vest', 'n4s').type).toBe(
+      'n4s n4s n4s',
+    );
+  });
+
   it('split', () => {
     expect(split('a,b,c', ',', 2).type).toEqual(['a', 'b']);
   });
@@ -88,6 +96,10 @@ describe('string parsers', () => {
 
   it('toCamel', () => {
     expect(toCamel('hello_world-test').type).toBe('helloWorldTest');
+  });
+
+  it('toCamel handles leading whitespace', () => {
+    expect(toCamel(' foo bar').type).toBe('fooBar');
   });
 
   it('toCapitalized', () => {

--- a/packages/n4s/src/rules/parsers/__tests__/toBoolean.test.ts
+++ b/packages/n4s/src/rules/parsers/__tests__/toBoolean.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { toBoolean } from '../toBoolean';
+
+describe('toBoolean parser', () => {
+  it('parses boolean input', () => {
+    expect(toBoolean(true).type).toBe(true);
+    expect(toBoolean(false).type).toBe(false);
+  });
+
+  it('parses string input', () => {
+    expect(toBoolean('true').type).toBe(true);
+    expect(toBoolean('YES').type).toBe(true);
+    expect(toBoolean('0').type).toBe(false);
+    expect(toBoolean('off').type).toBe(false);
+  });
+
+  it('parses numeric input', () => {
+    expect(toBoolean(1).type).toBe(true);
+    expect(toBoolean(0).type).toBe(false);
+  });
+
+  it('fails for unsupported input', () => {
+    expect(toBoolean('unknown')).toEqual({
+      pass: false,
+      type: false,
+      message: 'Could not parse to boolean',
+      path: undefined,
+    });
+  });
+});

--- a/packages/n4s/src/rules/parsers/arrayParsers.ts
+++ b/packages/n4s/src/rules/parsers/arrayParsers.ts
@@ -1,0 +1,12 @@
+import { mapPassing } from './parserUtils';
+
+export const join = (value: unknown[], separator = ',') =>
+  mapPassing((current: unknown[]) => current.join(separator))(value);
+
+export const uniq = (value: unknown[]) =>
+  mapPassing((current: unknown[]) => [...new Set(current)])(value);
+
+export const arrayParsers = {
+  join,
+  uniq,
+} as const;

--- a/packages/n4s/src/rules/parsers/generalParsers.ts
+++ b/packages/n4s/src/rules/parsers/generalParsers.ts
@@ -1,0 +1,27 @@
+import { RuleRunReturn } from '../../utils/RuleRunReturn';
+import { toBoolean } from './toBoolean';
+
+export function defaultTo<TValue>(
+  value: TValue,
+  fallback: NonNullable<TValue>,
+): RuleRunReturn<NonNullable<TValue>> {
+  if (value == null) {
+    return RuleRunReturn.Passing(fallback);
+  }
+
+  return RuleRunReturn.Passing(value as NonNullable<TValue>);
+}
+
+export const toJSON = (value: string): RuleRunReturn<unknown> => {
+  try {
+    return RuleRunReturn.Passing(JSON.parse(value));
+  } catch {
+    return RuleRunReturn.Failing(value, 'Could not parse JSON');
+  }
+};
+
+export const generalParsers = {
+  defaultTo,
+  toBoolean,
+  toJSON,
+} as const;

--- a/packages/n4s/src/rules/parsers/generalParsers.ts
+++ b/packages/n4s/src/rules/parsers/generalParsers.ts
@@ -12,7 +12,7 @@ export function defaultTo<TValue>(
   return RuleRunReturn.Passing(value as NonNullable<TValue>);
 }
 
-export const toJSON = (value: string): RuleRunReturn<unknown> => {
+export const parseJSON = (value: string): RuleRunReturn<unknown> => {
   try {
     return RuleRunReturn.Passing(JSON.parse(value));
   } catch {
@@ -22,6 +22,6 @@ export const toJSON = (value: string): RuleRunReturn<unknown> => {
 
 export const generalParsers = {
   defaultTo,
+  parseJSON,
   toBoolean,
-  toJSON,
 } as const;

--- a/packages/n4s/src/rules/parsers/generalParsers.ts
+++ b/packages/n4s/src/rules/parsers/generalParsers.ts
@@ -1,4 +1,5 @@
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
+import { CHAIN_PREPEND } from './parserUtils';
 import { toBoolean } from './toBoolean';
 
 export function defaultTo<TValue>(
@@ -11,6 +12,8 @@ export function defaultTo<TValue>(
 
   return RuleRunReturn.Passing(value as NonNullable<TValue>);
 }
+
+(defaultTo as unknown as Record<symbol, boolean>)[CHAIN_PREPEND] = true;
 
 export const parseJSON = (value: string): RuleRunReturn<unknown> => {
   try {

--- a/packages/n4s/src/rules/parsers/numberParsers.ts
+++ b/packages/n4s/src/rules/parsers/numberParsers.ts
@@ -18,6 +18,17 @@ export const toAbsolute = (value: number) =>
   mapPassing((current: number) => Math.abs(current))(value);
 
 export const toDate = (value: unknown): RuleRunReturn<Date> => {
+  if (
+    typeof value !== 'string' &&
+    typeof value !== 'number' &&
+    !(value instanceof Date)
+  ) {
+    return RuleRunReturn.Failing(
+      new Date(NaN),
+      'Could not parse to Date: expected string, number, or Date',
+    );
+  }
+
   const parsed = new Date(value as string | number | Date);
   if (Number.isNaN(parsed.getTime())) {
     return RuleRunReturn.Failing(parsed, 'Could not parse to Date');
@@ -35,10 +46,21 @@ export const toFloat = (value: unknown): RuleRunReturn<number> => {
   return RuleRunReturn.Passing(parsed);
 };
 
+function isValidRadix(radix: number): boolean {
+  return Number.isInteger(radix) && radix >= 2 && radix <= 36;
+}
+
 export const toInteger = (
   value: unknown,
   radix = 10,
 ): RuleRunReturn<number> => {
+  if (!isValidRadix(radix)) {
+    return RuleRunReturn.Failing(
+      NaN,
+      'Invalid radix: must be an integer between 2 and 36',
+    );
+  }
+
   const parsed =
     typeof value === 'number'
       ? Math.trunc(value)

--- a/packages/n4s/src/rules/parsers/numberParsers.ts
+++ b/packages/n4s/src/rules/parsers/numberParsers.ts
@@ -1,0 +1,63 @@
+import { RuleRunReturn } from '../../utils/RuleRunReturn';
+
+import { mapPassing } from './parserUtils';
+
+export const ceil = (value: number) =>
+  mapPassing((current: number) => Math.ceil(current))(value);
+
+export const clamp = (value: number, min: number, max: number) =>
+  mapPassing((current: number) => Math.min(max, Math.max(min, current)))(value);
+
+export const floor = (value: number) =>
+  mapPassing((current: number) => Math.floor(current))(value);
+
+export const round = (value: number) =>
+  mapPassing((current: number) => Math.round(current))(value);
+
+export const toAbsolute = (value: number) =>
+  mapPassing((current: number) => Math.abs(current))(value);
+
+export const toDate = (value: unknown): RuleRunReturn<Date> => {
+  const parsed = new Date(value as string | number | Date);
+  if (Number.isNaN(parsed.getTime())) {
+    return RuleRunReturn.Failing(parsed, 'Could not parse to Date');
+  }
+
+  return RuleRunReturn.Passing(parsed);
+};
+
+export const toFloat = (value: unknown): RuleRunReturn<number> => {
+  const parsed = typeof value === 'number' ? value : parseFloat(String(value));
+  if (Number.isNaN(parsed)) {
+    return RuleRunReturn.Failing(NaN, 'Could not parse to float');
+  }
+
+  return RuleRunReturn.Passing(parsed);
+};
+
+export const toInteger = (
+  value: unknown,
+  radix = 10,
+): RuleRunReturn<number> => {
+  const parsed =
+    typeof value === 'number'
+      ? Math.trunc(value)
+      : parseInt(String(value), radix);
+
+  if (Number.isNaN(parsed)) {
+    return RuleRunReturn.Failing(NaN, 'Could not parse to integer');
+  }
+
+  return RuleRunReturn.Passing(parsed);
+};
+
+export const numberParsers = {
+  ceil,
+  clamp,
+  floor,
+  round,
+  toAbsolute,
+  toDate,
+  toFloat,
+  toInteger,
+} as const;

--- a/packages/n4s/src/rules/parsers/parserUtils.ts
+++ b/packages/n4s/src/rules/parsers/parserUtils.ts
@@ -1,0 +1,7 @@
+import { RuleRunReturn } from '../../utils/RuleRunReturn';
+
+export function mapPassing<TInput, TOutput>(
+  transform: (value: TInput) => TOutput,
+): (value: TInput) => RuleRunReturn<TOutput> {
+  return (value: TInput) => RuleRunReturn.Passing(transform(value));
+}

--- a/packages/n4s/src/rules/parsers/parserUtils.ts
+++ b/packages/n4s/src/rules/parsers/parserUtils.ts
@@ -1,5 +1,12 @@
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
+/**
+ * Marks a parser as a pre-type-check transform.
+ * Parsers tagged with this symbol are prepended to the chain
+ * so they run before type checks (e.g. defaultTo).
+ */
+export const CHAIN_PREPEND: unique symbol = Symbol('chainPrepend');
+
 export function mapPassing<TInput, TOutput>(
   transform: (value: TInput) => TOutput,
 ): (value: TInput) => RuleRunReturn<TOutput> {

--- a/packages/n4s/src/rules/parsers/stringParsers.ts
+++ b/packages/n4s/src/rules/parsers/stringParsers.ts
@@ -1,12 +1,10 @@
 import { mapPassing } from './parserUtils';
 
-const WORD_SEPARATOR_REGEX = /[\s_-]+(.)?/g;
-
 function toCamelCase(value: string): string {
   return value
     .trim()
     .toLowerCase()
-    .replace(WORD_SEPARATOR_REGEX, (_match, chr: string | undefined) =>
+    .replace(/[\s_-]+(.)?/g, (_match, chr: string | undefined) =>
       chr ? chr.toUpperCase() : '',
     );
 }
@@ -66,13 +64,13 @@ export const replaceAll = (
 ) =>
   mapPassing((current: string) =>
     typeof searchValue === 'string'
-      ? current.split(searchValue).join(replaceValue)
+      ? searchValue === ''
+        ? current
+        : current.split(searchValue).join(replaceValue)
       : current.replace(
           new RegExp(
             searchValue.source,
-            searchValue.flags.includes('g')
-              ? searchValue.flags
-              : searchValue.flags + 'g',
+            [...new Set(searchValue.flags + 'g')].join(''),
           ),
           replaceValue,
         ),

--- a/packages/n4s/src/rules/parsers/stringParsers.ts
+++ b/packages/n4s/src/rules/parsers/stringParsers.ts
@@ -4,6 +4,7 @@ const WORD_SEPARATOR_REGEX = /[\s_-]+(.)?/g;
 
 function toCamelCase(value: string): string {
   return value
+    .trim()
     .toLowerCase()
     .replace(WORD_SEPARATOR_REGEX, (_match, chr: string | undefined) =>
       chr ? chr.toUpperCase() : '',
@@ -58,6 +59,25 @@ export const replace = (
     value,
   );
 
+export const replaceAll = (
+  value: string,
+  searchValue: string | RegExp,
+  replaceValue: string,
+) =>
+  mapPassing((current: string) =>
+    typeof searchValue === 'string'
+      ? current.split(searchValue).join(replaceValue)
+      : current.replace(
+          new RegExp(
+            searchValue.source,
+            searchValue.flags.includes('g')
+              ? searchValue.flags
+              : searchValue.flags + 'g',
+          ),
+          replaceValue,
+        ),
+  )(value);
+
 export const split = (
   value: string,
   separator: string | RegExp,
@@ -90,10 +110,7 @@ export const toSnake = (value: string) =>
 
 export const toTitle = (value: string) =>
   mapPassing((current: string) =>
-    current
-      .toLowerCase()
-      .replace(/\b\w/g, char => char.toUpperCase())
-      .trim(),
+    current.toLowerCase().replace(/\b\w/g, char => char.toUpperCase()),
   )(value);
 
 export const toUpper = (value: string) =>
@@ -116,6 +133,7 @@ export const stringParsers = {
   removeNonDigits,
   removeNonLetters,
   replace,
+  replaceAll,
   split,
   stripWhitespace,
   toCamel,

--- a/packages/n4s/src/rules/parsers/stringParsers.ts
+++ b/packages/n4s/src/rules/parsers/stringParsers.ts
@@ -1,0 +1,132 @@
+import { mapPassing } from './parserUtils';
+
+const WORD_SEPARATOR_REGEX = /[\s_-]+(.)?/g;
+
+function toCamelCase(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(WORD_SEPARATOR_REGEX, (_match, chr: string | undefined) =>
+      chr ? chr.toUpperCase() : '',
+    );
+}
+
+function toPascalCase(value: string): string {
+  const camel = toCamelCase(value);
+  return camel.charAt(0).toUpperCase() + camel.slice(1);
+}
+
+function toSnakeCase(value: string): string {
+  return value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[\s-]+/g, '_')
+    .toLowerCase();
+}
+
+function toKebabCase(value: string): string {
+  return value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase();
+}
+
+export const append = (value: string, suffix: string) =>
+  mapPassing((current: string) => `${current}${suffix}`)(value);
+
+export const normalizeWhitespace = (value: string) =>
+  mapPassing((current: string) => current.replace(/\s+/g, ' ').trim())(value);
+
+export const prepend = (value: string, prefix: string) =>
+  mapPassing((current: string) => `${prefix}${current}`)(value);
+
+export const removeNonAlphanumeric = (value: string) =>
+  mapPassing((current: string) => current.replace(/[^a-zA-Z0-9]/g, ''))(value);
+
+export const removeNonDigits = (value: string) =>
+  mapPassing((current: string) => current.replace(/\D+/g, ''))(value);
+
+export const removeNonLetters = (value: string) =>
+  mapPassing((current: string) => current.replace(/[^a-zA-Z]/g, ''))(value);
+
+export const replace = (
+  value: string,
+  searchValue: string | RegExp,
+  replaceValue: string,
+) =>
+  mapPassing((current: string) => current.replace(searchValue, replaceValue))(
+    value,
+  );
+
+export const split = (
+  value: string,
+  separator: string | RegExp,
+  limit?: number,
+) => mapPassing((current: string) => current.split(separator, limit))(value);
+
+export const stripWhitespace = (value: string) =>
+  mapPassing((current: string) => current.replace(/\s+/g, ''))(value);
+
+export const toCamel = (value: string) =>
+  mapPassing((current: string) => toCamelCase(current))(value);
+
+export const toCapitalized = (value: string) =>
+  mapPassing(
+    (current: string) =>
+      current.charAt(0).toUpperCase() + current.slice(1).toLowerCase(),
+  )(value);
+
+export const toKebab = (value: string) =>
+  mapPassing((current: string) => toKebabCase(current))(value);
+
+export const toLower = (value: string) =>
+  mapPassing((current: string) => current.toLowerCase())(value);
+
+export const toPascal = (value: string) =>
+  mapPassing((current: string) => toPascalCase(current))(value);
+
+export const toSnake = (value: string) =>
+  mapPassing((current: string) => toSnakeCase(current))(value);
+
+export const toTitle = (value: string) =>
+  mapPassing((current: string) =>
+    current
+      .toLowerCase()
+      .replace(/\b\w/g, char => char.toUpperCase())
+      .trim(),
+  )(value);
+
+export const toUpper = (value: string) =>
+  mapPassing((current: string) => current.toUpperCase())(value);
+
+export const trim = (value: string) =>
+  mapPassing((current: string) => current.trim())(value);
+
+export const trimEnd = (value: string) =>
+  mapPassing((current: string) => current.trimEnd())(value);
+
+export const trimStart = (value: string) =>
+  mapPassing((current: string) => current.trimStart())(value);
+
+export const stringParsers = {
+  append,
+  normalizeWhitespace,
+  prepend,
+  removeNonAlphanumeric,
+  removeNonDigits,
+  removeNonLetters,
+  replace,
+  split,
+  stripWhitespace,
+  toCamel,
+  toCapitalized,
+  toKebab,
+  toLower,
+  toPascal,
+  toSnake,
+  toTitle,
+  toUpper,
+  trim,
+  trimEnd,
+  trimStart,
+} as const;

--- a/packages/n4s/src/rules/parsers/toBoolean.ts
+++ b/packages/n4s/src/rules/parsers/toBoolean.ts
@@ -1,11 +1,14 @@
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
+const TRUTHY_STRINGS = new Set(['true', '1', 'yes', 'on']);
+const FALSY_STRINGS = new Set(['false', '0', 'no', 'off']);
+
 function parseStringBoolean(value: string): boolean | undefined {
   const normalized = value.trim().toLowerCase();
-  if (['true', '1', 'yes', 'on'].includes(normalized)) {
+  if (TRUTHY_STRINGS.has(normalized)) {
     return true;
   }
-  if (['false', '0', 'no', 'off'].includes(normalized)) {
+  if (FALSY_STRINGS.has(normalized)) {
     return false;
   }
 

--- a/packages/n4s/src/rules/parsers/toBoolean.ts
+++ b/packages/n4s/src/rules/parsers/toBoolean.ts
@@ -1,0 +1,35 @@
+import { RuleRunReturn } from '../../utils/RuleRunReturn';
+
+function parseStringBoolean(value: string): boolean | undefined {
+  const normalized = value.trim().toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['false', '0', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return undefined;
+}
+
+function parseNumberBoolean(value: number): boolean | undefined {
+  if (value === 1) return true;
+  if (value === 0) return false;
+  return undefined;
+}
+
+function parseBooleanValue(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') return parseStringBoolean(value);
+  if (typeof value === 'number') return parseNumberBoolean(value);
+  return undefined;
+}
+
+export function toBoolean(value: unknown): RuleRunReturn<boolean> {
+  const parsed = parseBooleanValue(value);
+  if (parsed !== undefined) {
+    return RuleRunReturn.Passing(parsed);
+  }
+
+  return RuleRunReturn.Failing(false, 'Could not parse to boolean');
+}

--- a/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
@@ -143,4 +143,16 @@ describe('schema parse integration', () => {
       nickname: '',
     });
   });
+
+  it('defaultTo applies fallback for nullish values before type checks', () => {
+    const schema = enforce.shape({
+      label: enforce.isString().defaultTo('N/A'),
+    });
+
+    // @ts-expect-error - testing nullish input against string schema
+    expect(schema.parse({ label: null })).toEqual({ label: 'N/A' });
+    // @ts-expect-error - testing nullish input against string schema
+    expect(schema.parse({ label: undefined })).toEqual({ label: 'N/A' });
+    expect(schema.parse({ label: 'hello' })).toEqual({ label: 'hello' });
+  });
 });

--- a/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
@@ -121,7 +121,7 @@ describe('schema parse integration', () => {
       age: enforce.isNumeric().toNumber().clamp(0, 120),
       subscribed: enforce.isString().trim().toBoolean(),
       tags: enforce.isArray<string>().uniq().join('|'),
-      payload: enforce.isString().toJSON(),
+      payload: enforce.isString().parseJSON(),
       nickname: enforce.isString().trim().defaultTo('N/A'),
     });
 

--- a/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
@@ -114,4 +114,33 @@ describe('schema parse integration', () => {
       { name: 'John', age: 45 },
     ]);
   });
+
+  it('shape parses values with built-in lazy parser chains', () => {
+    const schema = enforce.shape({
+      name: enforce.isString().trim().toTitle(),
+      age: enforce.isNumeric().toNumber().clamp(0, 120),
+      subscribed: enforce.isString().trim().toBoolean(),
+      tags: enforce.isArray<string>().uniq().join('|'),
+      payload: enforce.isString().toJSON(),
+      nickname: enforce.isString().trim().defaultTo('N/A'),
+    });
+
+    const result = schema.parse({
+      name: '  jANE DOE ',
+      age: '180',
+      subscribed: ' yes ',
+      tags: ['vest', 'n4s', 'vest'],
+      payload: '{"env":"test"}',
+      nickname: '   ',
+    });
+
+    expect(result).toEqual({
+      name: 'Jane Doe',
+      age: 120,
+      subscribed: true,
+      tags: 'vest|n4s',
+      payload: { env: 'test' },
+      nickname: '',
+    });
+  });
 });

--- a/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { create, enforce, test } from '../../vest';
+import { enforce as n4sEnforce } from '../../../../n4s/src/n4s';
 
 describe('suite schema integration', () => {
   it('validates schema object and passes data into suite body', () => {
@@ -172,5 +173,90 @@ describe('suite schema integration', () => {
 
     expect(result.hasErrors()).toBe(true);
     expect(result.hasErrors('security')).toBe(true);
+  });
+
+  it('applies lazy parser chains before running the suite callback', () => {
+    const schema = n4sEnforce.shape({
+      age: n4sEnforce.isNumeric().toNumber().clamp(0, 120),
+      name: n4sEnforce.isString().trim().toTitle(),
+      subscribed: n4sEnforce.isString().trim().toBoolean(),
+      tags: n4sEnforce.isArray<string>().uniq().join('|'),
+      payload: n4sEnforce.isString().toJSON(),
+    });
+
+    let callbackData: any;
+
+    const suite = create((data: any) => {
+      callbackData = data;
+
+      test('age', () => {
+        enforce(data.age).equals(120);
+      });
+
+      test('name', () => {
+        enforce(data.name).equals('Jane Doe');
+      });
+
+      test('subscribed', () => {
+        enforce(data.subscribed).isTruthy();
+      });
+
+      test('tags', () => {
+        enforce(data.tags).equals('vest|n4s');
+      });
+
+      test('payload', () => {
+        enforce(data.payload.env).equals('test');
+      });
+    }, schema);
+
+    const result = suite.run({
+      // @ts-expect-error - input value is intentionally pre-parse
+      age: '180',
+      name: '  jANE DOE ',
+      // @ts-expect-error - input value is intentionally pre-parse
+      subscribed: ' yes ',
+      // @ts-expect-error - input value is intentionally pre-parse
+      tags: ['vest', 'n4s', 'vest'],
+      payload: '{"env":"test"}',
+    });
+
+    expect(callbackData).toEqual({
+      age: 120,
+      name: 'Jane Doe',
+      subscribed: true,
+      tags: 'vest|n4s',
+      payload: { env: 'test' },
+    });
+    expect(result.value).toEqual({
+      age: 120,
+      name: 'Jane Doe',
+      subscribed: true,
+      tags: 'vest|n4s',
+      payload: { env: 'test' },
+    });
+    expect(result.isValid()).toBe(true);
+  });
+
+  it('uses original data in callback when parser chain fails in schema parse', () => {
+    const schema = n4sEnforce.shape({
+      subscribed: n4sEnforce.isString().trim().toBoolean(),
+    });
+
+    let callbackData: any;
+
+    const suite = create((data: any) => {
+      callbackData = data;
+      test('subscribed', () => {
+        enforce(data.subscribed).isNotEmpty();
+      });
+    }, schema);
+
+    // @ts-expect-error - testing parser failure with pre-parse input
+    const result = suite.run({ subscribed: 'unknown' });
+
+    expect(callbackData).toEqual({ subscribed: 'unknown' });
+    expect(result.value).toBeUndefined();
+    expect(result.hasErrors('subscribed')).toBe(true);
   });
 });

--- a/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { create, enforce, test } from '../../vest';
-import { enforce as n4sEnforce } from '../../../../n4s/src/n4s';
+import { enforce as n4sEnforce } from 'n4s';
 
 describe('suite schema integration', () => {
   it('validates schema object and passes data into suite body', () => {
@@ -181,7 +181,7 @@ describe('suite schema integration', () => {
       name: n4sEnforce.isString().trim().toTitle(),
       subscribed: n4sEnforce.isString().trim().toBoolean(),
       tags: n4sEnforce.isArray<string>().uniq().join('|'),
-      payload: n4sEnforce.isString().toJSON(),
+      payload: n4sEnforce.isString().parseJSON(),
     });
 
     let callbackData: any;
@@ -211,12 +211,9 @@ describe('suite schema integration', () => {
     }, schema);
 
     const result = suite.run({
-      // @ts-expect-error - input value is intentionally pre-parse
       age: '180',
       name: '  jANE DOE ',
-      // @ts-expect-error - input value is intentionally pre-parse
       subscribed: ' yes ',
-      // @ts-expect-error - input value is intentionally pre-parse
       tags: ['vest', 'n4s', 'vest'],
       payload: '{"env":"test"}',
     });
@@ -252,7 +249,6 @@ describe('suite schema integration', () => {
       });
     }, schema);
 
-    // @ts-expect-error - testing parser failure with pre-parse input
     const result = suite.run({ subscribed: 'unknown' });
 
     expect(callbackData).toEqual({ subscribed: 'unknown' });

--- a/packages/vest/vitest.config.ts
+++ b/packages/vest/vitest.config.ts
@@ -10,15 +10,16 @@ export default defineConfig({
   resolve: {
     alias: {
       vest: resolve(__dirname, 'src/vest.ts'),
+      n4s: resolve(__dirname, '../n4s/src/n4s.ts'),
     },
   },
   root: __dirname,
   test: {
-    globals: true,
-    include: ['./**/__tests__/*.test.ts'],
     benchmark: {
       include: ['./bench/**/*.bench.ts'],
     },
+    globals: true,
+    include: ['./**/__tests__/*.test.ts'],
     setupFiles: [
       resolve(__dirname, '../../', 'vx/config/vitest/customMatchers.ts'),
     ],

--- a/website/docs/enforce/builtin-enforce-plugins/data_parsers.md
+++ b/website/docs/enforce/builtin-enforce-plugins/data_parsers.md
@@ -1,0 +1,442 @@
+---
+sidebar_position: 6
+title: Data Parsers
+description: Built-in data parsers for transforming values in enforce chains. Parsers coerce and reshape data as part of validation.
+keywords:
+  [
+    Vest,
+    enforce,
+    parsers,
+    transform,
+    trim,
+    toBoolean,
+    parseJSON,
+    clamp,
+    toTitle,
+    toCamel,
+    toKebab,
+    toSnake,
+    defaultTo,
+    n4s,
+  ]
+---
+
+# Data Parsers
+
+Data parsers transform values as they pass through an enforce chain. Unlike validation rules that only check whether a value is valid, parsers **coerce the value** into a new form — trimming whitespace, converting types, clamping numbers, and more.
+
+Parsers are available on **lazy chains** started with a type rule such as `enforce.isString()`, `enforce.isNumber()`, or `enforce.isArray()`. They are not available on eager `enforce(value)` chains.
+
+## Accessing parsed results
+
+Use `.run()` or `.parse()` to get the transformed output:
+
+```js
+// .run() returns { pass, type } — type holds the transformed value
+const result = enforce.isString().trim().toUpper().run('  hello  ');
+// result → { pass: true, type: 'HELLO' }
+
+// .parse() returns the transformed value directly, or throws on failure
+const value = enforce.isString().trim().toUpper().parse('  hello  ');
+// value → 'HELLO'
+```
+
+Parsers also work inside schema definitions, so `schema.parse(data)` returns a fully transformed object:
+
+```js
+const schema = enforce.shape({
+  name: enforce.isString().trim().toTitle(),
+  age: enforce.isNumeric().toNumber().clamp(0, 120),
+});
+
+schema.parse({ name: '  jANE DOE ', age: '180' });
+// → { name: 'Jane Doe', age: 120 }
+```
+
+---
+
+## String Parsers
+
+Available on `enforce.isString()` chains.
+
+### trim
+
+Removes leading and trailing whitespace.
+
+```js
+enforce.isString().trim().parse('  vest  ');
+// → 'vest'
+```
+
+### trimStart
+
+Removes leading whitespace only.
+
+```js
+enforce.isString().trimStart().parse('  vest');
+// → 'vest'
+```
+
+### trimEnd
+
+Removes trailing whitespace only.
+
+```js
+enforce.isString().trimEnd().parse('vest  ');
+// → 'vest'
+```
+
+### toUpper
+
+Converts to uppercase.
+
+```js
+enforce.isString().toUpper().parse('vest');
+// → 'VEST'
+```
+
+### toLower
+
+Converts to lowercase.
+
+```js
+enforce.isString().toLower().parse('VeSt');
+// → 'vest'
+```
+
+### toTitle
+
+Capitalizes the first letter of each word.
+
+```js
+enforce.isString().toTitle().parse('hello world');
+// → 'Hello World'
+```
+
+### toCapitalized
+
+Capitalizes the first character and lowercases the rest.
+
+```js
+enforce.isString().toCapitalized().parse('vEST');
+// → 'Vest'
+```
+
+### toCamel
+
+Converts to camelCase.
+
+```js
+enforce.isString().toCamel().parse('hello_world-test');
+// → 'helloWorldTest'
+```
+
+### toPascal
+
+Converts to PascalCase.
+
+```js
+enforce.isString().toPascal().parse('hello_world-test');
+// → 'HelloWorldTest'
+```
+
+### toSnake
+
+Converts to snake_case.
+
+```js
+enforce.isString().toSnake().parse('helloWorld Test');
+// → 'hello_world_test'
+```
+
+### toKebab
+
+Converts to kebab-case.
+
+```js
+enforce.isString().toKebab().parse('helloWorld Test');
+// → 'hello-world-test'
+```
+
+### append
+
+Appends a suffix string.
+
+```js
+enforce.isString().append('-js').parse('vest');
+// → 'vest-js'
+```
+
+### prepend
+
+Prepends a prefix string.
+
+```js
+enforce.isString().prepend('hello-').parse('vest');
+// → 'hello-vest'
+```
+
+### replace
+
+Replaces the first match of a search value.
+
+```js
+enforce.isString().replace('rocks', 'rules').parse('vest rocks');
+// → 'vest rules'
+```
+
+### replaceAll
+
+Replaces all occurrences of a search value.
+
+```js
+enforce.isString().replaceAll('vest', 'n4s').parse('vest vest vest');
+// → 'n4s n4s n4s'
+```
+
+### split
+
+Splits a string into an array by a separator. Accepts an optional limit.
+
+```js
+enforce.isString().split(',', 2).parse('a,b,c');
+// → ['a', 'b']
+```
+
+### normalizeWhitespace
+
+Collapses multiple whitespace characters into a single space and trims.
+
+```js
+enforce.isString().normalizeWhitespace().parse('  v   e   s t  ');
+// → 'v e s t'
+```
+
+### stripWhitespace
+
+Removes all whitespace characters.
+
+```js
+enforce.isString().stripWhitespace().parse(' v e s t ');
+// → 'vest'
+```
+
+### removeNonAlphanumeric
+
+Removes all characters that are not letters or digits.
+
+```js
+enforce.isString().removeNonAlphanumeric().parse('v-e_s t!42');
+// → 'vest42'
+```
+
+### removeNonDigits
+
+Removes all non-digit characters.
+
+```js
+enforce.isString().removeNonDigits().parse('v1e2s3t');
+// → '123'
+```
+
+### removeNonLetters
+
+Removes all non-letter characters.
+
+```js
+enforce.isString().removeNonLetters().parse('v1e_2s-3t!');
+// → 'vest'
+```
+
+---
+
+## Number Parsers
+
+Available on `enforce.isNumber()` and `enforce.isNumeric()` chains.
+
+### round
+
+Rounds to the nearest integer.
+
+```js
+enforce.isNumber().round().parse(2.5);
+// → 3
+```
+
+### ceil
+
+Rounds up to the next integer.
+
+```js
+enforce.isNumber().ceil().parse(2.1);
+// → 3
+```
+
+### floor
+
+Rounds down to the previous integer.
+
+```js
+enforce.isNumber().floor().parse(2.9);
+// → 2
+```
+
+### clamp
+
+Clamps a value between a minimum and maximum.
+
+```js
+enforce.isNumeric().toNumber().clamp(0, 100).parse('120');
+// → 100
+
+enforce.isNumber().clamp(0, 100).parse(-5);
+// → 0
+```
+
+### toAbsolute
+
+Returns the absolute value.
+
+```js
+enforce.isNumber().toAbsolute().parse(-15);
+// → 15
+```
+
+### toFloat
+
+Parses a value into a floating-point number. Fails if the result is `NaN`.
+
+```js
+enforce.isNumeric().toFloat().parse('10.5');
+// → 10.5
+```
+
+### toInteger
+
+Parses a value into an integer. Accepts an optional radix (2–36, default 10). Fails if the result is `NaN`.
+
+```js
+enforce.isNumeric().toInteger().parse('11.8');
+// → 11
+
+enforce.isNumeric().toInteger(2).parse('1011');
+// → 11
+```
+
+### toDate
+
+Parses a string, number, or Date into a `Date` object. Fails for invalid or non-date-like inputs.
+
+```js
+enforce.isNumber().toDate().parse(1704067200000);
+// → Date object (2024-01-01T00:00:00.000Z)
+```
+
+---
+
+## Array Parsers
+
+Available on `enforce.isArray()` chains.
+
+### uniq
+
+Removes duplicate elements (uses `Set`).
+
+```js
+enforce.isArray().uniq().parse(['a', 'a', 'b']);
+// → ['a', 'b']
+```
+
+### join
+
+Joins array elements into a string with a separator (default `','`).
+
+```js
+enforce.isArray().join('-').parse(['a', 'b', 'c']);
+// → 'a-b-c'
+```
+
+---
+
+## General Parsers
+
+Available on **all** typed chains (`isString`, `isNumber`, `isNumeric`, `isArray`).
+
+### toBoolean
+
+Parses a value into a boolean. Recognizes common truthy/falsy representations. Fails for unrecognized input.
+
+**Truthy values:** `true`, `1`, `'true'`, `'1'`, `'yes'`, `'on'`
+
+**Falsy values:** `false`, `0`, `'false'`, `'0'`, `'no'`, `'off'`
+
+```js
+enforce.isString().trim().toBoolean().parse(' yes ');
+// → true
+
+enforce.isString().trim().toBoolean().parse('0');
+// → false
+
+// Fails for unrecognized values:
+enforce.isString().toBoolean().run('unknown');
+// → { pass: false, type: false, message: 'Could not parse to boolean' }
+```
+
+### parseJSON
+
+Parses a JSON string into a JavaScript value. Fails if the input is not valid JSON.
+
+```js
+enforce.isString().parseJSON().parse('{"name":"vest"}');
+// → { name: 'vest' }
+```
+
+### defaultTo
+
+Provides a fallback value for `null` or `undefined` inputs. This parser runs **before** other rules in the chain, so the fallback is applied before type checks.
+
+```js
+const schema = enforce.shape({
+  label: enforce.isString().defaultTo('N/A'),
+});
+
+schema.parse({ label: null });
+// → { label: 'N/A' }
+
+schema.parse({ label: 'hello' });
+// → { label: 'hello' }
+```
+
+---
+
+## Chaining Parsers
+
+Parsers can be chained together to build transformation pipelines. Each parser receives the output of the previous one:
+
+```js
+const schema = enforce.shape({
+  name: enforce.isString().trim().toTitle(),
+  age: enforce.isNumeric().toNumber().clamp(0, 120),
+  subscribed: enforce.isString().trim().toBoolean(),
+  tags: enforce.isArray().uniq().join('|'),
+  payload: enforce.isString().parseJSON(),
+  nickname: enforce.isString().trim().defaultTo('N/A'),
+});
+
+schema.parse({
+  name: '  jANE DOE ',
+  age: '180',
+  subscribed: ' yes ',
+  tags: ['vest', 'n4s', 'vest'],
+  payload: '{"env":"test"}',
+  nickname: '   ',
+});
+// → {
+//   name: 'Jane Doe',
+//   age: 120,
+//   subscribed: true,
+//   tags: 'vest|n4s',
+//   payload: { env: 'test' },
+//   nickname: '',
+// }
+```

--- a/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
+++ b/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
@@ -135,3 +135,19 @@ enforce({ data: [1, 2, 3] }).shape({
   data: enforce.isArrayOf(enforce.isNumber()),
 });
 ```
+
+## Schema Parsing
+
+Schema rules can also **transform** values using built-in data parsers. Parsers like `trim()`, `toNumber()`, and `toBoolean()` coerce data as it passes through the chain, and `schema.parse()` returns the fully transformed result.
+
+```js
+const schema = enforce.shape({
+  name: enforce.isString().trim().toTitle(),
+  age: enforce.isNumeric().toNumber().clamp(0, 120),
+});
+
+schema.parse({ name: '  jANE DOE ', age: '180' });
+// → { name: 'Jane Doe', age: 120 }
+```
+
+See the full list of available parsers in [Data Parsers](./data_parsers.md).

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -141,3 +141,26 @@ suite.only('username').run({
 ## Inspecting schema results
 
 The suite result includes a `types` object that captures the validated `input` and coerced `output` from the schema run. This is useful for debugging and type-safe consumers.
+
+## Schema Parsing
+
+Schema rules support built-in [data parsers](../enforce/builtin-enforce-plugins/data_parsers.md) that transform values as part of validation. When a schema uses parsers, `suite.run()` receives the transformed data in the callback, and `result.value` contains the parsed output.
+
+```js
+import { create, test, enforce } from 'vest';
+
+const schema = enforce.shape({
+  name: enforce.isString().trim().toTitle(),
+  age: enforce.isNumeric().toNumber().clamp(0, 120),
+});
+
+const suite = create(data => {
+  // data is already parsed: { name: 'Jane Doe', age: 120 }
+  test('name', 'Name is required', () => {
+    enforce(data.name).isNotBlank();
+  });
+}, schema);
+
+const result = suite.run({ name: '  jANE DOE ', age: '180' });
+// result.value → { name: 'Jane Doe', age: 120 }
+```


### PR DESCRIPTION
### Motivation

- Provide a set of reusable parser functions (string, number, array, general) that can be composed lazily on top of existing type checks so values can be coerced/transformed after validation.
- Enable schema and suite parsing to apply those lazy parser chains before handing parsed data into consumers while preserving failure semantics.
- Centralize parser helpers (like `mapPassing`) and a robust `toBoolean` parser to standardize parsing behavior.

### Description

- Added parser utilities and implementations: `parserUtils.mapPassing`, `stringParsers`, `numberParsers`, `arrayParsers`, `generalParsers`, and `toBoolean` under `rules/parsers` to perform common transformations and parsing.
- Extended `typeRules` to compose rules + parsers into `lazyArrayRules`, `lazyNumberRules`, and `lazyStringRules`, added `Lazy*RuleInstance` types, and updated `isArray`, `isNumber`, `isNumeric`, and `isString` to return lazy-capable chains via `addToChain`.
- Added unit tests for all parser modules and utilities (`__tests__` under `rules/parsers`), a `lazyParsers.test.ts` for lazy-chain behavior, and updated integration tests in `schema.parse.integration.test.ts` and suite integration in `vest` to cover parser chains and failure semantics.

### Testing

- Ran unit tests for parser utilities and modules using `vitest`, including `stringParsers`, `numberParsers`, `arrayParsers`, `generalParsers`, `toBoolean`, and `parserUtils`, which all passed.
- Ran integration tests covering schema parsing and suite behavior (`schema.parse.integration.test.ts` and updated `vest` suite tests) to verify parser chains are applied before callbacks and that failures preserve original data, and they passed.
- Executed the lazy-chain behavior tests (`lazyParsers.test.ts`) to confirm lazy-only methods are not available on eager chains and parse failures throw as expected, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a43cbee9b88330ac4cdea1b19fb040)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded lazy parsers: many new string, number and array transforms (including replaceAll, uniq, join), general parsers (defaultTo, parseJSON, toBoolean) and a shared mapPassing helper.
  * Chain API: added prepend to control predicate order; parser chains run before schema callbacks (callbacks still receive original input when parsing fails).

* **Tests**
  * Added extensive unit and integration tests covering parsers and lazy-chain behavior.

* **Documentation**
  * New docs describing data parsers and schema parsing usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->