### PR TITLE
feat(n4s): add pick/omit schema modifiers for partial resolution

### DIFF
--- a/packages/n4s/docs/schema.md
+++ b/packages/n4s/docs/schema.md
@@ -57,3 +57,15 @@ When a suite is created with a schema:
 - Key checks are O(1) average-case (`Set.has`, own-property checks).
 - Rule execution remains linear in the number of relevant keys: O(n).
 - No recursive cloning is performed in schema wrappers; copying is shallow by design.
+
+## Lazy Rule Structure
+
+In `n4s`, schema validation rules heavily utilize a lazy builder API. When a rule is called (e.g., `enforce.shape({...})`), it doesn't evaluate immediately. Instead, it builds a `RuleInstance` wrapper inside an evaluation chain that captures the context.
+
+To achieve this, `lazy.ts` structurally categorizes rules:
+
+1. **Schema Modifiers (`optional`, `partial`, `pick`, `omit`)**: These rules modify schema behavior or keys dynamically. They are cleanly mapped over `adaptDynamicRules` without any proxy overhead attached.
+2. **Schema Evaluators (`shape`, `loose`)**: These are the baseline schema definitions. Because testing frameworks (like Vest) might need to peek at the underlying keys for specific focus states (`.only()`/`.skip()`), their lazy execution proxy explicitly maps the original `__schema` payload onto the resulting rule (`rule.__schema = schema`).
+3. **Compound/Array Rules (`isArrayOf`)**: Manually chained onto the context to inherently iterate dynamically inside array bodies properly.
+
+By explicitly differentiating modifiers from base evaluators natively within the lazy composition tree, the schema architecture reliably transforms static schemas into dynamic, traversable lazy validation chains.

--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -71,7 +71,7 @@ const schemaEvaluators = adaptDynamicRules<
 const schemaAttacher =
   (ruleFn: (schema: any) => RuleInstance<any, [any]>) => (schema: any) => {
     const rule = ruleFn(schema);
-    (rule as any).__schema = schema;
+    rule.__schema = schema;
     return rule;
   };
 

--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -45,12 +45,12 @@ type TCustomLazyRules = {
 // Explicitly adapt only the schema modifiers that act as wrappers
 const schemaModifiers = adaptDynamicRules<
   RuleInstance<any, [any]>,
-  Pick<typeof schemaRules, 'optional' | 'partial' | 'pick' | 'omit'>
+  Pick<typeof schemaRules, 'omit' | 'optional' | 'partial' | 'pick'>
 >({
+  omit: schemaRules.omit,
   optional: schemaRules.optional,
   partial: schemaRules.partial,
   pick: schemaRules.pick,
-  omit: schemaRules.omit,
 });
 
 // Explicitly adapt the base schema evaluators that need __schema exposure
@@ -62,11 +62,12 @@ const schemaEvaluators = adaptDynamicRules<
   loose: schemaRules.loose,
 });
 
-const schemaAttacher = (ruleFn: any) => (schema: any) => {
-  const rule = ruleFn(schema);
-  rule.__schema = schema;
-  return rule;
-};
+const schemaAttacher =
+  (ruleFn: (schema: any) => RuleInstance<any, [any]>) => (schema: any) => {
+    const rule = ruleFn(schema);
+    (rule as any).__schema = schema;
+    return rule;
+  };
 
 // Build the final schema rules object with special handling for arrays and base evaluators
 const schemaRulesWithArrayChaining = {

--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -62,6 +62,12 @@ const schemaEvaluators = adaptDynamicRules<
   loose: schemaRules.loose,
 });
 
+/**
+ * Wraps a lazy schema evaluator so the resulting RuleInstance carries
+ * a `__schema` reference to the original schema definition.
+ * Downstream code (e.g. vest's focus/only filtering) reads `__schema`
+ * to introspect the schema keys. Treat `__schema` as internal metadata.
+ */
 const schemaAttacher =
   (ruleFn: (schema: any) => RuleInstance<any, [any]>) => (schema: any) => {
     const rule = ruleFn(schema);
@@ -79,8 +85,8 @@ const schemaRulesWithArrayChaining = {
       );
       return RuleRunReturn.create(result, value);
     }),
-  shape: schemaAttacher(schemaEvaluators.shape),
   loose: schemaAttacher(schemaEvaluators.loose),
