### PR TITLE
feat(vest): add schema filtering via focus/only with pick/omit

### DIFF
--- a/packages/vest/src/suite/__tests__/schema.example.ts
+++ b/packages/vest/src/suite/__tests__/schema.example.ts
@@ -170,4 +170,8 @@ suite2.run({ foo: 'baz' });
 // ✅ Should pass
 suite2.run({ foo: 'baz', bar: 1 });
 
+// ✅ Should pass missing age when focused on name using `pick` organically
+// The schema compiler will inherently drop the `age` requirement.
+suite.focus({ only: 'name' }).run({ name: 'John' });
+
 export { validSuite, looseSuite, nestedSuite };

--- a/packages/vest/src/suite/__tests__/schema.example.ts
+++ b/packages/vest/src/suite/__tests__/schema.example.ts
@@ -171,7 +171,7 @@ suite2.run({ foo: 'baz' });
 suite2.run({ foo: 'baz', bar: 1 });
 
 // ✅ Should pass missing age when focused on name using `pick` organically
-// The schema compiler will inherently drop the `age` requirement.
+// The schema parser will inherently drop the `age` requirement.
 suite.focus({ only: 'name' }).run({ name: 'John' });
 
 export { validSuite, looseSuite, nestedSuite };

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -346,5 +346,38 @@ describe('Schema Runtime Validation', () => {
       expect(res.hasErrors()).toBe(true);
       expect(res.hasErrors('required')).toBe(true);
     });
+
+    it('should maintain state of previously tested fields during focused runs', () => {
+      const schema = enforce.shape({
+        field1: enforce.isString(),
+        field2: enforce.isString(),
+      });
+
+      const suite = create(data => {
+        test('field1', () => {
+          enforce(data.field1).isNotBlank();
+        });
+        test('field2', () => {
+          enforce(data.field2).isNotBlank();
+        });
+      }, schema);
+      expect(suite.get().isValid('field1')).toBe(false);
+      expect(suite.get().isValid('field2')).toBe(false);
+
+      // First run: Both fields
+      suite.run({ field1: 'value1', field2: 'value2' });
+      expect(suite.get().isValid('field1')).toBe(true);
+      expect(suite.get().isValid('field2')).toBe(true);
+
+      // Second run: Focused on field1 only. field2 should remain valid from previous run.
+      suite
+        .focus({ only: 'field1' })
+        // @ts-expect-error - Invalid data
+        .run({ field1: null, field2: 'value2' });
+
+      expect(suite.get().isValid('field1')).toBe(false);
+      expect(suite.get().isValid('field2')).toBe(true); // Should remain valid from first run
+      expect(suite.get().testCount).toBe(2); // Both tests should be in the result
+    });
   });
 });

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -38,9 +38,9 @@ describe('Schema Runtime Validation', () => {
       expect(result.hasErrors('age')).toBe(true);
     });
 
