### PR TITLE
feat: expose focus configurations on suite result run object

### DIFF
--- a/packages/vest/src/suite/__tests__/focus.test.ts
+++ b/packages/vest/src/suite/__tests__/focus.test.ts
@@ -89,6 +89,37 @@ describe('suite.focus: only', () => {
         expect(res.run.focus?.skipGroup).toEqual(['groupE', 'groupF']);
       });
     });
+
+    describe('consecutive runs', () => {
+      it('should not persist focus data from previous runs', () => {
+        const suite = vest.create(() => {});
+
+        // First run with focus
+        suite.only('field_1').run();
+
+        // Second run without focus
+        const res2 = suite.run();
+
+        // Should be undefined because the second run had no focus modifiers
+        expect(res2.run.focus).toEqual({});
+      });
+
+      it('should not mutate previous run results with new focus data', () => {
+        const suite = vest.create(() => {});
+
+        // First run with focus on field_1
+        const res1 = suite.only('field_1').run();
+
+        // Second run with focus on field_2
+        const res2 = suite.only('field_2').run();
+
+        // Check that the first result was not mutated
+        expect(res1.run.focus?.only).toEqual(['field_1']);
+
+        // Check that the second result has the new focus
+        expect(res2.run.focus?.only).toEqual(['field_2']);
+      });
+    });
   });
 
   describe('behavior', () => {

--- a/packages/vest/src/suite/__tests__/focus.test.ts
+++ b/packages/vest/src/suite/__tests__/focus.test.ts
@@ -44,14 +44,14 @@ describe('suite.focus: only', () => {
         const suite = vest.create(() => {});
         const res = suite.focus({ skipGroup: 'groupA' }).run();
 
-        expect(res.run.focus?.skipGroup).toBe('groupA');
+        expect(res.run.focus?.skipGroup).toEqual(['groupA']);
       });
 
       it('should reflect the onlyGroup property when provided', () => {
         const suite = vest.create(() => {});
         const res = suite.focus({ onlyGroup: 'groupB' }).run();
 
-        expect(res.run.focus?.onlyGroup).toBe('groupB');
+        expect(res.run.focus?.onlyGroup).toEqual(['groupB']);
       });
     });
 
@@ -60,7 +60,33 @@ describe('suite.focus: only', () => {
         const suite = vest.create(() => {});
         const res = suite.only('field_3').run();
 
-        expect(res.run.focus?.only).toBe('field_3');
+        expect(res.run.focus?.only).toEqual(['field_3']);
+      });
+
+      it('should reflect a .skip() call deeply within run.focus', () => {
+        const suite = vest.create(() => {});
+
+        // We capture focus via focus({ skip: ... }) because
+        // there's currenty no top-level trailing .skip syntax exposed
+        const res = suite.focus({ skip: 'field_4' }).run();
+
+        expect(res.run.focus?.skip).toEqual(['field_4']);
+      });
+    });
+
+    describe('focus array parameters', () => {
+      it('should reflect the onlyGroup property when an array is provided', () => {
+        const suite = vest.create(() => {});
+        const res = suite.focus({ onlyGroup: ['groupC', 'groupD'] }).run();
+
+        expect(res.run.focus?.onlyGroup).toEqual(['groupC', 'groupD']);
+      });
+
+      it('should reflect the skipGroup property when an array is provided', () => {
+        const suite = vest.create(() => {});
+        const res = suite.focus({ skipGroup: ['groupE', 'groupF'] }).run();
+
+        expect(res.run.focus?.skipGroup).toEqual(['groupE', 'groupF']);
       });
     });
   });

--- a/packages/vest/src/suite/__tests__/focus.test.ts
+++ b/packages/vest/src/suite/__tests__/focus.test.ts
@@ -24,6 +24,47 @@ describe('suite.focus: only', () => {
     });
   });
 
