### PR TITLE
fix(types): allow Promise<boolean> as async test return

### DIFF
--- a/packages/vest/src/core/test/TestTypes.ts
+++ b/packages/vest/src/core/test/TestTypes.ts
@@ -5,7 +5,7 @@ import { TFieldName } from '../../suiteResult/SuiteResultTypes';
 export type TestFnPayload = { signal: AbortSignal };
 
 export type TestFn = (payload: TestFnPayload) => TestResult;
-export type AsyncTest = Promise<void>;
+export type AsyncTest = Promise<void | boolean>;
 export type TestResult = Maybe<AsyncTest | boolean> | void;
 
 export type WithFieldName<F extends TFieldName = TFieldName> = {


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Please fill the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✔|
| New feature?     | ✖ |
| Breaking change? | ✖ |
| Deprecations?    | ✖ |
| Documentation?   |✖ |
| Tests added?     | ✖ |
| Types added?     | ✖ |
| Related issues   |     |

<!-- Describe your changes below in detail. -->
The AsyncTest type was defined as Promise<void>, which caused TypeScript to reject async test functions that return Promise<boolean> inside skipWhen. This is a documented and valid pattern in vest's own docs.

Changed AsyncTest from Promise<void> to Promise<void | boolean> so TypeScript accepts both return types without errors.

Fixes #1156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Async test functions now support optional boolean return values alongside void, providing greater flexibility in test result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->