-    it('should skip schema validation when "only" is active', () => {
+    it('should validate only the focused fields when "only" is active', () => {
       // Invalid data for schema (age is string), but we focus on 'name'
-      // The schema validation should be skipped entirely
+      // The schema validation should pick 'name' and skip 'age'
       const result = suite
         .focus({ only: 'name' })
         // @ts-expect-error - Invalid data
@@ -50,7 +50,7 @@ describe('Schema Runtime Validation', () => {
       expect(result.isValid()).toBe(true);
     });
 
-    it('should skip schema validation when "only" is active via suite.focus().run()', () => {
+    it('should validate only the focused fields when "only" is active via suite.focus().run()', () => {
       // Invalid data for schema
       const result = suite
         .focus({ only: ['name'] })
@@ -58,6 +58,22 @@ describe('Schema Runtime Validation', () => {
         .run({ name: 'John', age: '30' });
 
       expect(result.hasErrors('age')).toBe(false);
+      expect(result.isValid()).toBe(true);
+    });
+
+    it('should drop intersected fields and parse schemas securely when only and skip intersect', () => {
+      // Only runs fields uniquely listed in `only` missing from `skip` natively.
+      // Expected execution: 'name' evaluates. 'age' and 'tags' bypass safely.
+      const result = suite
+        .focus({ only: ['name', 'age'], skip: 'age' })
+        // @ts-expect-error - Invalid data
+        .run({ name: 'John', age: 'thirty', tags: 'invalid_array' });
+
+      // Validating assertions
+      expect(result.hasErrors('name')).toBe(false); // Valid string evaluates correctly
+      expect(result.hasErrors('age')).toBe(false); // Skipped cleanly
+      expect(result.hasErrors('tags')).toBe(false); // Implicitly bypassed because it's missing from `only`
+
       expect(result.isValid()).toBe(true);
     });
   });
@@ -170,7 +186,7 @@ describe('Schema Runtime Validation', () => {
       expect(result.getErrors('price')).toContain('Price must be a number');
     });
 
-    it('should not run with focus enabled', () => {
+    it('should only validate focused schema fields with focus enabled', () => {
       const schemaWithMessage = enforce.shape({
         price: enforce.isNumber().message('Price must be a number'),
         quantity: enforce.isNumber().message('Quantity must be a number'),
@@ -182,9 +198,9 @@ describe('Schema Runtime Validation', () => {
         });
       }, schemaWithMessage);
 
-      // Focus on quantity, invalid price should be ignored
+      // Focus on quantity, invalid price should be ignored naturally by `pick`
       const result = testSuite.focus({ only: 'quantity' }).run({
-        price: 'invalid',
+        price: 'invalid', // should be naturally dropped from validation
         quantity: 10,
       });
 
@@ -303,9 +319,10 @@ describe('Schema Runtime Validation', () => {
   });
 
   describe('Stateful behavior', () => {
-    it('should run schema validation only when not focused even if ran focused previously', () => {
+    it('should run schema validation dynamically based on focus per execution', () => {
       const schema = enforce.shape({
         required: enforce.isString(),
+        field: enforce.optional(enforce.isString()), // Define 'field' so it's a valid generic for .only()
       });
 
       const suite = create(_data => {
@@ -313,15 +330,17 @@ describe('Schema Runtime Validation', () => {
       }, schema);
 
       // First run: Focused
-      // Schema validation should be skipped
-      // @ts-expect-error - Invalid data
-      let res = suite.focus({ only: 'field' }).run({ required: 123 });
+      // Schema validation should pick 'field' and ignore 'required'
+      let res = suite.focus({ only: 'field' }).run({
+        // @ts-expect-error - Invalid data skipped by focus filtering
+        required: 123,
+      });
 
       expect(res.hasErrors()).toBe(false);
       expect(res.isValid()).toBe(true);
 
       // Second run: Not focused
-      // Schema validation should run and fail
+      // Schema validation should pick all fields intrinsically and fail
       // @ts-expect-error - Invalid data
       res = suite.run({ required: 123 });
       expect(res.hasErrors()).toBe(true);

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -1,3 +1,4 @@
+import { enforce } from 'n4s';
 import {
   assign,
   asArray,
@@ -61,8 +62,8 @@ export function useCreateSuiteRunner<
     const { resolve, promise } = withResolvers<SuiteResult<F, G, S>>();
 
     const schemaInput = args[0];
-    const schemaRunResult = shouldRunSchema(schema, transformedModifiers)
-      ? runSchemaWithParse(schema, schemaInput)
+    const schemaRunResult = shouldRunSchema(schema)
+      ? runSchemaWithParse(schema, schemaInput, transformedModifiers)
       : undefined;
 
     const callbackInput = getCallbackInput(schemaRunResult, schemaInput);
@@ -107,19 +108,7 @@ export function useCreateSuiteRunner<
       },
     );
 
-    const result = assign(promise, suiteResult);
-
-    Object.defineProperty(result, 'run', {
-      configurable: true,
-      enumerable: false,
-      value: Object.freeze({
-        data: runData,
-        time: runTime,
-      }),
-      writable: true,
-    });
-
-    return result;
+    return bindSuiteResultMethods(promise, suiteResult, runData, runTime);
   };
 }
 
@@ -172,7 +161,7 @@ function useRunSuiteCallback<
     (suiteCallback as CB)(...args);
 
     IsolateReorderable(
-      runSchemaValidation(schema, modifiers, schemaRunResult),
+      runSchemaValidation(schema, schemaRunResult),
       undefined,
       {
         tests: [],
@@ -200,17 +189,13 @@ function useTransformedModifiers<F extends TFieldName>(
 /**
  * Emits schema failures into vest test tree.
  */
-function runSchemaValidation<
-  F extends TFieldName,
-  S extends TSchema = undefined,
->(
+function runSchemaValidation<S extends TSchema = undefined>(
   schema: S | undefined,
-  modifiers: ReturnType<typeof useTransformedModifiers<F>>,
   schemaRunResult?: SchemaRunResult[],
 ) {
   // eslint-disable-next-line complexity
   return () => {
-    if (!shouldRunSchema(schema, modifiers) || !schemaRunResult) {
+    if (!shouldRunSchema(schema) || !schemaRunResult) {
       return;
     }
 
@@ -236,30 +221,21 @@ function runSchemaValidation<
  * Attempts to parse the schema. Returns null if parse fails gracefully,
  * so the caller can fall back to schema.run.
  */
-function tryParseSchema(schema: any, data: unknown): SchemaRunResult[] | null {
-  if (!isFunction(schema.parse)) {
-    return null;
-  }
+function tryParseSchema(
+  executableSchema: any,
+  data: unknown,
+): SchemaRunResult[] | null {
+  if (!isFunction(executableSchema.parse)) return null;
 
   try {
-    const parsedValue = schema.parse(data);
+    const parsedValue = executableSchema.parse(data);
 
-    if (shouldRunAfterParse(schema)) {
-      return normalizeSchemaRunResult(schema.run(parsedValue), parsedValue);
-    }
-
-    return [
-      {
-        pass: true,
-        type: parsedValue,
-      },
-    ];
+    return shouldRunAfterParse(executableSchema)
+      ? normalizeSchemaRunResult(executableSchema.run(parsedValue), parsedValue)
+      : [{ pass: true, type: parsedValue }];
   } catch (error) {
-    if (!isExpectedSchemaParseError(error)) {
-      throw error;
-    }
-    // Expected validation failures can fallback to run(raw) for field-level path/message details.
-    return null;
+    if (isExpectedSchemaParseError(error)) return null;
+    throw error;
   }
 }
 
@@ -269,14 +245,20 @@ function tryParseSchema(schema: any, data: unknown): SchemaRunResult[] | null {
  * 2) if parse succeeds, treat it as the authoritative validation output
  * 3) on expected parse validation failures, fallback to run(raw)
  */
-function runSchemaWithParse(schema: any, data: unknown): SchemaRunResult[] {
-  const parseResult = tryParseSchema(schema, data);
+function runSchemaWithParse(
+  schema: any,
+  data: unknown,
+  modifiers: { only?: unknown; skip?: unknown },
+): SchemaRunResult[] {
+  const executableSchema = applySchemaFocus(schema, modifiers);
+
+  const parseResult = tryParseSchema(executableSchema, data);
   if (parseResult) {
     return parseResult;
   }
 
-  if (isFunction(schema.run)) {
-    return normalizeSchemaRunResult(schema.run(data), data);
+  if (isFunction(executableSchema.run)) {
+    return normalizeSchemaRunResult(executableSchema.run(data), data);
   }
 
   return [
@@ -285,6 +267,55 @@ function runSchemaWithParse(schema: any, data: unknown): SchemaRunResult[] {
       type: data,
     },
   ];
+}
+
+const N4S_VENDOR = 'n4s';
+
+function isN4sSchema(schema: any): boolean {
+  return schema?.['~standard']?.vendor === N4S_VENDOR && !!schema?.__schema;
+}
+
+function applySchemaFocus(
+  schema: any,
+  modifiers: { only?: unknown; skip?: unknown },
+): any {
+  if (!isN4sSchema(schema)) {
+    return schema;
+  }
+
+  const only = buildArrayProp(modifiers.only);
+  const skip = buildArrayProp(modifiers.skip);
+
+  return buildFocusedSchemaInstance(schema, only, skip);
+}
+
+function buildArrayProp(prop: unknown): string[] | null {
+  return prop ? (asArray(prop) as string[]) : null;
+}
+
+function buildIntersectedSchemaInstance(
+  schema: any,
+  only: string[],
+  skip: string[],
+): any {
+  return enforce.pick(
+    schema.__schema,
+    only.filter(f => !skip.includes(f)),
+  );
+}
+
+function buildFocusedSchemaInstance(
+  schema: any,
+  only: string[] | null,
+  skip: string[] | null,
+): any {
+  if (only) {
+    return skip
+      ? buildIntersectedSchemaInstance(schema, only, skip)
+      : enforce.pick(schema.__schema, only);
+  }
+
+  return skip ? enforce.omit(schema.__schema, skip) : schema;
 }
 
 /**
@@ -359,8 +390,6 @@ function isExpectedSchemaParseError(error: unknown): boolean {
   return typedError.isValidation === true || typedError.name === 'TypeError';
 }
 
-const N4S_VENDOR = 'n4s';
-
 /**
  * Determines whether schema.run should execute after a successful parse call.
  *
@@ -376,16 +405,31 @@ function shouldRunAfterParse(schema: any): boolean {
   return schema?.['~standard']?.vendor !== N4S_VENDOR;
 }
 
-/**
- * Schema should run only when schema exists and the run is not field-focused.
- */
-function shouldRunSchema(
-  schema: unknown,
-  modifiers: { only?: unknown },
-): boolean {
-  const hasOnly = isArray(modifiers.only)
-    ? modifiers.only.length > 0
-    : !!modifiers.only;
+function shouldRunSchema(schema: unknown): boolean {
+  return !!schema;
+}
 
-  return !hasOnly && !!schema;
+function bindSuiteResultMethods<
+  F extends TFieldName,
+  G extends TGroupName,
+  S extends TSchema,
+>(
+  promise: Promise<SuiteResult<F, G, S>>,
+  suiteResult: SuiteResult<F, G, S>,
+  runData: unknown,
+  runTime: Date,
+): SuiteResult<F, G, S> {
+  const result = assign(promise, suiteResult);
+
+  Object.defineProperty(result, 'run', {
+    configurable: true,
+    enumerable: false,
+    value: Object.freeze({
+      data: runData,
+      time: runTime,
+    }),
+    writable: true,
+  });
+
+  return result;
 }

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -290,7 +290,9 @@ function applySchemaFocus(
 }
 
 function buildArrayProp(prop: unknown): string[] | null {
-  return prop ? (asArray(prop) as string[]) : null;
+  if (!prop) return null;
+  const arr = asArray(prop) as string[];
+  return arr.length > 0 ? arr : null;
 }
 
 function buildIntersectedSchemaInstance(

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -300,9 +300,10 @@ function buildIntersectedSchemaInstance(
   only: string[],
   skip: string[],
 ): any {
+  const skipSet = new Set(skip);
   return enforce.pick(
     schema.__schema,
-    only.filter(f => !skip.includes(f)),
+    only.filter(f => !skipSet.has(f)),
   );
 }
 

--- a/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
+++ b/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
@@ -132,7 +132,7 @@ enforce({ name: 'Laura', code: 'x23', internal: true }).pick(
 
 ### enforce.omit() - omit a subset of fields
 
-When you want to validate an object against a schema but explicitly exclude certain fields from that validation, use `enforce.omit`.
+When you want to validate an object against a schema but explicitly exclude certain fields from that validation, use `enforce.omit`. The second argument accepts a single key or an array of keys to omit.
 
 ```js
 enforce({ name: 'Laura', code: 'x23' }).omit(
@@ -143,6 +143,16 @@ enforce({ name: 'Laura', code: 'x23' }).omit(
   'code',
 );
 // ✅ This will pass, validating `name` but skipping `code`
+
+enforce({ name: 'Laura', code: 'x23', internal: true }).omit(
+  {
+    name: enforce.isString(),
+    code: enforce.isNumber(),
+    internal: enforce.isBoolean(),
+  },
+  ['code', 'internal'],
+);
+// ✅ This will pass, validating only `name` and skipping `code` and `internal`
 ```
 
 ## enforce.isArrayOf() - array shape matching

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -120,10 +120,10 @@ suite.focus({ onlyGroup: 'account' }); // typed group name
 ```
 
 :::note Focused runs
-When you focus the suite with `suite.only()` or `suite.focus({ only })`, schema validation is skipped for fields outside the focus scope. This allows you to validate a single field even if the full payload does not satisfy the schema.
+When you focus the suite with `suite.only()`, `suite.skip()`, or `suite.focus()`, Vest intelligently subsets your validation schema under the hood using `enforce.pick` and `enforce.omit`. This ensures that schema validation still runs securely for the fields in focus—and provides correct types in the test callback!—while safely ignoring un-focused fields and allowing you to validate partial payloads effectively.
 
 ```javascript
-// Validate only the username field
+// Validate only the username field, enforcing the schema for 'username' while ignoring 'age'
 suite.only('username').run({
   username: 'example',
 });


### PR DESCRIPTION
## Summary

- Wire n4s `pick`/`omit` into vest's suite runner so `focus({ only, skip })` narrows schema validation to specified fields
- Refactor `applySchemaFocus` and `buildFocusedSchemaInstance` for cleaner n4s vendor detection and intersection handling
- Extract `bindSuiteResultMethods` helper for result construction
- Add integration test for intersected only/skip behavior

## Stack
- PR 1/3: n4s pick/omit schema modifiers
- **PR 2/3** (this PR)
- PR 3/3: getData resolver on suite result

Depends on #1248

## Test plan
- [x] Integration test: intersected only/skip fields parse correctly
- [x] Existing schema runtime tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Focused runs (suite.only(), suite.focus(), suite.skip()) now subset validation so you can validate partial payloads (only focused fields).

* **Tests**
  * Expanded and clarified tests for focus behavior, focus+skip interactions, focused-run semantics, and dynamic per-run validation scenarios.

* **Documentation**
  * Updated guides and examples for focused runs and clarified omit()/omit-like usage to accept single keys or arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->