+  describe('run.focus property', () => {
+    describe('focus object parameters', () => {
+      it('should reflect the only property when provided', () => {
+        const suite = vest.create(() => {});
+        const res = suite.focus({ only: ['field_1'] }).run();
+
+        expect(res.run.focus?.only).toEqual(['field_1']);
+      });
+
+      it('should reflect the skip property when provided', () => {
+        const suite = vest.create(() => {});
+        const res = suite.focus({ skip: ['field_2'] }).run();
+
+        expect(res.run.focus?.skip).toEqual(['field_2']);
+      });
+
+      it('should reflect the skipGroup property when provided', () => {
+        const suite = vest.create(() => {});
+        const res = suite.focus({ skipGroup: 'groupA' }).run();
+
+        expect(res.run.focus?.skipGroup).toBe('groupA');
+      });
+
+      it('should reflect the onlyGroup property when provided', () => {
+        const suite = vest.create(() => {});
+        const res = suite.focus({ onlyGroup: 'groupB' }).run();
+
+        expect(res.run.focus?.onlyGroup).toBe('groupB');
+      });
+    });
+
+    describe('focus methods', () => {
+      it('should reflect a .only() call deeply within run.focus', () => {
+        const suite = vest.create(() => {});
+        const res = suite.only('field_3').run();
+
+        expect(res.run.focus?.only).toBe('field_3');
+      });
+    });
+  });
+
   describe('behavior', () => {
     it('should focus on the specified field when a single field is provided', () => {
       const suite = vest.create(() => {

--- a/packages/vest/src/suite/__tests__/focus.test.ts
+++ b/packages/vest/src/suite/__tests__/focus.test.ts
@@ -67,7 +67,7 @@ describe('suite.focus: only', () => {
         const suite = vest.create(() => {});
 
         // We capture focus via focus({ skip: ... }) because
-        // there's currenty no top-level trailing .skip syntax exposed
+        // there's currently no top-level trailing .skip syntax exposed
         const res = suite.focus({ skip: 'field_4' }).run();
 
         expect(res.run.focus?.skip).toEqual(['field_4']);
@@ -100,7 +100,7 @@ describe('suite.focus: only', () => {
         // Second run without focus
         const res2 = suite.run();
 
-        // Should be undefined because the second run had no focus modifiers
+        // Should be an empty object because the second run had no focus modifiers
         expect(res2.run.focus).toEqual({});
       });
 

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -223,26 +223,35 @@ function useTransformedModifiers<F extends TFieldName, G extends TGroupName>(
 function snapshotFocus<F extends TFieldName, G extends TGroupName>(
   modifiers: ReturnType<typeof useTransformedModifiers<F, G>>,
 ): SuiteModifiers<F, G> {
-  return Object.freeze({
-    ...(modifiers.only && {
-      only: Object.freeze([...asArray(modifiers.only)]) as SuiteModifiers<
-        F,
-        G
-      >['only'],
-    }),
-    ...(modifiers.skip && {
-      skip: Object.freeze([...asArray(modifiers.skip)]) as SuiteModifiers<
-        F,
-        G
-      >['skip'],
-    }),
-    ...(modifiers.onlyGroup.size > 0 && {
-      onlyGroup: Object.freeze([...modifiers.onlyGroup]) as G[],
-    }),
-    ...(modifiers.skipGroup.size > 0 && {
-      skipGroup: Object.freeze([...modifiers.skipGroup]) as G[],
-    }),
-  });
+  return freezeAssign<SuiteModifiers<F, G>>(
+    {},
+    modifiers.only
+      ? {
+          only: Object.freeze([...asArray(modifiers.only)]) as SuiteModifiers<
+            F,
+            G
+          >['only'],
+        }
+      : {},
+    modifiers.skip
+      ? {
+          skip: Object.freeze([...asArray(modifiers.skip)]) as SuiteModifiers<
+            F,
+            G
+          >['skip'],
+        }
+      : {},
+    modifiers.onlyGroup.size > 0
+      ? {
+          onlyGroup: Object.freeze([...modifiers.onlyGroup]) as G[],
+        }
+      : {},
+    modifiers.skipGroup.size > 0
+      ? {
+          skipGroup: Object.freeze([...modifiers.skipGroup]) as G[],
+        }
+      : {},
+  );
 }
 
 /**

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -100,7 +100,7 @@ export function useCreateSuiteRunner<
             runData,
             runTime,
             mergedParsedData,
-            modifiers,
+            snapshotFocus(transformedModifiers),
           );
 
           if (!result.isPending()) {
@@ -214,6 +214,33 @@ function useTransformedModifiers<F extends TFieldName, G extends TGroupName>(
     onlyGroup: new Set(modifiers.onlyGroup ? asArray(modifiers.onlyGroup) : []),
     skipGroup: new Set(modifiers.skipGroup ? asArray(modifiers.skipGroup) : []),
   };
+}
+
+/**
+ * Normalizes internal focus Sets back into the external Array representation
+ * and freezes the structure explicitly for immutability in the results.
+ */
+function snapshotFocus<F extends TFieldName, G extends TGroupName>(
+  modifiers: ReturnType<typeof useTransformedModifiers<F, G>>,
+): SuiteModifiers<F, G> {
+  const result: SuiteModifiers<F, G> = {};
+  if (modifiers.only)
+    result.only = Object.freeze([...asArray(modifiers.only)]) as SuiteModifiers<
+      F,
+      G
+    >['only'];
+  if (modifiers.skip)
+    result.skip = Object.freeze([...asArray(modifiers.skip)]) as SuiteModifiers<
+      F,
+      G
+    >['skip'];
+
+  if (modifiers.onlyGroup.size > 0)
+    result.onlyGroup = Object.freeze([...modifiers.onlyGroup]) as G[];
+  if (modifiers.skipGroup.size > 0)
+    result.skipGroup = Object.freeze([...modifiers.skipGroup]) as G[];
+
+  return Object.freeze(result);
 }
 
 /**

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -225,33 +225,32 @@ function snapshotFocus<F extends TFieldName, G extends TGroupName>(
 ): SuiteModifiers<F, G> {
   return freezeAssign<SuiteModifiers<F, G>>(
     {},
-    modifiers.only
-      ? {
-          only: Object.freeze([...asArray(modifiers.only)]) as SuiteModifiers<
-            F,
-            G
-          >['only'],
-        }
-      : {},
-    modifiers.skip
-      ? {
-          skip: Object.freeze([...asArray(modifiers.skip)]) as SuiteModifiers<
-            F,
-            G
-          >['skip'],
-        }
-      : {},
-    modifiers.onlyGroup.size > 0
-      ? {
-          onlyGroup: Object.freeze([...modifiers.onlyGroup]) as G[],
-        }
-      : {},
-    modifiers.skipGroup.size > 0
-      ? {
-          skipGroup: Object.freeze([...modifiers.skipGroup]) as G[],
-        }
-      : {},
+    snapshotField(modifiers, 'only'),
+    snapshotField(modifiers, 'skip'),
+    snapshotGroup(modifiers, 'onlyGroup'),
+    snapshotGroup(modifiers, 'skipGroup'),
   );
+}
+
+function snapshotField<F extends TFieldName, G extends TGroupName>(
+  modifiers: ReturnType<typeof useTransformedModifiers<F, G>>,
+  key: 'only' | 'skip',
+): Partial<SuiteModifiers<F, G>> {
+  const original = modifiers[key];
+
+  if (!original) {
+    return {};
+  }
+  const value = asArray(original);
+  return value.length > 0 ? { [key]: Object.freeze([...value]) } : {};
+}
+
+function snapshotGroup<F extends TFieldName, G extends TGroupName>(
+  modifiers: ReturnType<typeof useTransformedModifiers<F, G>>,
+  key: 'onlyGroup' | 'skipGroup',
+): Partial<SuiteModifiers<F, G>> {
+  const value = modifiers[key];
+  return value.size > 0 ? { [key]: Object.freeze([...value]) } : {};
 }
 
 /**

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -51,10 +51,10 @@ export function useCreateSuiteRunner<
   S extends TSchema = undefined,
 >(
   suiteCallback: SuiteCallbackWithSchema<S, T>,
-  modifiers: SuiteModifiers<F>,
+  modifiers: SuiteModifiers<F, G>,
   schema?: S,
 ) {
-  const transformedModifiers = useTransformedModifiers(modifiers);
+  const transformedModifiers = useTransformedModifiers<F, G>(modifiers);
 
   return function runSuite(
     ...args: S extends undefined
@@ -100,6 +100,7 @@ export function useCreateSuiteRunner<
             runData,
             runTime,
             mergedParsedData,
+            modifiers,
           );
 
           if (!result.isPending()) {
@@ -167,7 +168,7 @@ function useRunSuiteCallback<
   D = unknown,
 >(params: {
   args: any[];
-  modifiers: ReturnType<typeof useTransformedModifiers<F>>;
+  modifiers: ReturnType<typeof useTransformedModifiers<F, G>>;
   schema: S | undefined;
   schemaRunResult?: SchemaRunResult[];
   suiteCallback: SuiteCallbackWithSchema<S, T>;
@@ -205,8 +206,8 @@ function useRunSuiteCallback<
 /**
  * Normalizes user-provided modifiers into deterministic sets for O(1) membership checks.
  */
-function useTransformedModifiers<F extends TFieldName>(
-  modifiers: SuiteModifiers<F>,
+function useTransformedModifiers<F extends TFieldName, G extends TGroupName>(
+  modifiers: SuiteModifiers<F, G>,
 ) {
   return {
     ...modifiers,
@@ -461,6 +462,7 @@ function bindSuiteResultMethods<
         raw: runData,
         parsed: suiteResult.run.data.parsed,
       }),
+      focus: suiteResult.run.focus,
       time: runTime,
     }),
     writable: true,

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -223,24 +223,26 @@ function useTransformedModifiers<F extends TFieldName, G extends TGroupName>(
 function snapshotFocus<F extends TFieldName, G extends TGroupName>(
   modifiers: ReturnType<typeof useTransformedModifiers<F, G>>,
 ): SuiteModifiers<F, G> {
-  const result: SuiteModifiers<F, G> = {};
-  if (modifiers.only)
-    result.only = Object.freeze([...asArray(modifiers.only)]) as SuiteModifiers<
-      F,
-      G
-    >['only'];
-  if (modifiers.skip)
-    result.skip = Object.freeze([...asArray(modifiers.skip)]) as SuiteModifiers<
-      F,
-      G
-    >['skip'];
-
-  if (modifiers.onlyGroup.size > 0)
-    result.onlyGroup = Object.freeze([...modifiers.onlyGroup]) as G[];
-  if (modifiers.skipGroup.size > 0)
-    result.skipGroup = Object.freeze([...modifiers.skipGroup]) as G[];
-
-  return Object.freeze(result);
+  return Object.freeze({
+    ...(modifiers.only && {
+      only: Object.freeze([...asArray(modifiers.only)]) as SuiteModifiers<
+        F,
+        G
+      >['only'],
+    }),
+    ...(modifiers.skip && {
+      skip: Object.freeze([...asArray(modifiers.skip)]) as SuiteModifiers<
+        F,
+        G
+      >['skip'],
+    }),
+    ...(modifiers.onlyGroup.size > 0 && {
+      onlyGroup: Object.freeze([...modifiers.onlyGroup]) as G[],
+    }),
+    ...(modifiers.skipGroup.size > 0 && {
+      skipGroup: Object.freeze([...modifiers.skipGroup]) as G[],
+    }),
+  });
 }
 
 /**

--- a/packages/vest/src/suiteResult/SuiteResultTypes.ts
+++ b/packages/vest/src/suiteResult/SuiteResultTypes.ts
@@ -6,6 +6,7 @@ import { TIsolateSuite } from '../core/isolate/IsolateSuite/IsolateSuite';
 import { Severity } from './Severity';
 import { SummaryFailure } from './SummaryFailure';
 import { SuiteSelectors } from './selectors/suiteSelectors';
+import { SuiteModifiers } from '../suite/SuiteTypes';
 
 export class SummaryBase {
   public errorCount = 0;
@@ -30,6 +31,7 @@ export class SuiteSummary<
       parsed: Partial<InferSchemaOutput<S>> | undefined;
     };
     time: Date;
+    focus?: SuiteModifiers<F, G>;
   };
   public valid: Nullable<boolean> = null;
 

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -4,6 +4,7 @@ import { VestRuntime } from 'vestjs-runtime';
 
 import { useSuiteResultCache } from '../core/Runtime';
 import { TIsolateSuite } from '../core/isolate/IsolateSuite/IsolateSuite';
+import { SuiteModifiers } from '../suite/SuiteTypes';
 
 import { Severity } from './Severity';
 import {
@@ -28,6 +29,7 @@ export function useCreateSuiteResult<
   inputData?: D,
   runTime: Date = new Date(),
   parsedData?: Partial<InferSchemaOutput<S>>,
+  focus?: SuiteModifiers<F, G>,
 ): SuiteResult<F, G, S, D> {
   return useSuiteResultCache<F, G, S, D>(() => {
     // @vx-allow use-use
@@ -37,6 +39,7 @@ export function useCreateSuiteResult<
         raw: inputData,
         parsed: parsedData,
       },
+      focus,
       time: runTime,
     };
 

--- a/website/docs/writing_your_suite/accessing_the_result.md
+++ b/website/docs/writing_your_suite/accessing_the_result.md
@@ -44,11 +44,11 @@ result.run.focus; // { only: ..., skip: ..., onlyGroup: ..., skipGroup: ... }
 Provides insight into the exact modifiers that were used to focus the current run. This is either populated by calling `.focus(...)` or `.only(...)`/`.skip(...)`.
 
 ```js
-suite.only('username').run().focus;
+suite.only('username').run().run.focus;
 // { only: ['username'] }
 
-suite.focus({ skipGroup: 'groupA' }).run().focus;
-// { skipGroup: 'groupA' }
+suite.focus({ skipGroup: 'groupA' }).run().run.focus;
+// { skipGroup: ['groupA'] }
 ```
 
 ## `isValid`

--- a/website/docs/writing_your_suite/accessing_the_result.md
+++ b/website/docs/writing_your_suite/accessing_the_result.md
@@ -29,6 +29,28 @@ Use this playground to see how the result object properties change as you intera
 
 <AccessingResultSandpack />
 
+## `run`
+
+The `run` object contains metadata about the current suite execution.
+
+```js
+result.run.data; // { raw: ..., parsed: ... }
+result.run.time; // Date object
+result.run.focus; // { only: ..., skip: ..., onlyGroup: ..., skipGroup: ... }
+```
+
+### `run.focus`
+
+Provides insight into the exact modifiers that were used to focus the current run. This is either populated by calling `.focus(...)` or `.only(...)`/`.skip(...)`.
+
+```js
+suite.only('username').run().focus;
+// { only: ['username'] }
+
+suite.focus({ skipGroup: 'groupA' }).run().focus;
+// { skipGroup: 'groupA' }
+```
+
 ## `isValid`
 
 `isValid` returns whether the validation suite as a whole or a single field is valid or not.


### PR DESCRIPTION
Adds `run.focus` to the suite result object, allowing users to inspect the exact focus and exclusion parameters (`only`, `skip`, `onlyGroup`, `skipGroup`) for the current run.

### Changes
- ✨ Added `run.focus` property to `SuiteSummary`.
- 🛠️ Implemented `snapshotFocus` to safely capture normalized, frozen arrays of current focus modifiers.
- 🧊 Ensured deep immutability using `freezeAssign` and `Object.freeze`.
- 🔄 Verified that focus data does not bleed into subsequent runs or mutate previous result references.
- 📚 Updated `accessing_the_result.md` documentation.

### Verification
- Added comprehensive unit tests in `focus.test.ts` covering:
  - Property mirroring for object and method-chain configurations.
  - Isolation between consecutive runs.
  - Snapshot immutability.
- All tests passing (`yarn test`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run results now include a run.focus field showing applied focus modifiers (only/skip and group variants, including array forms); focus snapshots are immutable and do not persist across runs.

* **Tests**
  * Added tests validating focus propagation, group-array handling, deep reflection in results, and isolation/non-mutation across consecutive runs.

* **Documentation**
  * Docs updated with examples for accessing and interpreting run.focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->