### PR TITLE
feat(types): distinguish schema input from output types for parser chains

### DIFF
--- a/packages/n4s/docs/schema.md
+++ b/packages/n4s/docs/schema.md
@@ -49,12 +49,12 @@ When a suite is created with a schema:
 - If `schema.parse` exists, it is used first.
 - On parse throw, Vest falls back to `schema.run` for rich path/message reporting.
 - The suite callback receives parsed data.
-- `SuiteResult.value` and `types.output` are the parsed output.
-- `types.input` and `types.output` are typed from the schema's `~standard.types`.
+- On successful validation, `SuiteResult.value` and `types.output` are the parsed output.
+- `types.input` and `types.output` are typed from the schema's `~standard.types`. At runtime, both hold the parsed output value.
 
 ## Type-level input vs output distinction
 
-Parser chains produce `RuleInstance<T, [Args]>` where `Args[0]` is the input type and `T` is the
+Parser chains produce `RuleInstance<T, Args>` where `Args[0]` is the input type and `T` is the
 output type. For example, `enforce.isNumeric().toNumber()` produces `RuleInstance<number, [string | number]>`:
 
 - Input type (`Args[0]`): `string | number` — what `suite.run()` accepts.

--- a/packages/n4s/docs/schema.md
+++ b/packages/n4s/docs/schema.md
@@ -49,8 +49,24 @@ When a suite is created with a schema:
 - If `schema.parse` exists, it is used first.
 - On parse throw, Vest falls back to `schema.run` for rich path/message reporting.
 - The suite callback receives parsed data.
-- `SuiteResult.value` and `types.output` are parsed output.
-- `types.input` remains the original input.
+- `SuiteResult.value` and `types.output` are the parsed output.
+- `types.input` and `types.output` are typed from the schema's `~standard.types`.
+
+## Type-level input vs output distinction
+
+Parser chains produce `RuleInstance<T, [Args]>` where `Args[0]` is the input type and `T` is the
+output type. For example, `enforce.isNumeric().toNumber()` produces `RuleInstance<number, [string | number]>`:
+
+- Input type (`Args[0]`): `string | number` — what `suite.run()` accepts.
+- Output type (`T`): `number` — what the suite callback receives and what `result.value` contains.
+
+This distinction is preserved through `~standard.types.input` and `~standard.types.output` on each
+`RuleInstance`, and `InferSchemaData<S>` / `InferSchemaOutput<S>` extract the correct side.
+
+The `types` property on `RuleInstance`'s `~standard` declaration is intersected as required (not
+optional as in the base `StandardSchemaV1.Props`) so that TypeScript's conditional type inference
+can reliably match `{ '~standard': { types: { input: infer I } } }` and extract the input type
+separately from the output type.
 
 ## Complexity notes
 

--- a/packages/n4s/src/rules/schemaRules/__tests__/schemaObjectUtils.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schemaObjectUtils.test.ts
@@ -25,9 +25,9 @@ describe('schemaObjectUtils', () => {
     });
 
     it('Should return empty array for non-objects', () => {
-      expect(ownKeys(null as any)).toEqual([]);
-      expect(ownKeys(undefined as any)).toEqual([]);
-      expect(ownKeys('string' as any)).toEqual([]);
+      expect(ownKeys(null)).toEqual([]);
+      expect(ownKeys(undefined)).toEqual([]);
+      expect(ownKeys('string')).toEqual([]);
     });
   });
 
@@ -77,9 +77,9 @@ describe('schemaObjectUtils', () => {
     });
 
     it('Should handle non-object payloads gracefully (returns null)', () => {
-      expect(checkDangerousKeys(null as any, {})).toBeNull();
-      expect(checkDangerousKeys(undefined as any, {})).toBeNull();
-      expect(checkDangerousKeys('string' as any, {})).toBeNull();
+      expect(checkDangerousKeys(null, {})).toBeNull();
+      expect(checkDangerousKeys(undefined, {})).toBeNull();
+      expect(checkDangerousKeys('string', {})).toBeNull();
     });
   });
 });

--- a/packages/n4s/src/utils/RuleInstance.ts
+++ b/packages/n4s/src/utils/RuleInstance.ts
@@ -7,8 +7,8 @@ import { RuleRunReturn } from './RuleRunReturn';
  * RuleInstances support chaining and can be reused across multiple validations.
  * Implements StandardSchemaV1 for interoperability with other schema libraries.
  *
