### PR TITLE
fix(core): ensure callback parameters are preserved during deferred callbacks execution

### DIFF
--- a/packages/vest-utils/src/__tests__/withCatch.test.ts
+++ b/packages/vest-utils/src/__tests__/withCatch.test.ts
@@ -14,4 +14,19 @@ describe('withCatch', () => {
     });
     expect(fn()).toBe(error);
   });
+
+  it('should pass arguments down to the callback', () => {
+    const fn = withCatch((a: number, b: string) => `${a}-${b}`);
+    expect(fn(1, 'b')).toBe('1-b');
+  });
+
+  it('should pass arguments to async deferred executions', async () => {
+    const fn = withCatch((a: number) => a * 2);
+
+    const result = await new Promise(resolve => {
+      setTimeout(() => resolve(fn(5)), 10);
+    });
+
+    expect(result).toBe(10);
+  });
 });

--- a/packages/vest-utils/src/withCatch.ts
+++ b/packages/vest-utils/src/withCatch.ts
@@ -1,9 +1,11 @@
 import { CB } from './utilityTypes';
 
-export function withCatch<T>(cb: CB<T>): () => T | unknown {
-  return () => {
+export function withCatch<F extends CB>(
+  cb: F,
+): (...args: Parameters<F>) => ReturnType<F> | unknown {
+  return (...args: Parameters<F>) => {
     try {
-      return cb();
+      return cb(...args);
     } catch (error) {
       return error;
     }

--- a/packages/vest/src/core/Runtime.ts
+++ b/packages/vest/src/core/Runtime.ts
@@ -11,7 +11,9 @@ import {
 import { TIsolateSuite } from './isolate/IsolateSuite/IsolateSuite';
 import { useReprocessTree } from './isolate/registerTests';
 
-export type DoneCallback = (res: SuiteResult<TFieldName, TGroupName>) => void;
+export type DoneCallback = (
+  res: SuiteResult<TFieldName, TGroupName, any, any>,
+) => void;
 type FieldCallbacks = Record<string, DoneCallbacks>;
 
 type DoneCallbacks = Array<DoneCallback>;

--- a/packages/vest/src/core/VestBus/VestBus.ts
+++ b/packages/vest/src/core/VestBus/VestBus.ts
@@ -14,6 +14,7 @@ import {
   useResetCallbacks,
   useResetSuite,
 } from '../Runtime';
+import { useCreateSuiteResult } from '../../suiteResult/suiteResult';
 import { TestWalker } from '../isolate/IsolateTest/TestWalker';
 import { VestTest } from '../isolate/IsolateTest/VestTest';
 
@@ -71,8 +72,9 @@ export function useInitVestBus() {
       if (!VestTest.isCanceled(isolate).unwrap()) {
         const { fieldName } = VestTest.getData(isolate);
 
-        useRunFieldCallbacks(fieldName);
-        useRunDoneCallbacks();
+        const result = useCreateSuiteResult();
+        useRunFieldCallbacks(fieldName, result);
+        useRunDoneCallbacks(result);
       }
     }
 
@@ -130,8 +132,9 @@ export function useInitVestBus() {
     }
 
     useOmitOptionalFields();
-    useRunSyncFieldCallbacks();
-    useRunDoneCallbacks();
+    const result = useCreateSuiteResult();
+    useRunSyncFieldCallbacks(result);
+    useRunDoneCallbacks(result);
   });
 
   VestBus.on('REMOVE_FIELD', (fieldName: TFieldName) => {

--- a/packages/vest/src/core/VestBus/VestBus.ts
+++ b/packages/vest/src/core/VestBus/VestBus.ts
@@ -72,7 +72,12 @@ export function useInitVestBus() {
       if (!VestTest.isCanceled(isolate).unwrap()) {
         const { fieldName } = VestTest.getData(isolate);
 
-        const result = useCreateSuiteResult();
+        useExpireSuiteResultCache();
+        const root = VestRuntime.useAvailableRoot<TIsolateSuite>();
+        const result = useCreateSuiteResult(
+          root?.data.schema,
+          root?.data.outputData,
+        );
         useRunFieldCallbacks(fieldName, result);
         useRunDoneCallbacks(result);
       }
@@ -132,7 +137,14 @@ export function useInitVestBus() {
     }
 
     useOmitOptionalFields();
-    const result = useCreateSuiteResult();
+
+    // Attempt extracting the snapshot of schema and raw params passed natively to cache
+    const root = VestRuntime.useAvailableRoot<TIsolateSuite>();
+    const result = useCreateSuiteResult(
+      root?.data.schema,
+      root?.data.outputData,
+    );
+
     useRunSyncFieldCallbacks(result);
     useRunDoneCallbacks(result);
   });

--- a/packages/vest/src/core/isolate/IsolateSuite/IsolateSuite.ts
+++ b/packages/vest/src/core/isolate/IsolateSuite/IsolateSuite.ts
@@ -19,6 +19,8 @@ import {
 export type TIsolateSuite = TVestIsolate<{
   optional: OptionalFields;
   resolver: CB<SuiteResult<TFieldName, TGroupName, any>>;
+  schema?: any;
+  outputData?: any;
   // Registry indices (populated by IsolateRegistry)
   registry_all?: RegistryIndex;
   registry_failed?: RegistryIndex;
@@ -33,10 +35,14 @@ export type TIsolateSuite = TVestIsolate<{
 export function IsolateSuite<Callback extends CB = CB>(
   callback: Callback,
   resolver: CB<SuiteResult<TFieldName, TGroupName, any>>,
+  schema?: any,
+  outputData?: any,
 ): TIsolateSuite {
   return createVestIsolate(VestIsolateType.Suite, callback, {
     optional: {},
     resolver,
+    schema,
+    outputData,
   });
 }
 

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -69,8 +69,14 @@ type FocusedMethods<
   T extends CB,
   S extends TSchema,
 > = {
-  afterEach: CB<FocusedMethods<F, G, T, S>, [callback: CB]>;
-  afterField: CB<FocusedMethods<F, G, T, S>, [fieldName: F, callback: CB]>;
+  afterEach: CB<
+    FocusedMethods<F, G, T, S>,
+    [callback: (res: SuiteResult<F, G, S>) => void]
+  >;
+  afterField: CB<
+    FocusedMethods<F, G, T, S>,
+    [fieldName: F, callback: (res: SuiteResult<F, G, S>) => void]
+  >;
   focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F, G>]>;
   only: CB<FocusedMethods<F, G, T, S>, [onlyField: FieldExclusion<F>]>;
   // run is included but runStatic is intentionally omitted: runStatic is stateless
@@ -88,8 +94,14 @@ type AfterMethods<
   T extends CB,
   S extends TSchema,
 > = {
-  afterEach: CB<AfterMethods<F, G, T, S>, [callback: CB]>;
-  afterField: CB<AfterMethods<F, G, T, S>, [fieldName: F, callback: CB]>;
+  afterEach: CB<
+    AfterMethods<F, G, T, S>,
+    [callback: (res: SuiteResult<F, G, S>) => void]
+  >;
+  afterField: CB<
+    AfterMethods<F, G, T, S>,
+    [fieldName: F, callback: (res: SuiteResult<F, G, S>) => void]
+  >;
   focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F, G>]>;
   only: CB<FocusedMethods<F, G, T, S>, [onlyField: FieldExclusion<F>]>;
   run: (

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -71,11 +71,11 @@ type FocusedMethods<
 > = {
   afterEach: CB<
     FocusedMethods<F, G, T, S>,
-    [callback: (res: SuiteResult<F, G, S>) => void]
+    [callback: (res: SuiteResult<F, G, S>) => unknown]
   >;
   afterField: CB<
     FocusedMethods<F, G, T, S>,
-    [fieldName: F, callback: (res: SuiteResult<F, G, S>) => void]
+    [fieldName: F, callback: (res: SuiteResult<F, G, S>) => unknown]
   >;
   focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F, G>]>;
   only: CB<FocusedMethods<F, G, T, S>, [onlyField: FieldExclusion<F>]>;
@@ -96,11 +96,11 @@ type AfterMethods<
 > = {
   afterEach: CB<
     AfterMethods<F, G, T, S>,
-    [callback: (res: SuiteResult<F, G, S>) => void]
+    [callback: (res: SuiteResult<F, G, S>) => unknown]
   >;
   afterField: CB<
     AfterMethods<F, G, T, S>,
-    [fieldName: F, callback: (res: SuiteResult<F, G, S>) => void]
+    [fieldName: F, callback: (res: SuiteResult<F, G, S>) => unknown]
   >;
   focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F, G>]>;
   only: CB<FocusedMethods<F, G, T, S>, [onlyField: FieldExclusion<F>]>;

--- a/packages/vest/src/suite/after/__tests__/afterEach.additional.test.ts
+++ b/packages/vest/src/suite/after/__tests__/afterEach.additional.test.ts
@@ -133,7 +133,7 @@ describe('afterEach - additional test coverage', () => {
   });
 
   describe('afterEach callback parameters', () => {
-    test('should not receive any arguments', () => {
+    test('should receive the suite result as an argument', () => {
       const callback = vi.fn();
 
       const suite = vest.create(() => {
@@ -151,7 +151,7 @@ describe('afterEach - additional test coverage', () => {
       expect(callback).toHaveBeenCalledOnce();
 
       const param = callback.mock.calls[0][0];
-      expect(param).toBeUndefined();
+      expect(param).toEqual(suite.get());
     });
   });
 });

--- a/packages/vest/src/suite/after/__tests__/afterEach.test.ts
+++ b/packages/vest/src/suite/after/__tests__/afterEach.test.ts
@@ -11,39 +11,61 @@ describe('afterEach', () => {
     it('should call the afterEach callback immediately once', async () => {
       const afterCallback = vi.fn();
 
-      const res = vest
-        .create(() => {
-          dummyTest.passing();
-          dummyTest.passing();
-          dummyTest.failing();
-          dummyTest.failing();
-          dummyTest.passing();
-          dummyTest.failingWarning('field_2');
-        })
-        .afterEach(afterCallback)
-        .run();
+      const suite = vest.create(() => {
+        dummyTest.passing();
+        dummyTest.passing();
+        dummyTest.failing();
+        dummyTest.failing();
+        dummyTest.passing();
+        dummyTest.failingWarning('field_2');
+      });
+
+      const res = suite.afterEach(afterCallback).run();
 
       expect(afterCallback).toHaveBeenCalledOnce();
 
       await res;
       expect(afterCallback).toHaveBeenCalledOnce();
+      expect(afterCallback.mock.calls[0][0]).toEqual(suite.get());
     });
   });
 
   describe('When both sync and async tests', () => {
     it('should call the `afterEach` callback once when the sync tests are done and again for each async test', async () => {
-      const afterCallback = vi.fn();
-      const suite = vest.create(() => {
+      const control = vi.fn();
+      let suite: ReturnType<typeof vest.create>;
+      const afterCallback = vi.fn((res: ReturnType<typeof suite.get>) => {
+        expect(res).toEqual(suite.get());
+        control();
+      });
+      suite = vest.create(() => {
         dummyTest.passing();
         dummyTest.failingAsync('field_1', { time: 10 });
         dummyTest.failingAsync('field_2', { time: 15 });
       });
       suite.afterEach(afterCallback).run();
       expect(afterCallback).toHaveBeenCalledTimes(1);
+      expect(control).toHaveBeenCalledTimes(1);
+
+      const res1 = afterCallback.mock.calls[0][0];
+      expect(res1).toEqual(suite.get());
+      expect(res1.hasErrors()).toBe(false);
+
       await wait(10);
       expect(afterCallback).toHaveBeenCalledTimes(2);
+      expect(control).toHaveBeenCalledTimes(2);
+
+      const res2 = afterCallback.mock.calls[1][0];
+      expect(res2).toEqual(suite.get());
+      expect(res2.hasErrors('field_1')).toBe(true);
+
       await wait(10);
       expect(afterCallback).toHaveBeenCalledTimes(3);
+      expect(control).toHaveBeenCalledTimes(3);
+
+      const res3 = afterCallback.mock.calls[2][0];
+      expect(res3).toEqual(suite.get());
+      expect(res3.hasErrors('field_2')).toBe(true);
     });
   });
 

--- a/packages/vest/src/suite/after/__tests__/afterEach.test.ts
+++ b/packages/vest/src/suite/after/__tests__/afterEach.test.ts
@@ -33,15 +33,14 @@ describe('afterEach', () => {
   describe('When both sync and async tests', () => {
     it('should call the `afterEach` callback once when the sync tests are done and again for each async test', async () => {
       const control = vi.fn();
-      let suite: ReturnType<typeof vest.create>;
-      const afterCallback = vi.fn((res: ReturnType<typeof suite.get>) => {
-        expect(res).toEqual(suite.get());
-        control();
-      });
-      suite = vest.create(() => {
+      const suite = vest.create(() => {
         dummyTest.passing();
         dummyTest.failingAsync('field_1', { time: 10 });
         dummyTest.failingAsync('field_2', { time: 15 });
+      });
+      const afterCallback = vi.fn((res: ReturnType<typeof suite.get>) => {
+        expect(res).toEqual(suite.get());
+        control();
       });
       suite.afterEach(afterCallback).run();
       expect(afterCallback).toHaveBeenCalledTimes(1);

--- a/packages/vest/src/suite/after/__tests__/afterField.test.ts
+++ b/packages/vest/src/suite/after/__tests__/afterField.test.ts
@@ -35,7 +35,7 @@ describe('afterField', () => {
         const control = vi.fn();
         const suite = vest.create(() => {
           vest.test('field_1' as TFieldName, async () => {
-            await wait(100);
+            await wait(200);
           });
           vest.test('field_2' as TFieldName, () => {});
           vest.test('field_3' as TFieldName, async () => {
@@ -62,7 +62,7 @@ describe('afterField', () => {
         expect(control).toHaveBeenCalledTimes(1);
         expect(cb3).not.toHaveBeenCalled();
 
-        await wait(55);
+        await wait(100);
         expect(cb3).toHaveBeenCalled();
         expect(cb3.mock.calls[0][0]).toEqual(suite.get());
         expect(control).toHaveBeenCalledTimes(2);
@@ -94,6 +94,8 @@ describe('afterField', () => {
 
         // Calling run again cancels the pending async tests from the previous run
         suite.run();
+
+        await wait(15);
 
         expect(cb1).not.toHaveBeenCalled();
         expect(cb2).not.toHaveBeenCalled();

--- a/packages/vest/src/suite/after/__tests__/afterField.test.ts
+++ b/packages/vest/src/suite/after/__tests__/afterField.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+import wait from 'wait';
+
+import { TFieldName } from '../../../suiteResult/SuiteResultTypes';
+import { dummyTest } from '../../../testUtils/testDummy';
+import * as vest from '../../../vest';
+
+describe('afterField', () => {
+  describe('Runtime behavior', () => {
+    describe('When no async tests for the field', () => {
+      it('should call the afterField callback immediately once', async () => {
+        const afterCallback = vi.fn();
+
+        const suite = vest.create(() => {
+          dummyTest.passing('field_1');
+          dummyTest.passing('field_1');
+          dummyTest.failing('field_2');
+        });
+
+        const res = suite
+          .afterField('field_1' as TFieldName, afterCallback)
+          .run();
+
+        expect(afterCallback).toHaveBeenCalledOnce();
+        expect(afterCallback.mock.calls[0][0]).toEqual(suite.get());
+
+        await res;
+        expect(afterCallback).toHaveBeenCalledOnce();
+        expect(afterCallback.mock.calls[0][0]).toEqual(suite.get());
+      });
+    });
+
+    describe('When there are async tests for the field', () => {
+      it('Should only run field callbacks for completed tests', async () => {
+        const control = vi.fn();
+        let suite: ReturnType<typeof vest.create>;
+
+        const cb2 = vi.fn((res: ReturnType<typeof suite.get>) => {
+          expect(res).toEqual(suite.get());
+          control();
+        });
+        const cb3 = vi.fn((res: ReturnType<typeof suite.get>) => {
+          expect(res).toEqual(suite.get());
+          control();
+        });
+
+        suite = vest.create(() => {
+          vest.test('field_1' as TFieldName, async () => {
+            await wait(100);
+          });
+          vest.test('field_2' as TFieldName, () => {});
+          vest.test('field_3' as TFieldName, async () => {
+            await wait(50);
+          });
+        });
+
+        suite
+          .afterField('field_2' as TFieldName, cb2)
+          .afterField('field_3' as TFieldName, cb3)
+          .run();
+
+        expect(cb2).toHaveBeenCalled();
+        expect(cb2.mock.calls[0][0]).toEqual(suite.get());
+        expect(control).toHaveBeenCalledTimes(1);
+        expect(cb3).not.toHaveBeenCalled();
+
+        await wait(55);
+        expect(cb3).toHaveBeenCalled();
+        expect(cb3.mock.calls[0][0]).toEqual(suite.get());
+        expect(control).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('When the test run was canceled', () => {
+      it('Should not run the field callbacks of the canceled run', async () => {
+        const cb1 = vi.fn();
+        const cb2 = vi.fn();
+        const cb3 = vi.fn();
+
+        const suite = vest.create(() => {
+          vest.test('field_1' as TFieldName, async () => {
+            await wait(10);
+          });
+          vest.test('field_2' as TFieldName, () => {});
+        });
+
+        suite
+          .afterField('field_1' as TFieldName, cb1)
+          .afterField('field_1' as TFieldName, cb2)
+          .afterField('field_1' as TFieldName, cb3)
+          .run();
+
+        expect(cb1).not.toHaveBeenCalled();
+        expect(cb2).not.toHaveBeenCalled();
+        expect(cb3).not.toHaveBeenCalled();
+
+        // Calling run again cancels the pending async tests from the previous run
+        suite.run();
+
+        expect(cb1).not.toHaveBeenCalled();
+        expect(cb2).not.toHaveBeenCalled();
+        expect(cb3).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Typing examples', () => {
+    it('Pattern 1: Escape hatch — create<null>()', () => {
+      const suite = vest.create<null>((_data: any) => {
+        vest.test('dynamic_field', () => {});
+      });
+
+      // Suite-level APIs all accept any string
+      suite.afterField('dynamic_field', () => {});
+      suite.afterField('anything_else', () => {});
+    });
+
+    it('Pattern 2: Config generic — create<{ fields; groups }>()', () => {
+      const suite = vest.create<{
+        fields: 'username' | 'password';
+        groups: 'auth';
+      }>((_data: unknown) => {
+        vest.test('username', () => {});
+      });
+
+      suite.afterField('password', () => {});
+      suite.afterField('username', () => {});
+
+      // @ts-expect-error - invalid field for suite.afterField
+      suite.afterField('invalid', () => {});
+    });
+
+    it('Pattern 3: Schema inferred — create(cb, schema)', () => {
+      const schema = vest.enforce.shape({
+        firstName: vest.enforce.isString(),
+        age: vest.enforce.isNumber(),
+      });
+
+      const suite = vest.create(data => {
+        vest.test('firstName', () => {
+          vest.enforce(data.firstName).isNotBlank();
+        });
+      }, schema);
+
+      suite.afterField('age', () => {});
+      suite.afterField('firstName', () => {
+        const result = suite.get();
+        result.hasErrors('firstName');
+        result.getErrors('age');
+
+        // @ts-expect-error - unknown field
+        result.hasErrors('invalid');
+      });
+
+      // @ts-expect-error - unknown field for suite.afterField
+      suite.afterField('unknown', () => {});
+    });
+
+    it('Pattern 4: Untyped fallback — create(cb)', () => {
+      const suite = vest.create((_data: any) => {
+        vest.test('whatever', () => {});
+      });
+
+      suite.afterField('whatever', () => {});
+      suite.afterField('other', () => {});
+    });
+  });
+});

--- a/packages/vest/src/suite/after/__tests__/afterField.test.ts
+++ b/packages/vest/src/suite/after/__tests__/afterField.test.ts
@@ -33,7 +33,15 @@ describe('afterField', () => {
     describe('When there are async tests for the field', () => {
       it('Should only run field callbacks for completed tests', async () => {
         const control = vi.fn();
-        let suite: ReturnType<typeof vest.create>;
+        const suite = vest.create(() => {
+          vest.test('field_1' as TFieldName, async () => {
+            await wait(100);
+          });
+          vest.test('field_2' as TFieldName, () => {});
+          vest.test('field_3' as TFieldName, async () => {
+            await wait(50);
+          });
+        });
 
         const cb2 = vi.fn((res: ReturnType<typeof suite.get>) => {
           expect(res).toEqual(suite.get());
@@ -42,16 +50,6 @@ describe('afterField', () => {
         const cb3 = vi.fn((res: ReturnType<typeof suite.get>) => {
           expect(res).toEqual(suite.get());
           control();
-        });
-
-        suite = vest.create(() => {
-          vest.test('field_1' as TFieldName, async () => {
-            await wait(100);
-          });
-          vest.test('field_2' as TFieldName, () => {});
-          vest.test('field_3' as TFieldName, async () => {
-            await wait(50);
-          });
         });
 
         suite

--- a/packages/vest/src/suite/runCallbacks.ts
+++ b/packages/vest/src/suite/runCallbacks.ts
@@ -1,17 +1,23 @@
-import { isArray, callEach, greaterThan } from 'vest-utils';
+import { isArray } from 'vest-utils';
 
 import { useDoneCallbacks, useFieldCallbacks } from '../core/Runtime';
-import { TFieldName } from '../suiteResult/SuiteResultTypes';
-import { useCreateSuiteResult } from '../suiteResult/suiteResult';
+import {
+  SuiteResult,
+  TFieldName,
+  TGroupName,
+} from '../suiteResult/SuiteResultTypes';
 
 /**
  * Runs done callback per field when async tests are finished running.
  */
-export function useRunFieldCallbacks(fieldName: TFieldName): void {
+export function useRunFieldCallbacks(
+  fieldName: TFieldName,
+  result: SuiteResult<TFieldName, TGroupName>,
+): void {
   const [fieldCallbacks] = useFieldCallbacks();
 
   if (isArray(fieldCallbacks[fieldName])) {
-    callEach(fieldCallbacks[fieldName]);
+    fieldCallbacks[fieldName].forEach(cb => cb(result));
   }
 }
 
@@ -19,9 +25,10 @@ export function useRunFieldCallbacks(fieldName: TFieldName): void {
  * Runs field callbacks (done callbacks) that can be executed immediately.
  * This happens when a field has non-pending tests (synchronous tests).
  */
-export function useRunSyncFieldCallbacks(): void {
+export function useRunSyncFieldCallbacks(
+  result: SuiteResult<TFieldName, TGroupName>,
+): void {
   const [fieldCallbacks] = useFieldCallbacks();
-  const result = useCreateSuiteResult();
 
   // Iterate over all fields that have registered done callbacks
   for (const fieldName in fieldCallbacks) {
@@ -37,13 +44,10 @@ export function useRunSyncFieldCallbacks(): void {
       // pendingCount is the number of tests currently running (async).
       // If testCount > pendingCount, it means there is at least one test
       // that has already finished (synchronous), so we can run the callbacks.
-      if (
-        testSummary &&
-        greaterThan(testSummary.testCount, testSummary.pendingCount)
-      ) {
+      if (testSummary && testSummary.testCount > testSummary.pendingCount) {
         // Execute all registered callbacks for this field.
         // This is the "nested loop" that iterates over the callbacks array.
-        callEach(callbacks);
+        callbacks.forEach(cb => cb(result));
       }
     }
   }
@@ -52,8 +56,10 @@ export function useRunSyncFieldCallbacks(): void {
 /**
  * Runs unlabelled done callback when async tests are finished running.
  */
-export function useRunDoneCallbacks() {
+export function useRunDoneCallbacks(
+  result: SuiteResult<TFieldName, TGroupName>,
+) {
   const [doneCallbacks] = useDoneCallbacks();
 
-  callEach(doneCallbacks);
+  doneCallbacks.forEach(cb => cb(result));
 }

--- a/packages/vest/src/suite/runCallbacks.ts
+++ b/packages/vest/src/suite/runCallbacks.ts
@@ -12,7 +12,7 @@ import {
  */
 export function useRunFieldCallbacks(
   fieldName: TFieldName,
-  result: SuiteResult<TFieldName, TGroupName>,
+  result: SuiteResult<TFieldName, TGroupName, any, any>,
 ): void {
   const [fieldCallbacks] = useFieldCallbacks();
 
@@ -26,7 +26,7 @@ export function useRunFieldCallbacks(
  * This happens when a field has non-pending tests (synchronous tests).
  */
 export function useRunSyncFieldCallbacks(
-  result: SuiteResult<TFieldName, TGroupName>,
+  result: SuiteResult<TFieldName, TGroupName, any, any>,
 ): void {
   const [fieldCallbacks] = useFieldCallbacks();
 
@@ -57,7 +57,7 @@ export function useRunSyncFieldCallbacks(
  * Runs unlabelled done callback when async tests are finished running.
  */
 export function useRunDoneCallbacks(
-  result: SuiteResult<TFieldName, TGroupName>,
+  result: SuiteResult<TFieldName, TGroupName, any, any>,
 ) {
   const [doneCallbacks] = useDoneCallbacks();
 

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -103,6 +103,8 @@ export function useCreateSuiteRunner<
             useResolver,
           }),
           useResolver,
+          schema,
+          callbackInput,
         ).output;
       },
     );

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -508,6 +508,429 @@ value = "12"   -> 🚨 (value is a string and longer than 1)
 ```
 
 
+# Data Parsers
+
+# Data Parsers
+
+Data parsers transform values as they pass through an enforce chain. Unlike validation rules that only check whether a value is valid, parsers **coerce the value** into a new form — trimming whitespace, converting types, clamping numbers, and more.
+
+Parsers are available on **lazy chains** started with a type rule such as `enforce.isString()`, `enforce.isNumber()`, or `enforce.isArray()`. They are not available on eager `enforce(value)` chains.
+
+## Accessing parsed results
+
+Use `.run()` or `.parse()` to get the transformed output:
+
+```js
+// .run() returns { pass, type } — type holds the transformed value
+const result = enforce.isString().trim().toUpper().run('  hello  ');
+// result → { pass: true, type: 'HELLO' }
+
+// .parse() returns the transformed value directly, or throws on failure
+const value = enforce.isString().trim().toUpper().parse('  hello  ');
+// value → 'HELLO'
+```
+
+Parsers also work inside schema definitions, so `schema.parse(data)` returns a fully transformed object:
+
+```js
+const schema = enforce.shape({
+  name: enforce.isString().trim().toTitle(),
+  age: enforce.isNumeric().toNumber().clamp(0, 120),
+});
+
+schema.parse({ name: '  jANE DOE ', age: '180' });
+// → { name: 'Jane Doe', age: 120 }
+```
+
+---
+
+## String Parsers
+
+Available on `enforce.isString()` chains.
+
+### trim
+
+Removes leading and trailing whitespace.
+
+```js
+enforce.isString().trim().parse('  vest  ');
+// → 'vest'
+```
+
+### trimStart
+
+Removes leading whitespace only.
+
+```js
+enforce.isString().trimStart().parse('  vest');
+// → 'vest'
+```
+
+### trimEnd
+
+Removes trailing whitespace only.
+
+```js
+enforce.isString().trimEnd().parse('vest  ');
+// → 'vest'
+```
+
+### toUpper
+
+Converts to uppercase.
+
+```js
+enforce.isString().toUpper().parse('vest');
+// → 'VEST'
+```
+
+### toLower
+
+Converts to lowercase.
+
+```js
+enforce.isString().toLower().parse('VeSt');
+// → 'vest'
+```
+
+### toTitle
+
+Capitalizes the first letter of each word.
+
+```js
+enforce.isString().toTitle().parse('hello world');
+// → 'Hello World'
+```
+
+### toCapitalized
+
+Capitalizes the first character and lowercases the rest.
+
+```js
+enforce.isString().toCapitalized().parse('vEST');
+// → 'Vest'
+```
+
+### toCamel
+
+Converts to camelCase.
+
+```js
+enforce.isString().toCamel().parse('hello_world-test');
+// → 'helloWorldTest'
+```
+
+### toPascal
+
+Converts to PascalCase.
+
+```js
+enforce.isString().toPascal().parse('hello_world-test');
+// → 'HelloWorldTest'
+```
+
+### toSnake
+
+Converts to snake_case.
+
+```js
+enforce.isString().toSnake().parse('helloWorld Test');
+// → 'hello_world_test'
+```
+
+### toKebab
+
+Converts to kebab-case.
+
+```js
+enforce.isString().toKebab().parse('helloWorld Test');
+// → 'hello-world-test'
+```
+
+### append
+
+Appends a suffix string.
+
+```js
+enforce.isString().append('-js').parse('vest');
+// → 'vest-js'
+```
+
+### prepend
+
+Prepends a prefix string.
+
+```js
+enforce.isString().prepend('hello-').parse('vest');
+// → 'hello-vest'
+```
+
+### replace
+
+Replaces the first match of a search value.
+
+```js
+enforce.isString().replace('rocks', 'rules').parse('vest rocks');
+// → 'vest rules'
+```
+
+### replaceAll
+
+Replaces all occurrences of a search value.
+
+```js
+enforce.isString().replaceAll('vest', 'n4s').parse('vest vest vest');
+// → 'n4s n4s n4s'
+```
+
+### split
+
+Splits a string into an array by a separator. Accepts an optional limit.
+
+```js
+enforce.isString().split(',', 2).parse('a,b,c');
+// → ['a', 'b']
+```
+
+### normalizeWhitespace
+
+Collapses multiple whitespace characters into a single space and trims.
+
+```js
+enforce.isString().normalizeWhitespace().parse('  v   e   s t  ');
+// → 'v e s t'
+```
+
+### stripWhitespace
+
+Removes all whitespace characters.
+
+```js
+enforce.isString().stripWhitespace().parse(' v e s t ');
+// → 'vest'
+```
+
+### removeNonAlphanumeric
+
+Removes all characters that are not letters or digits.
+
+```js
+enforce.isString().removeNonAlphanumeric().parse('v-e_s t!42');
+// → 'vest42'
+```
+
+### removeNonDigits
+
+Removes all non-digit characters.
+
+```js
+enforce.isString().removeNonDigits().parse('v1e2s3t');
+// → '123'
+```
+
+### removeNonLetters
+
+Removes all non-letter characters.
+
+```js
+enforce.isString().removeNonLetters().parse('v1e_2s-3t!');
+// → 'vest'
+```
+
+---
+
+## Number Parsers
+
+Available on `enforce.isNumber()` and `enforce.isNumeric()` chains.
+
+### round
+
+Rounds to the nearest integer.
+
+```js
+enforce.isNumber().round().parse(2.5);
+// → 3
+```
+
+### ceil
+
+Rounds up to the next integer.
+
+```js
+enforce.isNumber().ceil().parse(2.1);
+// → 3
+```
+
+### floor
+
+Rounds down to the previous integer.
+
+```js
+enforce.isNumber().floor().parse(2.9);
+// → 2
+```
+
+### clamp
+
+Clamps a value between a minimum and maximum.
+
+```js
+enforce.isNumeric().toNumber().clamp(0, 100).parse('120');
+// → 100
+
+enforce.isNumber().clamp(0, 100).parse(-5);
+// → 0
+```
+
+### toAbsolute
+
+Returns the absolute value.
+
+```js
+enforce.isNumber().toAbsolute().parse(-15);
+// → 15
+```
+
+### toFloat
+
+Parses a value into a floating-point number. Fails if the result is `NaN`.
+
+```js
+enforce.isNumeric().toFloat().parse('10.5');
+// → 10.5
+```
+
+### toInteger
+
+Parses a value into an integer. Accepts an optional radix (2–36, default 10). Fails if the result is `NaN`.
+
+```js
+enforce.isNumeric().toInteger().parse('11.8');
+// → 11
+
+enforce.isNumeric().toInteger(2).parse('1011');
+// → 11
+```
+
+### toDate
+
+Parses a string, number, or Date into a `Date` object. Fails for invalid or non-date-like inputs.
+
+```js
+enforce.isNumber().toDate().parse(1704067200000);
+// → Date object (2024-01-01T00:00:00.000Z)
+```
+
+---
+
+## Array Parsers
+
+Available on `enforce.isArray()` chains.
+
+### uniq
+
+Removes duplicate elements (uses `Set`).
+
+```js
+enforce.isArray().uniq().parse(['a', 'a', 'b']);
+// → ['a', 'b']
+```
+
+### join
+
+Joins array elements into a string with a separator (default `','`).
+
+```js
+enforce.isArray().join('-').parse(['a', 'b', 'c']);
+// → 'a-b-c'
+```
+
+---
+
+## General Parsers
+
+Available on **all** typed chains (`isString`, `isNumber`, `isNumeric`, `isArray`).
+
+### toBoolean
+
+Parses a value into a boolean. Recognizes common truthy/falsy representations. Fails for unrecognized input.
+
+**Truthy values:** `true`, `1`, `'true'`, `'1'`, `'yes'`, `'on'`
+
+**Falsy values:** `false`, `0`, `'false'`, `'0'`, `'no'`, `'off'`
+
+```js
+enforce.isString().trim().toBoolean().parse(' yes ');
+// → true
+
+enforce.isString().trim().toBoolean().parse('0');
+// → false
+
+// Fails for unrecognized values:
+enforce.isString().toBoolean().run('unknown');
+// → { pass: false, type: false, message: 'Could not parse to boolean' }
+```
+
+### parseJSON
+
+Parses a JSON string into a JavaScript value. Fails if the input is not valid JSON.
+
+```js
+enforce.isString().parseJSON().parse('{"name":"vest"}');
+// → { name: 'vest' }
+```
+
+### defaultTo
+
+Provides a fallback value for `null` or `undefined` inputs. This parser runs **before** other rules in the chain, so the fallback is applied before type checks.
+
+```js
+const schema = enforce.shape({
+  label: enforce.isString().defaultTo('N/A'),
+});
+
+schema.parse({ label: null });
+// → { label: 'N/A' }
+
+schema.parse({ label: 'hello' });
+// → { label: 'hello' }
+```
+
+---
+
+## Chaining Parsers
+
+Parsers can be chained together to build transformation pipelines. Each parser receives the output of the previous one:
+
+```js
+const schema = enforce.shape({
+  name: enforce.isString().trim().toTitle(),
+  age: enforce.isNumeric().toNumber().clamp(0, 120),
+  subscribed: enforce.isString().trim().toBoolean(),
+  tags: enforce.isArray().uniq().join('|'),
+  payload: enforce.isString().parseJSON(),
+  nickname: enforce.isString().trim().defaultTo('N/A'),
+});
+
+schema.parse({
+  name: '  jANE DOE ',
+  age: '180',
+  subscribed: ' yes ',
+  tags: ['vest', 'n4s', 'vest'],
+  payload: '{"env":"test"}',
+  nickname: '   ',
+});
+// → {
+//   name: 'Jane Doe',
+//   age: 120,
+//   subscribed: true,
+//   tags: 'vest|n4s',
+//   payload: { env: 'test' },
+//   nickname: '',
+// }
+```
+
+
 # Date Enforce Rules
 
 # Date Enforce Rules
@@ -911,6 +1334,22 @@ enforce({ data: [1, 2, 3] }).shape({
   data: enforce.isArrayOf(enforce.isNumber()),
 });
 ```
+
+## Schema Parsing
+
+Schema rules can also **transform** values using built-in data parsers. Parsers like `trim()`, `toNumber()`, and `toBoolean()` coerce data as it passes through the chain, and `schema.parse()` returns the fully transformed result.
+
+```js
+const schema = enforce.shape({
+  name: enforce.isString().trim().toTitle(),
+  age: enforce.isNumeric().toNumber().clamp(0, 120),
+});
+
+schema.parse({ name: '  jANE DOE ', age: '180' });
+// → { name: 'Jane Doe', age: 120 }
+```
+
+See the full list of available parsers in [Data Parsers](./data_parsers.md).
 
 
 # Enforce Rules Composition
@@ -7209,6 +7648,29 @@ suite.only('username').run({
 ## Inspecting schema results
 
 The suite result includes a `types` object that captures the validated `input` and coerced `output` from the schema run. This is useful for debugging and type-safe consumers.
+
+## Schema Parsing
+
+Schema rules support built-in [data parsers](../enforce/builtin-enforce-plugins/data_parsers.md) that transform values as part of validation. When a schema uses parsers, `suite.run()` receives the transformed data in the callback, and `result.value` contains the parsed output.
+
+```js
+import { create, test, enforce } from 'vest';
+
+const schema = enforce.shape({
+  name: enforce.isString().trim().toTitle(),
+  age: enforce.isNumeric().toNumber().clamp(0, 120),
+});
+
+const suite = create(data => {
+  // data is already parsed: { name: 'Jane Doe', age: 120 }
+  test('name', 'Name is required', () => {
+    enforce(data.name).isNotBlank();
+  });
+}, schema);
+
+const result = suite.run({ name: '  jANE DOE ', age: '180' });
+// result.value → { name: 'Jane Doe', age: 120 }
+```
 
 
 # The Suite Object

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -510,8 +510,6 @@ value = "12"   -> 🚨 (value is a string and longer than 1)
 
 # Data Parsers
 
-# Data Parsers
-
 Data parsers transform values as they pass through an enforce chain. Unlike validation rules that only check whether a value is valid, parsers **coerce the value** into a new form — trimming whitespace, converting types, clamping numbers, and more.
 
 Parsers are available on **lazy chains** started with a type rule such as `enforce.isString()`, `enforce.isNumber()`, or `enforce.isArray()`. They are not available on eager `enforce(value)` chains.
@@ -742,6 +740,15 @@ enforce.isString().removeNonLetters().parse('v1e_2s-3t!');
 ## Number Parsers
 
 Available on `enforce.isNumber()` and `enforce.isNumeric()` chains.
+
+### toNumber
+
+Parses a string or number into a JavaScript Number. Fails if the result is `NaN` or invalid.
+
+```js
+enforce.isNumeric().toNumber().clamp(0, 100).parse('120');
+// → 100
+```
 
 ### round
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -62,6 +62,7 @@
 - [Creating custom enforce rules](/docs/enforce/creating_custom_rules)
 - [Schema Validation with Enforce](/docs/enforce/builtin-enforce-plugins/schema_rules)
 - [Consuming third party rules](/docs/enforce/consuming_external_rules)
+- [Data Parsers](/docs/enforce/builtin-enforce-plugins/data_parsers)
 - [Enforce Rules Composition](/docs/enforce/composing_enforce_rules)
 - [Failing with a message](/docs/enforce/failing_with_a_message)
 


### PR DESCRIPTION
This PR fixes the issue where callback execution wrapping for async testing wiped the parameters.

1. Added unit tests for `afterField`
2. Added support for passing the result object to `afterField` and `afterEach`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * afterEach/afterField callbacks now receive the suite result object.
  * Focused runs accept partial input data shapes.
  * Callback handlers now receive a shared suite result across more run paths.

* **Utilities**
  * Utility callback wrapper now forwards arguments to wrapped callbacks.

* **Documentation**
  * Added extensive Data Parsers documentation with examples and schema parsing guidance.

* **Tests**
  * New and enhanced tests for afterField/afterEach behavior, cancellation, typing, and async flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->