+  shape: schemaAttacher(schemaEvaluators.shape),
 };
 
 const baseEnforceLazy = {

--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -42,15 +42,35 @@ type TCustomLazyRules = {
   >;
 };
 
-// Create schema rules with isArrayOf handled specially
-const adaptedSchemaRules = adaptDynamicRules<
+// Explicitly adapt only the schema modifiers that act as wrappers
+const schemaModifiers = adaptDynamicRules<
   RuleInstance<any, [any]>,
-  typeof schemaRules
->(schemaRules);
+  Pick<typeof schemaRules, 'optional' | 'partial' | 'pick' | 'omit'>
+>({
+  optional: schemaRules.optional,
+  partial: schemaRules.partial,
+  pick: schemaRules.pick,
+  omit: schemaRules.omit,
+});
 
-// Override isArrayOf to chain array rules
+// Explicitly adapt the base schema evaluators that need __schema exposure
+const schemaEvaluators = adaptDynamicRules<
+  RuleInstance<any, [any]>,
+  Pick<typeof schemaRules, 'shape' | 'loose'>
+>({
+  shape: schemaRules.shape,
+  loose: schemaRules.loose,
+});
+
+const schemaAttacher = (ruleFn: any) => (schema: any) => {
+  const rule = ruleFn(schema);
+  rule.__schema = schema;
+  return rule;
+};
+
+// Build the final schema rules object with special handling for arrays and base evaluators
 const schemaRulesWithArrayChaining = {
-  ...adaptedSchemaRules,
+  ...schemaModifiers,
   isArrayOf: <T>(...rules: any[]): ArrayRuleInstance<T> =>
     addToChain<ArrayRuleInstance<T>>(arrayRules, (value: any) => {
       const result = ctx.run({ value }, () =>
@@ -58,6 +78,8 @@ const schemaRulesWithArrayChaining = {
       );
       return RuleRunReturn.create(result, value);
     }),
+  shape: schemaAttacher(schemaEvaluators.shape),
+  loose: schemaAttacher(schemaEvaluators.loose),
 };
 
 const baseEnforceLazy = {

--- a/packages/n4s/src/rules/schemaRules/__tests__/omit.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/omit.test.ts
@@ -61,9 +61,12 @@ describe('omit', () => {
     const schema = { name: enforce.isString() };
     const omittedSchema = enforce.omit(schema, ['name']);
 
-    expect(omittedSchema.run('string_value' as any).pass).toBe(false);
-    expect(omittedSchema.run(123 as any).pass).toBe(false);
-    expect(omittedSchema.run(null as any).pass).toBe(false);
+    // @ts-expect-error - testing non-object value
+    expect(omittedSchema.run('string_value').pass).toBe(false);
+    // @ts-expect-error - testing non-object value
+    expect(omittedSchema.run(123).pass).toBe(false);
+    // @ts-expect-error - testing non-object value
+    expect(omittedSchema.run(null).pass).toBe(false);
   });
 
   it('Should protect against dangerous prototype keys', () => {
@@ -76,7 +79,8 @@ describe('omit', () => {
   });
 
   it('Should fail when schema is not an object', () => {
-    const schema = 'not_a_schema' as any;
+    const schema = 'not_a_schema';
+    // @ts-expect-error - testing non-object schema
     const omittedSchema = enforce.omit(schema, ['id']);
 
     const result = omittedSchema.run({ id: 1 });

--- a/packages/n4s/src/rules/schemaRules/__tests__/omit.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/omit.test.ts
@@ -1,24 +1,27 @@
 import { describe, expect, it } from 'vitest';
 import { enforce } from '../../../n4s';
-import { omit } from '../omit';
 
 describe('omit', () => {
   it('Should successfully validate a schema ignoring omitted keys', () => {
     const schema = {
       name: enforce.isString(),
       age: enforce.isNumber(),
-      email: enforce.isString(), // 'email' not provided, but omitted
+      email: enforce.isString(),
     };
 
-    const value = { name: 'John Doe', age: 30 };
+    const omittedSchema = enforce.omit(schema, ['email']);
 
     // Omit email, validating valid inputs for name and age
-    const result = omit(value, schema, ['email']);
+    // @ts-expect-error - partial object, omitted keys missing
+    const result = omittedSchema.run({ name: 'John Doe', age: 30 });
     expect(result.pass).toBe(true);
 
     // Test failing condition in the non-omitted keys
-    const invalidValue = { name: 'John Doe', age: 'thirty' } as any;
-    const invalidResult = omit(invalidValue, schema, ['email']);
+    const invalidResult = omittedSchema.run({
+      name: 'John Doe',
+      // @ts-expect-error - intentionally passing string instead of number
+      age: 'thirty',
+    });
     expect(invalidResult.pass).toBe(false);
   });
 
@@ -29,11 +32,16 @@ describe('omit', () => {
     };
 
     // omit name
-    const value = { id: 1 };
-    const result = omit(value, schema, 'name');
+    const omittedSchema = enforce.omit(schema, 'name');
+
+    // @ts-expect-error - partial object, omitted keys missing
+    const result = omittedSchema.run({ id: 1 });
     expect(result.pass).toBe(true);
 
-    const invalidResult = omit({ id: 'one' } as any, schema, 'name');
+    const invalidResult = omittedSchema.run({
+      // @ts-expect-error - intentionally passing string instead of number
+      id: 'one',
+    });
     expect(invalidResult.pass).toBe(false);
   });
 
@@ -42,55 +50,58 @@ describe('omit', () => {
       id: enforce.isNumber(),
     };
 
-    // 'extra' is not in the schema, but omit validates via loose under the hood
-    const value = { id: 1, extra: 'data' };
     // omit nothing
-    const result = omit(value, schema, []);
+    const omittedSchema = enforce.omit(schema, []);
+    // @ts-expect-error - extra keys not in schema
+    const result = omittedSchema.run({ id: 1, extra: 'data' });
     expect(result.pass).toBe(true);
   });
 
   it('Should fail immediately and return false if the value is not an object', () => {
     const schema = { name: enforce.isString() };
+    const omittedSchema = enforce.omit(schema, ['name']);
 
-    expect(omit('string_value' as any, schema, ['name']).pass).toBe(false);
-    expect(omit(123 as any, schema, ['name']).pass).toBe(false);
-    expect(omit(null as any, schema, ['name']).pass).toBe(false);
+    expect(omittedSchema.run('string_value' as any).pass).toBe(false);
+    expect(omittedSchema.run(123 as any).pass).toBe(false);
+    expect(omittedSchema.run(null as any).pass).toBe(false);
   });
 
   it('Should protect against dangerous prototype keys', () => {
     const schema = { admin: enforce.isBoolean() };
+    const omittedSchema = enforce.omit(schema, ['id']);
 
     const dangerousValue = JSON.parse('{"__proto__": {"admin": true}}');
-    const result = omit(dangerousValue, schema, ['id']);
+    const result = omittedSchema.run(dangerousValue);
     expect(result.pass).toBe(false);
   });
 
   it('Should fail when schema is not an object', () => {
     const schema = 'not_a_schema' as any;
-    const value = { id: 1 };
+    const omittedSchema = enforce.omit(schema, ['id']);
 
-    const result = omit(value, schema, ['id']);
+    const result = omittedSchema.run({ id: 1 });
     expect(result.pass).toBe(false);
   });
 
   it('Should omit everything and accept invalid un-checked properties', () => {
     const schema = { id: enforce.isNumber() };
-    const value = { id: 'invalid_type_but_omitted' } as any;
+    const omittedSchema = enforce.omit(schema, ['id']);
 
-    const result = omit(value, schema, ['id']);
+    const result = omittedSchema.run({
+      // @ts-expect-error - intentionally passing string instead of number
+      id: 'invalid_type_but_omitted',
+    });
     expect(result.pass).toBe(true);
   });
-});
 
-describe('omit - lazy API', () => {
-  it('should successfully evaluate enforce.omit() wrapped schema shapes dynamically', () => {
-    const defaultSchema = {
+  it('Should pass with valid fields and ignore invalid omitted fields', () => {
+    const schema = {
       name: enforce.isString(),
       age: enforce.isNumber(),
       email: enforce.isString(),
     };
 
-    const omittedSchema = enforce.omit(defaultSchema, ['email']);
+    const omittedSchema = enforce.omit(schema, ['email']);
 
     // Should pass since we dropped the invalid email constraint via omit
     const result = omittedSchema.run({

--- a/packages/n4s/src/rules/schemaRules/__tests__/omit.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/omit.test.ts
@@ -95,20 +95,21 @@ describe('omit - lazy API', () => {
     const omittedSchema = enforce.omit(defaultSchema, ['email']);
 
     // Should pass since we dropped the invalid email constraint via omit
-    // @ts-expect-error - Expected 2 arguments but got 1
     const result = omittedSchema.run({
       name: 'John',
       age: 30,
+      // @ts-expect-error - intentionally passing number instead of string
       email: 123,
     });
 
     expect(result.pass).toBe(true);
 
     // Should fail because age breaks the remaining shape constraint
-    // @ts-expect-error - Expected 2 arguments but got 1
     const invalidResult = omittedSchema.run({
       name: 'John',
+      // @ts-expect-error - intentionally passing string instead of number
       age: 'thirty',
+      // @ts-expect-error - intentionally passing number instead of string
       email: 123,
     });
 

--- a/packages/n4s/src/rules/schemaRules/__tests__/omit.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/omit.test.ts
@@ -65,14 +65,12 @@ describe('omit', () => {
     expect(result.pass).toBe(false);
   });
 
-  it('Should gracefully handle schemas that are not objects', () => {
-    // e.g. enforcing shape with `omit` but passing a bad schema representation
+  it('Should fail when schema is not an object', () => {
     const schema = 'not_a_schema' as any;
     const value = { id: 1 };
 
-    // Still passes by checking nothing and defaulting to loose empty schema check
     const result = omit(value, schema, ['id']);
-    expect(result.pass).toBe(true);
+    expect(result.pass).toBe(false);
   });
 
   it('Should omit everything and accept invalid un-checked properties', () => {

--- a/packages/n4s/src/rules/schemaRules/__tests__/omit.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/omit.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { enforce } from '../../../n4s';
+import { omit } from '../omit';
+
+describe('omit', () => {
+  it('Should successfully validate a schema ignoring omitted keys', () => {
+    const schema = {
+      name: enforce.isString(),
+      age: enforce.isNumber(),
+      email: enforce.isString(), // 'email' not provided, but omitted
+    };
+
+    const value = { name: 'John Doe', age: 30 };
+
+    // Omit email, validating valid inputs for name and age
+    const result = omit(value, schema, ['email']);
+    expect(result.pass).toBe(true);
+
+    // Test failing condition in the non-omitted keys
+    const invalidValue = { name: 'John Doe', age: 'thirty' } as any;
+    const invalidResult = omit(invalidValue, schema, ['email']);
+    expect(invalidResult.pass).toBe(false);
+  });
+
+  it('Should handle string param for keysToOmit', () => {
+    const schema = {
+      id: enforce.isNumber(),
+      name: enforce.isString(),
+    };
+
+    // omit name
+    const value = { id: 1 };
+    const result = omit(value, schema, 'name');
+    expect(result.pass).toBe(true);
+
+    const invalidResult = omit({ id: 'one' } as any, schema, 'name');
+    expect(invalidResult.pass).toBe(false);
+  });
+
+  it('Should validate schema even if the payload has extra unspecified keys', () => {
+    const schema = {
+      id: enforce.isNumber(),
+    };
+
+    // 'extra' is not in the schema, but omit validates via loose under the hood
+    const value = { id: 1, extra: 'data' };
+    // omit nothing
+    const result = omit(value, schema, []);
+    expect(result.pass).toBe(true);
+  });
+
+  it('Should fail immediately and return false if the value is not an object', () => {
+    const schema = { name: enforce.isString() };
+
+    expect(omit('string_value' as any, schema, ['name']).pass).toBe(false);
+    expect(omit(123 as any, schema, ['name']).pass).toBe(false);
+    expect(omit(null as any, schema, ['name']).pass).toBe(false);
+  });
+
+  it('Should protect against dangerous prototype keys', () => {
+    const schema = { admin: enforce.isBoolean() };
+
+    const dangerousValue = JSON.parse('{"__proto__": {"admin": true}}');
+    const result = omit(dangerousValue, schema, ['id']);
+    expect(result.pass).toBe(false);
+  });
+
+  it('Should gracefully handle schemas that are not objects', () => {
+    // e.g. enforcing shape with `omit` but passing a bad schema representation
+    const schema = 'not_a_schema' as any;
+    const value = { id: 1 };
+
+    // Still passes by checking nothing and defaulting to loose empty schema check
+    const result = omit(value, schema, ['id']);
+    expect(result.pass).toBe(true);
+  });
+
+  it('Should omit everything and accept invalid un-checked properties', () => {
+    const schema = { id: enforce.isNumber() };
+    const value = { id: 'invalid_type_but_omitted' } as any;
+
+    const result = omit(value, schema, ['id']);
+    expect(result.pass).toBe(true);
+  });
+});
+
+describe('omit - lazy API', () => {
+  it('should successfully evaluate enforce.omit() wrapped schema shapes dynamically', () => {
+    const defaultSchema = {
+      name: enforce.isString(),
+      age: enforce.isNumber(),
+      email: enforce.isString(),
+    };
+
+    const omittedSchema = enforce.omit(defaultSchema, ['email']);
+
+    // Should pass since we dropped the invalid email constraint via omit
+    // @ts-expect-error - Expected 2 arguments but got 1
+    const result = omittedSchema.run({
+      name: 'John',
+      age: 30,
+      email: 123,
+    });
+
+    expect(result.pass).toBe(true);
+
+    // Should fail because age breaks the remaining shape constraint
+    // @ts-expect-error - Expected 2 arguments but got 1
+    const invalidResult = omittedSchema.run({
+      name: 'John',
+      age: 'thirty',
+      email: 123,
+    });
+
+    expect(invalidResult.pass).toBe(false);
+  });
+});

--- a/packages/n4s/src/rules/schemaRules/__tests__/pick.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/pick.test.ts
@@ -107,20 +107,21 @@ describe('pick - lazy API', () => {
     const pickedSchema = enforce.pick(defaultSchema, ['name', 'age']);
 
     // Should pass since we dropped the invalid email constraint
-    // @ts-expect-error - Expected 2 arguments but got 1
     const result = pickedSchema.run({
       name: 'John',
       age: 30,
+      // @ts-expect-error - intentionally passing number instead of string
       email: 123,
     });
 
     expect(result.pass).toBe(true);
 
     // Should fail because age breaks the explicitly picked constraint
-    // @ts-expect-error - Expected 2 arguments but got 1
     const invalidResult = pickedSchema.run({
       name: 'John',
+      // @ts-expect-error - intentionally passing string instead of number
       age: 'thirty',
+      // @ts-expect-error - intentionally passing number instead of string
       email: 123,
     });
 

--- a/packages/n4s/src/rules/schemaRules/__tests__/pick.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/pick.test.ts
@@ -75,9 +75,12 @@ describe('pick', () => {
     const schema = { name: enforce.isString() };
     const pickedSchema = enforce.pick(schema, ['name']);
 
-    expect(pickedSchema.run('string_value' as any).pass).toBe(false);
-    expect(pickedSchema.run(123 as any).pass).toBe(false);
-    expect(pickedSchema.run(null as any).pass).toBe(false);
+    // @ts-expect-error - testing non-object value
+    expect(pickedSchema.run('string_value').pass).toBe(false);
+    // @ts-expect-error - testing non-object value
+    expect(pickedSchema.run(123).pass).toBe(false);
+    // @ts-expect-error - testing non-object value
+    expect(pickedSchema.run(null).pass).toBe(false);
   });
 
   it('Should protect against dangerous prototype keys', () => {
@@ -90,7 +93,8 @@ describe('pick', () => {
   });
 
   it('Should fail when schema is not an object', () => {
-    const schema = 'not_a_schema' as any;
+    const schema = 'not_a_schema';
+    // @ts-expect-error - testing non-object schema
     const pickedSchema = enforce.pick(schema, ['id']);
 
     const result = pickedSchema.run({ id: 1 });

--- a/packages/n4s/src/rules/schemaRules/__tests__/pick.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/pick.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { enforce } from '../../../n4s';
-import { pick } from '../pick';
 
 describe('pick', () => {
   it('Should successfully validate the picked subset of a schema', () => {
@@ -10,15 +9,19 @@ describe('pick', () => {
       email: enforce.isString(),
     };
 
-    const value = { name: 'John Doe', age: 30 };
+    const pickedSchema = enforce.pick(schema, ['name', 'age']);
 
     // Pick name and age, validating valid inputs
-    const result = pick(value, schema, ['name', 'age']);
+    // @ts-expect-error - partial object, un-picked keys omitted
+    const result = pickedSchema.run({ name: 'John Doe', age: 30 });
     expect(result.pass).toBe(true);
 
     // Test failing condition in the picked keys
-    const invalidValue = { name: 'John Doe', age: 'thirty' };
-    const invalidResult = pick(invalidValue, schema, ['name', 'age']);
+    const invalidResult = pickedSchema.run({
+      name: 'John Doe',
+      // @ts-expect-error - intentionally passing string instead of number
+      age: 'thirty',
+    });
     expect(invalidResult.pass).toBe(false);
   });
 
@@ -28,11 +31,16 @@ describe('pick', () => {
       name: enforce.isString(),
     };
 
-    const value = { id: 1 };
-    const result = pick(value, schema, 'id');
+    const pickedSchema = enforce.pick(schema, 'id');
+
+    // @ts-expect-error - partial object, un-picked keys omitted
+    const result = pickedSchema.run({ id: 1 });
     expect(result.pass).toBe(true);
 
-    const invalidResult = pick({ id: 'one' }, schema, 'id');
+    const invalidResult = pickedSchema.run({
+      // @ts-expect-error - intentionally passing string instead of number
+      id: 'one',
+    });
     expect(invalidResult.pass).toBe(false);
   });
 
@@ -45,8 +53,9 @@ describe('pick', () => {
 
     // 'email' is in the schema but missing in the value.
     // If we only pick 'name' and 'age', it should still pass.
-    const value = { name: 'John Doe', age: 30 };
-    const result = pick(value, schema, ['name', 'age']);
+    const pickedSchema = enforce.pick(schema, ['name', 'age']);
+    // @ts-expect-error - partial object, un-picked keys omitted
+    const result = pickedSchema.run({ name: 'John Doe', age: 30 });
     expect(result.pass).toBe(true);
   });
 
@@ -56,53 +65,57 @@ describe('pick', () => {
     };
 
     // 'extra' is not in the schema, but pick validates via loose under the hood
-    const value = { id: 1, extra: 'data' };
-    const result = pick(value, schema, ['id']);
+    const pickedSchema = enforce.pick(schema, ['id']);
+    // @ts-expect-error - extra keys not in schema
+    const result = pickedSchema.run({ id: 1, extra: 'data' });
     expect(result.pass).toBe(true);
   });
 
   it('Should fail immediately and return false if the value is not an object', () => {
     const schema = { name: enforce.isString() };
+    const pickedSchema = enforce.pick(schema, ['name']);
 
-    expect(pick('string_value' as any, schema, ['name']).pass).toBe(false);
-    expect(pick(123 as any, schema, ['name']).pass).toBe(false);
-    expect(pick(null as any, schema, ['name']).pass).toBe(false);
+    expect(pickedSchema.run('string_value' as any).pass).toBe(false);
+    expect(pickedSchema.run(123 as any).pass).toBe(false);
+    expect(pickedSchema.run(null as any).pass).toBe(false);
   });
 
   it('Should protect against dangerous prototype keys', () => {
     const schema = { admin: enforce.isBoolean() };
+    const pickedSchema = enforce.pick(schema, ['admin']);
 
     const dangerousValue = JSON.parse('{"__proto__": {"admin": true}}');
-    const result = pick(dangerousValue, schema, ['admin']);
+    const result = pickedSchema.run(dangerousValue);
     expect(result.pass).toBe(false);
   });
 
   it('Should fail when schema is not an object', () => {
     const schema = 'not_a_schema' as any;
-    const value = { id: 1 };
+    const pickedSchema = enforce.pick(schema, ['id']);
 
-    const result = pick(value, schema, ['id']);
+    const result = pickedSchema.run({ id: 1 });
     expect(result.pass).toBe(false);
   });
 
   it('Should work with empty pick list', () => {
     const schema = { id: enforce.isNumber() };
-    const value = { id: 'invalid_type_but_not_checked' };
+    const pickedSchema = enforce.pick(schema, []);
 
-    const result = pick(value, schema, []);
+    const result = pickedSchema.run({
+      // @ts-expect-error - intentionally passing string instead of number
+      id: 'invalid_type_but_not_checked',
+    });
     expect(result.pass).toBe(true);
   });
-});
 
-describe('pick - lazy API', () => {
-  it('should successfully evaluate enforce.pick() wrapped schema shapes dynamically', () => {
-    const defaultSchema = {
+  it('Should pass with valid picked fields and ignore invalid un-picked fields', () => {
+    const schema = {
       name: enforce.isString(),
       age: enforce.isNumber(),
       email: enforce.isString(),
     };
 
-    const pickedSchema = enforce.pick(defaultSchema, ['name', 'age']);
+    const pickedSchema = enforce.pick(schema, ['name', 'age']);
 
     // Should pass since we dropped the invalid email constraint
     const result = pickedSchema.run({

--- a/packages/n4s/src/rules/schemaRules/__tests__/pick.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/pick.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { enforce } from '../../../n4s';
+import { pick } from '../pick';
+
+describe('pick', () => {
+  it('Should successfully validate the picked subset of a schema', () => {
+    const schema = {
+      name: enforce.isString(),
+      age: enforce.isNumber(),
+      email: enforce.isString(),
+    };
+
+    const value = { name: 'John Doe', age: 30 };
+
+    // Pick name and age, validating valid inputs
+    const result = pick(value, schema, ['name', 'age']);
+    expect(result.pass).toBe(true);
+
+    // Test failing condition in the picked keys
+    const invalidValue = { name: 'John Doe', age: 'thirty' };
+    const invalidResult = pick(invalidValue, schema, ['name', 'age']);
+    expect(invalidResult.pass).toBe(false);
+  });
+
+  it('Should handle string param for keysToPick', () => {
+    const schema = {
+      id: enforce.isNumber(),
+      name: enforce.isString(),
+    };
+
+    const value = { id: 1 };
+    const result = pick(value, schema, 'id');
+    expect(result.pass).toBe(true);
+
+    const invalidResult = pick({ id: 'one' }, schema, 'id');
+    expect(invalidResult.pass).toBe(false);
+  });
+
+  it('Should not fail validation for missing un-picked keys', () => {
+    const schema = {
+      name: enforce.isString(),
+      age: enforce.isNumber(),
+      email: enforce.isString(),
+    };
+
+    // 'email' is in the schema but missing in the value.
+    // If we only pick 'name' and 'age', it should still pass.
+    const value = { name: 'John Doe', age: 30 };
+    const result = pick(value, schema, ['name', 'age']);
+    expect(result.pass).toBe(true);
+  });
+
+  it('Should validate schema even if the payload has extra unspecified keys', () => {
+    const schema = {
+      id: enforce.isNumber(),
+    };
+
+    // 'extra' is not in the schema, but pick validates via loose under the hood
+    const value = { id: 1, extra: 'data' };
+    const result = pick(value, schema, ['id']);
+    expect(result.pass).toBe(true);
+  });
+
+  it('Should fail immediately and return false if the value is not an object', () => {
+    const schema = { name: enforce.isString() };
+
+    expect(pick('string_value' as any, schema, ['name']).pass).toBe(false);
+    expect(pick(123 as any, schema, ['name']).pass).toBe(false);
+    expect(pick(null as any, schema, ['name']).pass).toBe(false);
+  });
+
+  it('Should protect against dangerous prototype keys', () => {
+    const schema = { admin: enforce.isBoolean() };
+
+    const dangerousValue = JSON.parse('{"__proto__": {"admin": true}}');
+    const result = pick(dangerousValue, schema, ['admin']);
+    expect(result.pass).toBe(false);
+  });
+
+  it('Should gracefully handle schemas that are not objects', () => {
+    // e.g. enforcing shape with `pick` but passing a bad schema representation
+    const schema = 'not_a_schema' as any;
+    const value = { id: 1 };
+
+    // Still passes by checking nothing and defaulting to loose empty schema check
+    const result = pick(value, schema, ['id']);
+    expect(result.pass).toBe(true);
+  });
+
+  it('Should work with empty pick list', () => {
+    const schema = { id: enforce.isNumber() };
+    const value = { id: 'invalid_type_but_not_checked' };
+
+    const result = pick(value, schema, []);
+    expect(result.pass).toBe(true);
+  });
+});
+
+describe('pick - lazy API', () => {
+  it('should successfully evaluate enforce.pick() wrapped schema shapes dynamically', () => {
+    const defaultSchema = {
+      name: enforce.isString(),
+      age: enforce.isNumber(),
+      email: enforce.isString(),
+    };
+
+    const pickedSchema = enforce.pick(defaultSchema, ['name', 'age']);
+
+    // Should pass since we dropped the invalid email constraint
+    // @ts-expect-error - Expected 2 arguments but got 1
+    const result = pickedSchema.run({
+      name: 'John',
+      age: 30,
+      email: 123,
+    });
+
+    expect(result.pass).toBe(true);
+
+    // Should fail because age breaks the explicitly picked constraint
+    // @ts-expect-error - Expected 2 arguments but got 1
+    const invalidResult = pickedSchema.run({
+      name: 'John',
+      age: 'thirty',
+      email: 123,
+    });
+
+    expect(invalidResult.pass).toBe(false);
+  });
+});

--- a/packages/n4s/src/rules/schemaRules/__tests__/pick.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/pick.test.ts
@@ -77,14 +77,12 @@ describe('pick', () => {
     expect(result.pass).toBe(false);
   });
 
-  it('Should gracefully handle schemas that are not objects', () => {
-    // e.g. enforcing shape with `pick` but passing a bad schema representation
+  it('Should fail when schema is not an object', () => {
     const schema = 'not_a_schema' as any;
     const value = { id: 1 };
 
-    // Still passes by checking nothing and defaulting to loose empty schema check
     const result = pick(value, schema, ['id']);
-    expect(result.pass).toBe(true);
+    expect(result.pass).toBe(false);
   });
 
   it('Should work with empty pick list', () => {

--- a/packages/n4s/src/rules/schemaRules/__tests__/schemaObjectUtils.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schemaObjectUtils.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkDangerousKeys,
+  findDangerousOwnKey,
+  ownKeys,
+} from '../schemaObjectUtils';
+
+describe('schemaObjectUtils', () => {
+  describe('ownKeys', () => {
+    it('Should return only own enumerable properties', () => {
+      const obj = { a: 1, b: 2 };
+      Object.defineProperty(obj, 'c', { value: 3, enumerable: false });
+
+      const proto = { inherited: true };
+      Object.setPrototypeOf(obj, proto);
+
+      const keys = ownKeys(obj);
+      expect(keys).toEqual(['a', 'b']);
+      expect(keys).not.toContain('c');
+      expect(keys).not.toContain('inherited');
+    });
+
+    it('Should work with empty objects', () => {
+      expect(ownKeys({})).toEqual([]);
+    });
+
+    it('Should return empty array for non-objects', () => {
+      expect(ownKeys(null as any)).toEqual([]);
+      expect(ownKeys(undefined as any)).toEqual([]);
+      expect(ownKeys('string' as any)).toEqual([]);
+    });
+  });
+
+  describe('findDangerousOwnKey', () => {
+    it('Should identify __proto__ and constructor as dangerous', () => {
+      expect(findDangerousOwnKey(JSON.parse('{"__proto__": {}}'))).toBe(
+        '__proto__',
+      );
+      expect(findDangerousOwnKey(JSON.parse('{"constructor": {}}'))).toBe(
+        'constructor',
+      );
+    });
+
+    it('Should not flag regular keys as dangerous', () => {
+      expect(findDangerousOwnKey({ name: 'john' })).toBeNull();
+      expect(findDangerousOwnKey({ id: 1 })).toBeNull();
+      expect(findDangerousOwnKey({ admin: true })).toBeNull();
+    });
+  });
+
+  describe('checkDangerousKeys', () => {
+    it('Should return false pass and path if the payload contains dangerous keys', () => {
+      const payload = JSON.parse('{"__proto__": {"admin": true}}');
+      const schema = { id: 1 };
+
+      const result = checkDangerousKeys(payload, schema);
+      expect(result).toEqual({ pass: false, path: ['__proto__'] });
+    });
+
+    it('Should return null if there are no dangerous keys', () => {
+      const payload = { username: 'john' };
+      const schema = { username: 1 };
+
+      const result = checkDangerousKeys(payload, schema);
+      expect(result).toBeNull();
+    });
+
+    it('Should return false pass and path if the schema contains dangerous keys', () => {
+      const payload = { id: 1 };
+      const schema = JSON.parse('{"constructor": 1}');
+
+      const result = checkDangerousKeys(payload, schema);
+      expect(result).toEqual({ pass: false, path: ['constructor'] });
+    });
+
+    it('Should handle non-object payloads gracefully (returns null)', () => {
+      expect(checkDangerousKeys(null as any, {})).toBeNull();
+      expect(checkDangerousKeys(undefined as any, {})).toBeNull();
+      expect(checkDangerousKeys('string' as any, {})).toBeNull();
+    });
+  });
+});

--- a/packages/n4s/src/rules/schemaRules/__tests__/schemaObjectUtils.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schemaObjectUtils.test.ts
@@ -32,12 +32,15 @@ describe('schemaObjectUtils', () => {
   });
 
   describe('findDangerousOwnKey', () => {
-    it('Should identify __proto__ and constructor as dangerous', () => {
+    it('Should identify __proto__, constructor, and prototype as dangerous', () => {
       expect(findDangerousOwnKey(JSON.parse('{"__proto__": {}}'))).toBe(
         '__proto__',
       );
       expect(findDangerousOwnKey(JSON.parse('{"constructor": {}}'))).toBe(
         'constructor',
+      );
+      expect(findDangerousOwnKey(JSON.parse('{"prototype": {}}'))).toBe(
+        'prototype',
       );
     });
 

--- a/packages/n4s/src/rules/schemaRules/omit.ts
+++ b/packages/n4s/src/rules/schemaRules/omit.ts
@@ -1,8 +1,10 @@
-import { isObject } from 'vest-utils';
-
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
-import { checkDangerousKeys, filterSchemaKeys } from './schemaObjectUtils';
+import {
+  checkDangerousKeys,
+  filterSchemaKeys,
+  isValidSchemaInput,
+} from './schemaObjectUtils';
 import { loose } from './loose';
 import type { ShapeType, ShapeInputType } from './shape';
 
@@ -21,7 +23,7 @@ export function omit<T extends Record<string, any>>(
   schema: Record<string, any>,
   keysToOmit: string[] | string,
 ): RuleRunReturn<T> {
-  if (!isObject(value)) {
+  if (!isValidSchemaInput(value, schema)) {
     return RuleRunReturn.Failing(value);
   }
 

--- a/packages/n4s/src/rules/schemaRules/omit.ts
+++ b/packages/n4s/src/rules/schemaRules/omit.ts
@@ -1,0 +1,59 @@
+import { isObject } from 'vest-utils';
+
+import type { RuleInstance } from '../../utils/RuleInstance';
+import { RuleRunReturn } from '../../utils/RuleRunReturn';
+import { ownKeys, checkDangerousKeys } from './schemaObjectUtils';
+import { loose } from './loose';
+
+/**
+ * Validates that an object loosely matches a schema but omits specified keys from validation.
+ * The omitted keys in the object are ignored and no validation is applied to them.
+ *
+ * @template T - The object type to validate
+ * @param value - The object to validate
+ * @param schema - Schema mapping keys to validation rules
+ * @param keysToOmit - Array of keys that should be omitted from schema validation
+ * @returns RuleRunReturn indicating success or failure
+ */
+export function omit<T extends Record<string, any>>(
+  value: T,
+  schema: Record<string, any>,
+  keysToOmit: string[] | string,
+): RuleRunReturn<T> {
+  if (!isObject(value)) {
+    return RuleRunReturn.Failing(value);
+  }
+
+  const omitKeys = new Set(
+    Array.isArray(keysToOmit) ? keysToOmit : [keysToOmit],
+  );
+
+  const dangerousKeyError = checkDangerousKeys(value, schema);
+  if (dangerousKeyError) {
+    return { ...RuleRunReturn.Failing(value), ...dangerousKeyError };
+  }
+
+  const omittedSchema = buildOmittedSchema(schema, omitKeys);
+
+  const baseRes = loose(value, omittedSchema);
+  return baseRes.pass ? RuleRunReturn.Passing(baseRes.type as T) : baseRes;
+}
+
+function buildOmittedSchema(
+  schema: Record<string, any>,
+  omitKeys: Set<string>,
+): Record<string, any> {
+  const omittedSchema: Record<string, any> = {};
+  if (!isObject(schema)) {
+    return omittedSchema;
+  }
+  for (const key of ownKeys(schema)) {
+    if (!omitKeys.has(key)) {
+      omittedSchema[key] = schema[key];
+    }
+  }
+  return omittedSchema;
+}
+
+export type OmitRuleInstance<S extends Record<string, RuleInstance<any>>> =
+  RuleInstance<any, [S, string[] | string]>;

--- a/packages/n4s/src/rules/schemaRules/omit.ts
+++ b/packages/n4s/src/rules/schemaRules/omit.ts
@@ -1,3 +1,5 @@
+import { asArray } from 'vest-utils';
+
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 import {
@@ -27,9 +29,7 @@ export function omit<T extends Record<string, any>>(
     return RuleRunReturn.Failing(value);
   }
 
-  const omitKeys = new Set(
-    Array.isArray(keysToOmit) ? keysToOmit : [keysToOmit],
-  );
+  const omitKeys = new Set(asArray(keysToOmit));
 
   const dangerousKeyError = checkDangerousKeys(value, schema);
   if (dangerousKeyError) {

--- a/packages/n4s/src/rules/schemaRules/omit.ts
+++ b/packages/n4s/src/rules/schemaRules/omit.ts
@@ -2,8 +2,9 @@ import { isObject } from 'vest-utils';
 
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
-import { ownKeys, checkDangerousKeys } from './schemaObjectUtils';
+import { checkDangerousKeys, filterSchemaKeys } from './schemaObjectUtils';
 import { loose } from './loose';
+import type { ShapeType, ShapeInputType } from './shape';
 
 /**
  * Validates that an object loosely matches a schema but omits specified keys from validation.
@@ -33,27 +34,11 @@ export function omit<T extends Record<string, any>>(
     return { ...RuleRunReturn.Failing(value), ...dangerousKeyError };
   }
 
-  const omittedSchema = buildOmittedSchema(schema, omitKeys);
+  const omittedSchema = filterSchemaKeys(schema, key => !omitKeys.has(key));
 
   const baseRes = loose(value, omittedSchema);
   return baseRes.pass ? RuleRunReturn.Passing(baseRes.type as T) : baseRes;
 }
 
-function buildOmittedSchema(
-  schema: Record<string, any>,
-  omitKeys: Set<string>,
-): Record<string, any> {
-  const omittedSchema: Record<string, any> = {};
-  if (!isObject(schema)) {
-    return omittedSchema;
-  }
-  for (const key of ownKeys(schema)) {
-    if (!omitKeys.has(key)) {
-      omittedSchema[key] = schema[key];
-    }
-  }
-  return omittedSchema;
-}
-
 export type OmitRuleInstance<S extends Record<string, RuleInstance<any>>> =
-  RuleInstance<any, [S, string[] | string]>;
+  RuleInstance<ShapeType<S>, [ShapeInputType<S>]>;

--- a/packages/n4s/src/rules/schemaRules/pick.ts
+++ b/packages/n4s/src/rules/schemaRules/pick.ts
@@ -2,8 +2,9 @@ import { isObject } from 'vest-utils';
 
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
-import { ownKeys, checkDangerousKeys } from './schemaObjectUtils';
+import { checkDangerousKeys, filterSchemaKeys } from './schemaObjectUtils';
 import { loose } from './loose';
+import type { ShapeType, ShapeInputType } from './shape';
 
 /**
  * Validates that an object loosely matches a schema but only validates the specified keys.
@@ -33,7 +34,7 @@ export function pick<T extends Record<string, any>>(
     return { ...RuleRunReturn.Failing(value), ...dangerousKeyError };
   }
 
-  const pickedSchema = buildPickedSchema(schema, pickKeys);
+  const pickedSchema = filterSchemaKeys(schema, key => pickKeys.has(key));
 
   // Use `loose` so we only care about validating our picked subset of schema rules
   // without failing if the object has extra unspecified fields.
@@ -41,21 +42,5 @@ export function pick<T extends Record<string, any>>(
   return baseRes.pass ? RuleRunReturn.Passing(baseRes.type as T) : baseRes;
 }
 
-function buildPickedSchema(
-  schema: Record<string, any>,
-  pickKeys: Set<string>,
-): Record<string, any> {
-  const pickedSchema: Record<string, any> = {};
-  if (!isObject(schema)) {
-    return pickedSchema;
-  }
-  for (const key of ownKeys(schema)) {
-    if (pickKeys.has(key)) {
-      pickedSchema[key] = schema[key];
-    }
-  }
-  return pickedSchema;
-}
-
 export type PickRuleInstance<S extends Record<string, RuleInstance<any>>> =
-  RuleInstance<any, [S, string[] | string]>;
+  RuleInstance<ShapeType<S>, [ShapeInputType<S>]>;

--- a/packages/n4s/src/rules/schemaRules/pick.ts
+++ b/packages/n4s/src/rules/schemaRules/pick.ts
@@ -1,3 +1,5 @@
+import { asArray } from 'vest-utils';
+
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 import {
@@ -27,9 +29,7 @@ export function pick<T extends Record<string, any>>(
     return RuleRunReturn.Failing(value);
   }
 
-  const pickKeys = new Set(
-    Array.isArray(keysToPick) ? keysToPick : [keysToPick],
-  );
+  const pickKeys = new Set(asArray(keysToPick));
 
   const dangerousKeyError = checkDangerousKeys(value, schema);
   if (dangerousKeyError) {

--- a/packages/n4s/src/rules/schemaRules/pick.ts
+++ b/packages/n4s/src/rules/schemaRules/pick.ts
@@ -1,0 +1,61 @@
+import { isObject } from 'vest-utils';
+
+import type { RuleInstance } from '../../utils/RuleInstance';
+import { RuleRunReturn } from '../../utils/RuleRunReturn';
+import { ownKeys, checkDangerousKeys } from './schemaObjectUtils';
+import { loose } from './loose';
+
+/**
+ * Validates that an object loosely matches a schema but only validates the specified keys.
+ * Other keys in the object are ignored and no validation is applied to them.
+ *
+ * @template T - The object type to validate
+ * @param value - The object to validate
+ * @param schema - Schema mapping keys to validation rules
+ * @param keysToPick - Array of keys that should be validated from the schema
+ * @returns RuleRunReturn indicating success or failure
+ */
+export function pick<T extends Record<string, any>>(
+  value: T,
+  schema: Record<string, any>,
+  keysToPick: string[] | string,
+): RuleRunReturn<T> {
+  if (!isObject(value)) {
+    return RuleRunReturn.Failing(value);
+  }
+
+  const pickKeys = new Set(
+    Array.isArray(keysToPick) ? keysToPick : [keysToPick],
+  );
+
+  const dangerousKeyError = checkDangerousKeys(value, schema);
+  if (dangerousKeyError) {
+    return { ...RuleRunReturn.Failing(value), ...dangerousKeyError };
+  }
+
+  const pickedSchema = buildPickedSchema(schema, pickKeys);
+
+  // Use `loose` so we only care about validating our picked subset of schema rules
+  // without failing if the object has extra unspecified fields.
+  const baseRes = loose(value, pickedSchema);
+  return baseRes.pass ? RuleRunReturn.Passing(baseRes.type as T) : baseRes;
+}
+
+function buildPickedSchema(
+  schema: Record<string, any>,
+  pickKeys: Set<string>,
+): Record<string, any> {
+  const pickedSchema: Record<string, any> = {};
+  if (!isObject(schema)) {
+    return pickedSchema;
+  }
+  for (const key of ownKeys(schema)) {
+    if (pickKeys.has(key)) {
+      pickedSchema[key] = schema[key];
+    }
+  }
+  return pickedSchema;
+}
+
+export type PickRuleInstance<S extends Record<string, RuleInstance<any>>> =
+  RuleInstance<any, [S, string[] | string]>;

--- a/packages/n4s/src/rules/schemaRules/pick.ts
+++ b/packages/n4s/src/rules/schemaRules/pick.ts
@@ -1,8 +1,10 @@
-import { isObject } from 'vest-utils';
-
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
-import { checkDangerousKeys, filterSchemaKeys } from './schemaObjectUtils';
+import {
+  checkDangerousKeys,
+  filterSchemaKeys,
+  isValidSchemaInput,
+} from './schemaObjectUtils';
 import { loose } from './loose';
 import type { ShapeType, ShapeInputType } from './shape';
 
@@ -21,7 +23,7 @@ export function pick<T extends Record<string, any>>(
   schema: Record<string, any>,
   keysToPick: string[] | string,
 ): RuleRunReturn<T> {
-  if (!isObject(value)) {
+  if (!isValidSchemaInput(value, schema)) {
     return RuleRunReturn.Failing(value);
   }
 

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -45,3 +45,23 @@ export function safeShallowCopy(
 
   return output;
 }
+
+/**
+ * Checks if the value or the schema contain any inherently dangerous keys natively.
+ */
+export function checkDangerousKeys<T>(
+  value: T,
+  schema: Record<string, any>,
+): { pass: false; path: string[] } | null {
+  const dangerousSchemaKey = findDangerousOwnKey(schema);
+  if (dangerousSchemaKey) {
+    return { pass: false, path: [dangerousSchemaKey] };
+  }
+
+  const dangerousValueKey = findDangerousOwnKey(value);
+  if (dangerousValueKey) {
+    return { pass: false, path: [dangerousValueKey] };
+  }
+
+  return null;
+}

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -47,6 +47,13 @@ export function safeShallowCopy(
 }
 
 /**
+ * Returns true if both value and schema are plain objects.
+ */
+export function isValidSchemaInput(value: unknown, schema: unknown): boolean {
+  return isObject(value) && isObject(schema);
+}
+
+/**
  * Checks if the value or the schema contain any inherently dangerous keys natively.
  */
 export function checkDangerousKeys<T>(

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -47,10 +47,15 @@ export function safeShallowCopy(
 }
 
 /**
- * Returns true if both value and schema are plain objects.
+ * Returns true if both value and schema are plain objects (not arrays).
  */
 export function isValidSchemaInput(value: unknown, schema: unknown): boolean {
-  return isObject(value) && isObject(schema);
+  return (
+    isObject(value) &&
+    !Array.isArray(value) &&
+    isObject(schema) &&
+    !Array.isArray(schema)
+  );
 }
 
 /**

--- a/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaObjectUtils.ts
@@ -65,3 +65,23 @@ export function checkDangerousKeys<T>(
 
   return null;
 }
+
+/**
+ * Filters schema keys using a predicate, returning a new schema
+ * containing only the keys for which the predicate returns true.
+ */
+export function filterSchemaKeys(
+  schema: Record<string, any>,
+  predicate: (key: string) => boolean,
+): Record<string, any> {
+  const filtered: Record<string, any> = {};
+  if (!isObject(schema)) {
+    return filtered;
+  }
+  for (const key of ownKeys(schema)) {
+    if (predicate(key)) {
+      filtered[key] = schema[key];
+    }
+  }
+  return filtered;
+}

--- a/packages/n4s/src/rules/schemaRules/schemaRules.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRules.ts
@@ -4,5 +4,7 @@ export { isArrayOf, type IsArrayOfRuleInstance } from './isArrayOf';
 export { loose, type LooseRuleInstance } from './loose';
 export { optional, type OptionalRuleInstance } from './optional';
 export { partial, type PartialRuleInstance } from './partial';
+export { pick, type PickRuleInstance } from './pick';
+export { omit, type OmitRuleInstance } from './omit';
 export { shape, type ShapeRuleInstance } from './shape';
 export type { SchemaRuleLazyTypes } from './schemaRulesLazyTypes';

--- a/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
@@ -5,6 +5,8 @@ import './isArrayOf';
 import './loose';
 import './optional';
 import './partial';
+import './pick';
+import './omit';
 import './shape';
 
 import type { RuleInstance } from '../../utils/RuleInstance';
@@ -15,6 +17,8 @@ import type {
   LooseRuleInstance,
   OptionalRuleInstance,
   PartialRuleInstance,
+  PickRuleInstance,
+  OmitRuleInstance,
   ShapeRuleInstance,
 } from './schemaRules';
 
@@ -34,6 +38,14 @@ export type SchemaRuleLazyTypes = {
   partial: <S extends Record<string, RuleInstance<any>>>(
     schema: S,
   ) => PartialRuleInstance<S>;
+  pick: <S extends Record<string, RuleInstance<any>>>(
+    schema: S,
+    keys: string[] | string,
+  ) => PickRuleInstance<S>;
+  omit: <S extends Record<string, RuleInstance<any>>>(
+    schema: S,
+    keys: string[] | string,
+  ) => OmitRuleInstance<S>;
   shape: <S extends Record<string, RuleInstance<any>>>(
     schema: S,
   ) => ShapeRuleInstance<S>;

--- a/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
@@ -211,10 +211,10 @@ describe('suite schema integration', () => {
     }, schema);
 
     const result = suite.run({
-      // @ts-expect-error - testing coercable string
+      // @ts-expect-error - testing coercible string
       age: '180',
       name: '  jANE DOE ',
-      // @ts-expect-error - testing coercable string
+      // @ts-expect-error - testing coercible string
       subscribed: ' yes ',
       // @ts-expect-error - testing array to string mapping coercion
       tags: ['vest', 'n4s', 'vest'],

--- a/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
@@ -211,9 +211,12 @@ describe('suite schema integration', () => {
     }, schema);
 
     const result = suite.run({
+      // @ts-expect-error - testing coercable string
       age: '180',
       name: '  jANE DOE ',
+      // @ts-expect-error - testing coercable string
       subscribed: ' yes ',
+      // @ts-expect-error - testing array to string mapping coercion
       tags: ['vest', 'n4s', 'vest'],
       payload: '{"env":"test"}',
     });
@@ -249,6 +252,7 @@ describe('suite schema integration', () => {
       });
     }, schema);
 
+    // @ts-expect-error - testing invalid fallback schema error
     const result = suite.run({ subscribed: 'unknown' });
 
     expect(callbackData).toEqual({ subscribed: 'unknown' });

--- a/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
+++ b/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
@@ -18,6 +18,8 @@ These rules are available in `enforce`:
   - [enforce.optional() - nullable values](#enforceoptional---nullable-values)
   - [enforce.partial() - allows supplying a subset of keys](#enforcepartial---allows-supplying-a-subset-of-keys)
   - [enforce.loose() - loose shape matching](#enforceloose---loose-shape-matching)
+  - [enforce.pick() - pick a subset of fields](#enforcepick---pick-a-subset-of-fields)
+  - [enforce.omit() - omit a subset of fields](#enforceomit---omit-a-subset-of-fields)
   - [enforce.isArrayOf() - array shape matching](#enforceisarrayof---array-shape-matching)
 
 ## enforce.shape() - Lean schema validation.
@@ -110,6 +112,37 @@ enforce({ name: 'Laura', code: 'x23' }).shape({ name: enforce.isString() });
 ```js
 enforce({ name: 'Laura', code: 'x23' }).loose({ name: enforce.isString() });
 // ✅ This will pass with `code` not being validated
+```
+
+### enforce.pick() - pick a subset of fields
+
+When you want to validate only a specific subset of fields from an existing schema, you can use `enforce.pick`. This rule validates only the designated fields, ignoring any extra keys present.
+
+```js
+enforce({ name: 'Laura', code: 'x23', internal: true }).pick(
+  {
+    name: enforce.isString(),
+    code: enforce.isString(),
+    internal: enforce.isBoolean(),
+  },
+  ['name', 'code'],
+);
+// ✅ This will pass, picking only the `name` and `code` fields for validation
+```
+
+### enforce.omit() - omit a subset of fields
+
+When you want to validate an object against a schema but explicitly exclude certain fields from that validation, use `enforce.omit`.
+
+```js
+enforce({ name: 'Laura', code: 'x23' }).omit(
+  {
+    name: enforce.isString(),
+    code: enforce.isNumber(),
+  },
+  'code',
+);
+// ✅ This will pass, validating `name` but skipping `code`
 ```
 
 ## enforce.isArrayOf() - array shape matching


### PR DESCRIPTION
## Summary

- Add `pick` and `omit` schema rules to n4s that allow validating a subset of schema fields
- Implement `schemaObjectUtils` for shared key-filtering logic used by both modifiers
- Wire schema modifiers into the lazy evaluation chain with proper type definitions
- Add comprehensive unit tests for pick, omit, and schemaObjectUtils

## Stack
- **PR 1/3** (this PR)
- PR 2/3: vest schema filtering via focus/only → pick/omit
- PR 3/3: getData resolver on suite result

## Test plan
- [x] Unit tests for `pick` (field selection, nested schemas, edge cases)
- [x] Unit tests for `omit` (field exclusion, nested schemas, edge cases)
- [x] Unit tests for `schemaObjectUtils` (key filtering utilities)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enforce.pick() and enforce.omit() for validating selected or excluded object fields.

* **Documentation**
  * Added "Lazy Rule Structure" and usage examples for pick/omit and lazy builder flows.

* **Tests**
  * Added comprehensive unit and integration tests for pick/omit, lazy API, and related utilities.

* **Security**
  * Strengthened detection of dangerous/prototype keys in schema validation.

* **Refactor**
  * Internal lazy-rule wiring modularized with no external behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->