- * @template T - The type of value this rule validates
- * @template Args - The argument types for this rule (first arg is always the value)
+ * @template T - The output type this rule produces (may differ from input when parsers are used)
+ * @template Args - The argument types for this rule (Args[0] is the input type)
  *
  * @example
  * ```typescript
@@ -44,8 +44,17 @@ export class RuleInstance<T, Args extends any[] = any[]> {
   // Type-only declaration for parse helper that throws on issues
   parse!: (...args: Args) => T;
 
-  // Type-only declaration for StandardSchema property
-  '~standard'!: StandardSchemaV1.Props<Args[0], T>;
+  // Type-only declaration for StandardSchema property.
+  // The intersection with `{ readonly types: ... }` narrows `types` from optional
+  // (as declared in StandardSchemaV1.Props) to required. This is safe because
+  // RuleInstance.create() always sets `types` at runtime, and it enables
+  // TypeScript's conditional type inference in `InferSchemaData<S>` and
+  // `InferSchemaOutput<S>` to correctly extract `input` (Args[0]) vs `output` (T)
+  // — which is critical for parser chains where input and output types differ
+  // (e.g., isNumeric().toNumber(): input = string | number, output = number).
+  '~standard'!: StandardSchemaV1.Props<Args[0], T> & {
+    readonly types: StandardSchemaV1.Types<Args[0], T>;
+  };
 
   private constructor() {}
 

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -47,17 +47,17 @@ type SuiteMethods<
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
-  ) => SuiteResult<F, G>;
+  ) => SuiteResult<F, G, S>;
   runStatic: (
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
-  ) => SuiteResult<F, G>;
+  ) => SuiteResult<F, G, S>;
   validate: (
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
-  ) => SuiteResult<F, G>;
+  ) => SuiteResult<F, G, S>;
   subscribe: Subscribe;
 } & AfterMethods<F, G, T, S> &
   TTypedMethods<F, G> &
@@ -79,7 +79,7 @@ type FocusedMethods<
     ...args: S extends undefined
       ? Parameters<T>
       : [data: Partial<InferSchemaData<S>>, ...args: any[]]
-  ) => SuiteResult<F, G>;
+  ) => SuiteResult<F, G, S>;
 };
 
 type AfterMethods<
@@ -96,7 +96,7 @@ type AfterMethods<
     ...args: S extends undefined
       ? Parameters<T>
       : [data: InferSchemaData<S>, ...args: any[]]
-  ) => SuiteResult<F, G>;
+  ) => SuiteResult<F, G, S>;
 };
 
 /**

--- a/packages/vest/src/suite/__tests__/runSummary.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/runSummary.integration.test.ts
@@ -72,7 +72,6 @@ describe('suite result run summary metadata', () => {
 
       const suite = create(() => {}, schema);
 
-      // @ts-expect-error - testing parser coercion: age is string '25' that gets parsed to number
       const result = suite.run({ name: '  alice  ', age: '25' });
 
       // raw reflects the parsed/transformed input for the current run
@@ -101,7 +100,7 @@ describe('suite result run summary metadata', () => {
       // Run 1: focus on firstName only, pass untrimmed input
       const res1 = suite
         .focus({ only: 'firstName' })
-        .run({ firstName: '  john  ' } as any);
+        .run({ firstName: '  john  ' });
 
       // raw is the transformed value for this run
       expect(res1.run.data.raw).toEqual({ firstName: 'JOHN' });
@@ -111,7 +110,7 @@ describe('suite result run summary metadata', () => {
       // Run 2: focus on lastName only, pass untrimmed input
       const res2 = suite
         .focus({ only: 'lastName' })
-        .run({ lastName: '  doe  ' } as any);
+        .run({ lastName: '  doe  ' });
 
       // raw is ONLY the current run's transformed value
       expect(res2.run.data.raw).toEqual({ lastName: 'doe' });
@@ -132,17 +131,15 @@ describe('suite result run summary metadata', () => {
       const suite = create(() => {}, schema);
 
       // Run 1: both fields
-      // @ts-expect-error - testing parser coercion: score is string that gets parsed to number
       const res1 = suite.run({ score: '42', label: '  hello  ' });
       expect(res1.run.data.parsed).toEqual({ score: 42, label: 'HELLO' });
 
       // Run 2: focus on score only, update it
-      const res2 = suite.focus({ only: 'score' }).run({ score: '99' } as any);
+      const res2 = suite.focus({ only: 'score' }).run({ score: '99' });
       // parsed retains the previous label and updates score
       expect(res2.run.data.parsed).toEqual({ score: 99, label: 'HELLO' });
 
       // Run 3: update both again
-      // @ts-expect-error - testing parser coercion
       const res3 = suite.run({ score: '7', label: '  world  ' });
       expect(res3.run.data.parsed).toEqual({ score: 7, label: 'WORLD' });
     });
@@ -156,9 +153,7 @@ describe('suite result run summary metadata', () => {
       const suite = create(() => {}, schema);
 
       // Run 1: valid name, parsed to trimmed+uppercase
-      const res1 = suite
-        .focus({ only: 'name' })
-        .run({ name: '  valid  ' } as any);
+      const res1 = suite.focus({ only: 'name' }).run({ name: '  valid  ' });
       expect(res1.run.data.parsed).toEqual({ name: 'VALID' });
 
       // Run 2: invalid age (string instead of number) — schema validation fails
@@ -181,19 +176,17 @@ describe('suite result run summary metadata', () => {
       const suite = create(() => {}, schema);
 
       // Run 1: focus on count — input is string '10', parsed should be number 10
-      const res1 = suite.focus({ only: 'count' }).run({ count: '10' } as any);
+      const res1 = suite.focus({ only: 'count' }).run({ count: '10' });
       expect(res1.run.data.parsed).toEqual({ count: 10 });
-      expect(typeof (res1.run.data.parsed as any).count).toBe('number');
+      expect(typeof res1.run.data.parsed?.count).toBe('number');
 
       // Run 2: focus on tag
-      const res2 = suite
-        .focus({ only: 'tag' })
-        .run({ tag: '  trimmed  ' } as any);
+      const res2 = suite.focus({ only: 'tag' }).run({ tag: '  trimmed  ' });
       expect(res2.run.data.parsed).toEqual({ count: 10, tag: 'trimmed' });
 
       // Verify the count from Run 1 is still a number, not reverted to string
-      expect(typeof (res2.run.data.parsed as any).count).toBe('number');
-      expect((res2.run.data.parsed as any).count).toBe(10);
+      expect(typeof res2.run.data.parsed?.count).toBe('number');
+      expect(res2.run.data.parsed?.count).toBe(10);
     });
   });
 });

--- a/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.parse.integration.test.ts
@@ -116,7 +116,6 @@ describe('suite schema integration', () => {
 
     expect(callbackData).toEqual({ quantity: 10, label: 'item' });
     expect(result.value).toEqual({ quantity: 10, label: 'item' });
-    // @ts-expect-error - types is defined at runtime when schema is used, but typed as undefined in SuiteResult return
     expect(result.types?.output).toEqual({
       quantity: 10,
       label: 'item',
@@ -211,12 +210,9 @@ describe('suite schema integration', () => {
     }, schema);
 
     const result = suite.run({
-      // @ts-expect-error - testing coercible string
       age: '180',
       name: '  jANE DOE ',
-      // @ts-expect-error - testing coercible string
       subscribed: ' yes ',
-      // @ts-expect-error - testing array to string mapping coercion
       tags: ['vest', 'n4s', 'vest'],
       payload: '{"env":"test"}',
     });
@@ -252,7 +248,6 @@ describe('suite schema integration', () => {
       });
     }, schema);
 
-    // @ts-expect-error - testing invalid fallback schema error
     const result = suite.run({ subscribed: 'unknown' });
 
     expect(callbackData).toEqual({ subscribed: 'unknown' });

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -296,12 +296,10 @@ describe('Schema Runtime Validation', () => {
         });
       }, schema);
 
-      // @ts-expect-error - testing parser coercion: age is string '32' that gets parsed to number
       const result = parsedSuite.run({ age: '32' });
 
       expect(receivedAge).toBe(32);
       expect(result.value).toEqual({ age: 32 });
-      // @ts-expect-error - types is defined at runtime when schema is used, but typed as undefined in SuiteResult return
       expect(result.types?.output).toEqual({ age: 32 });
     });
   });
@@ -315,7 +313,6 @@ describe('Schema Runtime Validation', () => {
 
       const suite = create(() => {}, schema);
 
-      // @ts-expect-error - testing parser coercion: age is string
       const result = suite.run({ name: '  bob  ', age: '30' });
 
       // raw is the single-run transformed output
@@ -326,8 +323,9 @@ describe('Schema Runtime Validation', () => {
 
       // Proves the parsers ran: original was '  bob  ' (string), now 'BOB' (trimmed, uppercased)
       // and original age was '30' (string), now 30 (number)
-      expect(typeof (result.run.data.parsed as any).age).toBe('number');
-      expect((result.run.data.parsed as any).name).toBe('BOB');
+      expect(typeof result.run.data.parsed?.age).toBe('number');
+      expect(result.run.data.parsed?.age).toBe(30);
+      expect(result.run.data.parsed?.name).toBe('BOB');
     });
 
     it('should cumulatively assign parsed data across focused suite runs using enforce parsers', () => {
@@ -341,13 +339,13 @@ describe('Schema Runtime Validation', () => {
       // Run 1: focus on username only
       const res1 = suite
         .focus({ only: 'username' })
-        .run({ username: '  Alice  ' } as any);
+        .run({ username: '  Alice  ' });
 
       expect(res1.run.data.raw).toEqual({ username: 'alice' });
       expect(res1.run.data.parsed).toEqual({ username: 'alice' });
 
       // Run 2: focus on score only
-      const res2 = suite.focus({ only: 'score' }).run({ score: '99' } as any);
+      const res2 = suite.focus({ only: 'score' }).run({ score: '99' });
 
       // raw is ONLY the current run's transformed value
       expect(res2.run.data.raw).toEqual({ score: 99 });
@@ -356,9 +354,9 @@ describe('Schema Runtime Validation', () => {
       expect(res2.run.data.parsed).toEqual({ username: 'alice', score: 99 });
 
       // Prove type persistence: score is number, not string
-      expect(typeof (res2.run.data.parsed as any).score).toBe('number');
+      expect(typeof res2.run.data.parsed?.score).toBe('number');
       // And username from Run 1 is still present as 'alice'
-      expect((res2.run.data.parsed as any).username).toBe('alice');
+      expect(res2.run.data.parsed?.username).toBe('alice');
     });
   });
 
@@ -422,6 +420,327 @@ describe('Schema Runtime Validation', () => {
       expect(suite.get().isValid('field1')).toBe(false);
       expect(suite.get().isValid('field2')).toBe(true); // Should remain valid from first run
       expect(suite.get().testCount).toBe(2); // Both tests should be in the result
+    });
+  });
+});
+
+describe('Schema input vs output type inference', () => {
+  describe('isNumeric().toNumber() — input: string | number, output: number', () => {
+    it('should accept string input without type error', () => {
+      const schema = enforce.shape({
+        age: enforce.isNumeric().toNumber(),
+      });
+      const suite = create(data => {
+        test('age', () => {
+          enforce(data.age).isNumber();
+        });
+      }, schema);
+
+      // string input is valid because isNumeric() accepts string | number
+      const result = suite.run({ age: '25' });
+      expect(result.hasErrors()).toBe(false);
+      expect(result.isValid()).toBe(true);
+      expect(result.value).toEqual({ age: 25 });
+    });
+
+    it('should accept number input without type error', () => {
+      const schema = enforce.shape({
+        age: enforce.isNumeric().toNumber(),
+      });
+      const suite = create(data => {
+        test('age', () => {
+          enforce(data.age).isNumber();
+        });
+      }, schema);
+
+      // number input is also valid
+      const result = suite.run({ age: 25 });
+      expect(result.isValid()).toBe(true);
+      expect(result.value).toEqual({ age: 25 });
+    });
+
+    it('should coerce string to number in parsed output', () => {
+      const schema = enforce.shape({
+        age: enforce.isNumeric().toNumber(),
+      });
+      const suite = create(data => {
+        test('age', () => {
+          enforce(data.age).isNumber();
+        });
+      }, schema);
+
+      const result = suite.run({ age: '42' });
+      expect(result.value).toEqual({ age: 42 });
+      expect(typeof result.value?.age).toBe('number');
+
+      // run.data holds the parsed value for both raw and parsed
+      expect(result.run.data.raw).toEqual({ age: 42 });
+      expect(result.run.data.parsed).toEqual({ age: 42 });
+      expect(typeof result.run.data.parsed?.age).toBe('number');
+    });
+  });
+
+  describe('isString().trim().toUpper() — input: string, output: string', () => {
+    it('should accept string input and produce transformed string output', () => {
+      const schema = enforce.shape({
+        name: enforce.isString().trim().toUpper(),
+      });
+      const suite = create(data => {
+        test('name', () => {
+          enforce(data.name).isNotBlank();
+        });
+      }, schema);
+
+      const result = suite.run({ name: '  alice  ' });
+      expect(result.isValid()).toBe(true);
+      expect(result.value).toEqual({ name: 'ALICE' });
+
+      // types reflect the parsed data at runtime
+      expect(result.types?.output).toEqual({ name: 'ALICE' });
+    });
+  });
+
+  describe('isString().toBoolean() — input: string, output: boolean', () => {
+    it('should accept string input and produce boolean output', () => {
+      const schema = enforce.shape({
+        active: enforce.isString().trim().toBoolean(),
+      });
+      const suite = create(data => {
+        test('active', () => {
+          enforce(data.active).isTruthy();
+        });
+      }, schema);
+
+      const result = suite.run({ active: ' yes ' });
+      expect(result.isValid()).toBe(true);
+      expect(result.value?.active).toBe(true);
+      expect(typeof result.value?.active).toBe('boolean');
+    });
+  });
+
+  describe('isArray<string>().uniq().join() — input: string[], output: string', () => {
+    it('should accept array input and produce string output', () => {
+      const schema = enforce.shape({
+        tags: enforce.isArray<string>().uniq().join('|'),
+      });
+      const suite = create(data => {
+        test('tags', () => {
+          enforce(data.tags).isNotEmpty();
+        });
+      }, schema);
+
+      const result = suite.run({ tags: ['a', 'b', 'a'] });
+      expect(result.isValid()).toBe(true);
+      expect(result.value?.tags).toBe('a|b');
+      expect(typeof result.value?.tags).toBe('string');
+    });
+  });
+
+  describe('isNumeric().toNumber().clamp() — multi-step parser chain', () => {
+    it('should accept string input through multi-step chain', () => {
+      const schema = enforce.shape({
+        score: enforce.isNumeric().toNumber().clamp(0, 100),
+      });
+      const suite = create(data => {
+        test('score', () => {
+          enforce(data.score).greaterThanOrEquals(0);
+        });
+      }, schema);
+
+      // String '150' accepted by isNumeric, converted to 150, clamped to 100
+      const result = suite.run({ score: '150' });
+      expect(result.isValid()).toBe(true);
+      expect(result.value?.score).toBe(100);
+    });
+
+    it('should accept number input through multi-step chain', () => {
+      const schema = enforce.shape({
+        score: enforce.isNumeric().toNumber().clamp(0, 100),
+      });
+      const suite = create(data => {
+        test('score', () => {
+          enforce(data.score).greaterThanOrEquals(0);
+        });
+      }, schema);
+
+      const result = suite.run({ score: -5 });
+      expect(result.isValid()).toBe(true);
+      expect(result.value?.score).toBe(0);
+    });
+  });
+
+  describe('Mixed schema with parser and non-parser fields', () => {
+    it('should correctly type each field independently', () => {
+      const schema = enforce.shape({
+        name: enforce.isString(),
+        age: enforce.isNumeric().toNumber(),
+        active: enforce.isString().toBoolean(),
+        tags: enforce.isArray<string>().uniq().join(','),
+      });
+
+      const suite = create(data => {
+        test('name', () => {
+          enforce(data.name).isNotBlank();
+        });
+      }, schema);
+
+      // Each field uses its own input type:
+      // name: string (no coercion)
+      // age: string | number (isNumeric accepts both)
+      // active: string (isString)
+      // tags: string[] (isArray<string>)
+      const result = suite.run({
+        name: 'Bob',
+        age: '30',
+        active: 'true',
+        tags: ['x', 'y', 'x'],
+      });
+
+      expect(result.isValid()).toBe(true);
+      expect(result.value).toEqual({
+        name: 'Bob',
+        age: 30,
+        active: true,
+        tags: 'x,y',
+      });
+    });
+
+    it('should still reject genuinely invalid input types', () => {
+      const schema = enforce.shape({
+        name: enforce.isString(),
+        age: enforce.isNumber(),
+      });
+
+      const suite = create(() => {}, schema);
+
+      // isNumber (not isNumeric) — input IS number, string is invalid
+      // @ts-expect-error - isNumber() does not accept string input
+      const result = suite.run({ name: 'Bob', age: '30' });
+      expect(result.hasErrors('age')).toBe(true);
+    });
+  });
+
+  describe('result.types carries schema type information', () => {
+    it('should have types defined when schema is used', () => {
+      const schema = enforce.shape({
+        value: enforce.isNumeric().toNumber(),
+      });
+      const suite = create(data => {
+        test('value', () => {
+          enforce(data.value).isNumber();
+        });
+      }, schema);
+
+      const result = suite.run({ value: '99' });
+
+      // types is defined (not undefined) when schema is present
+      expect(result.types).toBeDefined();
+      expect(result.types?.output).toEqual({ value: 99 });
+      // types.input also holds the parsed data at runtime
+      expect(result.types?.input).toEqual({ value: 99 });
+    });
+
+    it('should have matching input and output when no parsers are used', () => {
+      const schema = enforce.shape({
+        name: enforce.isString(),
+        count: enforce.isNumber(),
+      });
+      const suite = create(data => {
+        test('name', () => {
+          enforce(data.name).isNotBlank();
+        });
+      }, schema);
+
+      const result = suite.run({ name: 'test', count: 5 });
+
+      expect(result.types?.input).toEqual({ name: 'test', count: 5 });
+      expect(result.types?.output).toEqual({ name: 'test', count: 5 });
+    });
+  });
+
+  describe('Focused runs with parser schemas', () => {
+    it('should accept partial input matching the focused field types', () => {
+      const schema = enforce.shape({
+        username: enforce.isString().trim().toLower(),
+        score: enforce.isNumeric().toNumber(),
+      });
+
+      const suite = create(data => {
+        test('score', () => {
+          enforce(data.score).isNumber();
+        });
+        test('username', () => {
+          enforce(data.username).isNotBlank();
+        });
+      }, schema);
+
+      // Focus on score — passing string '88' is valid because isNumeric accepts string | number
+      const result = suite.focus({ only: 'score' }).run({ score: '88' });
+      expect(result.hasErrors('score')).toBe(false);
+    });
+
+    it('should cumulatively merge parsed values across focused runs', () => {
+      const schema = enforce.shape({
+        a: enforce.isString().trim(),
+        b: enforce.isNumeric().toNumber(),
+      });
+
+      const suite = create(data => {
+        test('a', () => {
+          enforce(data.a).isNotBlank();
+        });
+        test('b', () => {
+          enforce(data.b).isNumber();
+        });
+      }, schema);
+
+      const r1 = suite.focus({ only: 'a' }).run({ a: '  x  ' });
+      expect(r1.run.data.parsed).toEqual({ a: 'x' });
+
+      const r2 = suite.focus({ only: 'b' }).run({ b: '7' });
+      expect(r2.run.data.parsed).toEqual({ a: 'x', b: 7 });
+    });
+  });
+
+  describe('n4s RuleInstance type-level contract', () => {
+    it('should expose correct input and output on ~standard.types', () => {
+      const rule = enforce.isNumeric().toNumber();
+      const types = rule['~standard'].types;
+
+      // The types property should exist (not optional)
+      expect(types).toBeDefined();
+      expect(types).toHaveProperty('input');
+      expect(types).toHaveProperty('output');
+    });
+
+    it('should distinguish input from output in shape schemas', () => {
+      const schema = enforce.shape({
+        x: enforce.isNumeric().toNumber(),
+      });
+      const types = schema['~standard'].types;
+      expect(types).toBeDefined();
+    });
+
+    it('should produce correct parsed value from parse()', () => {
+      const rule = enforce.isNumeric().toNumber();
+      expect(rule.parse('42')).toBe(42);
+      expect(rule.parse(42)).toBe(42);
+    });
+
+    it('should accept input type in test()', () => {
+      const rule = enforce.isNumeric().toNumber();
+      expect(rule.test('100')).toBe(true);
+      expect(rule.test(100)).toBe(true);
+    });
+
+    it('should produce correct shape parse with coercion', () => {
+      const schema = enforce.shape({
+        name: enforce.isString().trim().toUpper(),
+        score: enforce.isNumeric().toNumber(),
+      });
+
+      const parsed = schema.parse({ name: '  hello  ', score: '7' });
+      expect(parsed).toEqual({ name: 'HELLO', score: 7 });
     });
   });
 });

--- a/website/docs/api_reference.md
+++ b/website/docs/api_reference.md
@@ -277,3 +277,6 @@ After running your suite, the results object is returned. It has the following f
 - `isTested(fieldName)`: Returns true if the provided field has been tested.
 - `isValid(fieldName?)`: Returns true if the suite or the provided field is valid.
 - `isValidByGroup(groupName)`: Returns true if a certain group or a field in a group is valid or not.
+- `value`: The parsed schema output when the suite is valid. Typed as the schema's output type. `undefined` when invalid or when no schema is used.
+- `types`: When a schema is present, an object with `input` and `output` properties typed from the schema. `undefined` when no schema is used.
+- `run`: Metadata about the latest run, including `run.data.raw` (current run data), `run.data.parsed` (cumulative parsed data across focused runs), and `run.time` (timestamp).

--- a/website/docs/enforce/builtin-enforce-plugins/data_parsers.md
+++ b/website/docs/enforce/builtin-enforce-plugins/data_parsers.md
@@ -440,3 +440,20 @@ schema.parse({
 //   nickname: '',
 // }
 ```
+
+### TypeScript type inference
+
+Parser chains correctly distinguish between input and output types. The first rule in the chain determines the **input type** (what the caller passes in), and the last parser determines the **output type** (what the consumer receives).
+
+```typescript
+// Input: string | number → Output: number
+const ageRule = enforce.isNumeric().toNumber().clamp(0, 120);
+
+// Input: string → Output: boolean
+const subscribedRule = enforce.isString().trim().toBoolean();
+
+// Input: string[] → Output: string
+const tagsRule = enforce.isArray<string>().uniq().join('|');
+```
+
+When used inside a Vest suite schema, this means `suite.run()` accepts the input types while the suite callback and `result.value` use the output types — no type casts needed.

--- a/website/docs/typescript_support.md
+++ b/website/docs/typescript_support.md
@@ -176,7 +176,28 @@ Use exported types to annotate variables and APIs:
 - `SuiteResult<FieldName, GroupName>` - the result returned from `run`, `runStatic`, or `get`.
 - `SuiteSummary<FieldName, GroupName>` - the static snapshot of all test results.
 
-`SuiteResult` also carries `types.input` and `types.output` when a schema is present.
+`SuiteResult` also carries `types.input` and `types.output` when a schema is present. When the schema uses parser chains (e.g., `isNumeric().toNumber()`), the input and output types are distinct:
+
+```typescript
+const schema = enforce.shape({
+  age: enforce.isNumeric().toNumber(),
+  name: enforce.isString().trim(),
+});
+
+const suite = create(data => {
+  test('age', () => {
+    enforce(data.age).greaterThan(0);
+  });
+}, schema);
+
+// suite.run() accepts the input type: { age: string | number; name: string }
+const result = suite.run({ age: '25', name: '  alice  ' });
+
+// result.value is typed as the output type: { age: number; name: string }
+result.value; // { age: 25, name: 'alice' }
+```
+
+`result.value` is typed as the schema output and is only available when the suite is valid (`result.valid === true`).
 
 ## Custom Enforce Rules
 

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -169,9 +169,9 @@ suite.only('username').run({
 The suite result includes typed properties for accessing validated and parsed data:
 
 - `result.value` — The parsed output when the suite is valid. Typed as the schema's output type. `undefined` when invalid.
-- `result.types.input` — Typed as the schema's input type (what `suite.run()` accepts).
-- `result.types.output` — Typed as the schema's output type (what the callback receives).
-- `result.run.data.raw` — The parsed data for the current run only.
+- `result.types.input` — Carries the schema's input type for static analysis. At runtime, holds the parsed output value.
+- `result.types.output` — Carries the schema's output type. At runtime, holds the parsed output value.
+- `result.run.data.raw` — The current run data passed into the suite callback (parsed when schema validation succeeds; original input when it fails).
 - `result.run.data.parsed` — Cumulatively merged parsed data across focused runs.
 
 ```typescript

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -73,6 +73,32 @@ suite.run({ username: 'john', age: 42 });
 // suite.run({ username: 'john', age: '42' });
 ```
 
+### Input vs output types with parsers
+
+When a schema uses [data parsers](../enforce/builtin-enforce-plugins/data_parsers.md), Vest distinguishes between the **input type** (what `suite.run()` accepts) and the **output type** (what the callback receives and what `result.value` contains).
+
+```typescript
+const schema = enforce.shape({
+  age: enforce.isNumeric().toNumber(), // input: string | number, output: number
+  name: enforce.isString().trim().toUpper(), // input: string, output: string
+});
+
+const suite = create(data => {
+  // data.age is typed as `number` (the output type)
+  test('age', () => {
+    enforce(data.age).greaterThan(0);
+  });
+}, schema);
+
+// suite.run() accepts `string | number` for age (the input type)
+suite.run({ age: '25', name: '  alice  ' }); // ✅ No type error
+
+const result = suite.run({ age: '25', name: '  alice  ' });
+result.value; // typed as { age: number; name: string }
+```
+
+The first rule in a chain determines the input type, and the last parser in the chain determines the output type. This means you never need `@ts-expect-error` or `as any` for valid parser coercion inputs.
+
 ### What becomes typed from the schema
 
 With `create(callback, schema)`, TypeScript narrows:
@@ -140,7 +166,31 @@ suite.only('username').run({
 
 ## Inspecting schema results
 
-The suite result includes a `types` object that captures the validated `input` and coerced `output` from the schema run. This is useful for debugging and type-safe consumers.
+The suite result includes typed properties for accessing validated and parsed data:
+
+- `result.value` — The parsed output when the suite is valid. Typed as the schema's output type. `undefined` when invalid.
+- `result.types.input` — Typed as the schema's input type (what `suite.run()` accepts).
+- `result.types.output` — Typed as the schema's output type (what the callback receives).
+- `result.run.data.raw` — The parsed data for the current run only.
+- `result.run.data.parsed` — Cumulatively merged parsed data across focused runs.
+
+```typescript
+const schema = enforce.shape({
+  score: enforce.isNumeric().toNumber(),
+});
+
+const suite = create(data => {
+  test('score', () => {
+    enforce(data.score).greaterThan(0);
+  });
+}, schema);
+
+const result = suite.run({ score: '42' });
+result.value; // { score: 42 }
+result.types?.output; // { score: 42 }
+result.run.data.raw; // { score: 42 }
+result.run.data.parsed; // { score: 42 }
+```
 
 ## Schema Parsing
 


### PR DESCRIPTION
## Summary

- **Makes `RuleInstance`'s `~standard.types` required** (not optional) so TypeScript conditional types in `InferSchemaData<S>` and `InferSchemaOutput<S>` can correctly extract `input` vs `output` — critical for parser chains where they differ (e.g., `isNumeric().toNumber()`: input = `string | number`, output = `number`).
- **Threads the schema generic `S` through all `SuiteResult<F, G, S>` return types** in `SuiteTypes.ts` (`run`, `runStatic`, `validate`, focused `run`), so `result.value` and `result.types` are properly typed.
- **Removes all `@ts-expect-error` and `as any` casts** from test files that are no longer needed after the fix.
- **Adds 19 new type inference tests** covering `isNumeric().toNumber()`, `isString().trim().toUpper()`, `isString().toBoolean()`, `isArray().uniq().join()`, multi-step chains, mixed schemas, `result.types`, focused runs, and the `RuleInstance` `~standard` contract.
- **Updates documentation** across `n4s/docs/schema.md`, `website/docs/schema_validation.md`, `website/docs/typescript_support.md`, `website/docs/data_parsers.md`, and `website/docs/api_reference.md` to document input vs output type distinction.

## Test plan

- [x] `npx tsc --noEmit -p packages/vest/tsconfig.json` passes with 0 errors
- [x] All 68 tests pass across 4 affected test files
- [x] No remaining `as any` casts in test files
- [x] No remaining unnecessary `@ts-expect-error` directives

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Suite Result now exposes value (parsed schema output), types (input/output), and run (latest-run metadata) when a schema is present and validation succeeds

* **Documentation**
  * Expanded TypeScript guidance and examples for parser chains, clarifying input vs. output types and how to inspect parsed vs. raw data
  * Updated API docs to describe the new Suite Result properties

* **Tests**
  * Test suite refined to align with the clarified typing and runtime behavior (no behavioral changes)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->