### PR TITLE
fix: skip executing omitWhen callback when ignored

### DIFF
--- a/packages/vest/src/__tests__/integration.byGroup.test.ts
+++ b/packages/vest/src/__tests__/integration.byGroup.test.ts
@@ -397,7 +397,7 @@ describe('Integration: byGroup selectors', () => {
       const result = suite.run(true);
       expect(result.hasErrorsByGroup('omit_group', 'field_1')).toBe(false);
       expect(result.hasErrorsByGroup('omit_group', 'field_2')).toBe(true);
-      expect(result.isValidByGroup('omit_group', 'field_1')).toBe(true);
+      expect(result.isValidByGroup('omit_group', 'field_1')).toBe(false);
     });
 
     it('should run the test and report its errors when omitWhen(false)', () => {

--- a/packages/vest/src/core/context/SuiteContext.ts
+++ b/packages/vest/src/core/context/SuiteContext.ts
@@ -32,7 +32,6 @@ type CTXType = {
   suiteParams: any[];
   currentTest?: TIsolateTest;
   skipped?: boolean;
-  omitted?: boolean;
   schema: TSchema;
   modifiers: TInternalModifiers<TFieldName>;
 };
@@ -59,10 +58,6 @@ export function useMode() {
 
 export function useSkipped() {
   return SuiteContext.useX().skipped ?? false;
-}
-
-export function useOmitted() {
-  return SuiteContext.useX().omitted ?? false;
 }
 
 export function useSuiteParams() {

--- a/packages/vest/src/core/test/testLevelFlowControl/verifyTestRun.ts
+++ b/packages/vest/src/core/test/testLevelFlowControl/verifyTestRun.ts
@@ -3,7 +3,6 @@ import { makeResult, Result } from 'vest-utils';
 import { useIsExcluded } from '../../../hooks/focused/useIsExcluded';
 import { useShouldSkipBasedOnMode } from '../../../hooks/optional/mode';
 import { useIsOptionalFieldApplied } from '../../../hooks/optional/optional';
-import { useWithinActiveOmitWhen } from '../../../isolates/omitWhen';
 import { useIsExcludedIndividually } from '../../../isolates/skipWhen';
 import { TFieldName } from '../../../suiteResult/SuiteResultTypes';
 import { TIsolateTest } from '../../isolate/IsolateTest/IsolateTest';
@@ -37,9 +36,7 @@ export function useVerifyTestRun(
 }
 
 function useShouldOmit(fieldName: TFieldName): Result<boolean> {
-  return makeResult.Ok(
-    useWithinActiveOmitWhen() || useIsOptionalFieldApplied(fieldName).unwrap(),
-  );
+  return makeResult.Ok(useIsOptionalFieldApplied(fieldName).unwrap());
 }
 
 function skipTestAndReturn(testNode: TIsolateTest): Result<TIsolateTest> {

--- a/packages/vest/src/isolates/__tests__/__snapshots__/omitWhen.test.ts.snap
+++ b/packages/vest/src/isolates/__tests__/__snapshots__/omitWhen.test.ts.snap
@@ -277,7 +277,7 @@ exports[`omitWhen > when conditional is truthy > boolean conditional > should av
   "pendingCount": 0,
   "testCount": 2,
   "tests": {
-    "field_1": {
+    "field_1": SummaryBase {
       "errorCount": 0,
       "errors": [],
       "pendingCount": 0,
@@ -292,24 +292,6 @@ exports[`omitWhen > when conditional is truthy > boolean conditional > should av
       "pendingCount": 0,
       "testCount": 1,
       "valid": false,
-      "warnCount": 0,
-      "warnings": [],
-    },
-    "field_3": SummaryBase {
-      "errorCount": 0,
-      "errors": [],
-      "pendingCount": 0,
-      "testCount": 0,
-      "valid": true,
-      "warnCount": 0,
-      "warnings": [],
-    },
-    "field_4": SummaryBase {
-      "errorCount": 0,
-      "errors": [],
-      "pendingCount": 0,
-      "testCount": 0,
-      "valid": true,
       "warnCount": 0,
       "warnings": [],
     },
@@ -352,7 +334,7 @@ exports[`omitWhen > when conditional is truthy > boolean conditional > should sk
   "pendingCount": 0,
   "testCount": 2,
   "tests": {
-    "field_1": {
+    "field_1": SummaryBase {
       "errorCount": 0,
       "errors": [],
       "pendingCount": 0,
@@ -367,24 +349,6 @@ exports[`omitWhen > when conditional is truthy > boolean conditional > should sk
       "pendingCount": 0,
       "testCount": 1,
       "valid": false,
-      "warnCount": 0,
-      "warnings": [],
-    },
-    "field_3": SummaryBase {
-      "errorCount": 0,
-      "errors": [],
-      "pendingCount": 0,
-      "testCount": 0,
-      "valid": true,
-      "warnCount": 0,
-      "warnings": [],
-    },
-    "field_4": SummaryBase {
-      "errorCount": 0,
-      "errors": [],
-      "pendingCount": 0,
-      "testCount": 0,
-      "valid": true,
       "warnCount": 0,
       "warnings": [],
     },
@@ -427,7 +391,7 @@ exports[`omitWhen > when conditional is truthy > function conditional > should a
   "pendingCount": 0,
   "testCount": 2,
   "tests": {
-    "field_1": {
+    "field_1": SummaryBase {
       "errorCount": 0,
       "errors": [],
       "pendingCount": 0,
@@ -442,24 +406,6 @@ exports[`omitWhen > when conditional is truthy > function conditional > should a
       "pendingCount": 0,
       "testCount": 1,
       "valid": false,
-      "warnCount": 0,
-      "warnings": [],
-    },
-    "field_3": SummaryBase {
-      "errorCount": 0,
-      "errors": [],
-      "pendingCount": 0,
-      "testCount": 0,
-      "valid": true,
-      "warnCount": 0,
-      "warnings": [],
-    },
-    "field_4": SummaryBase {
-      "errorCount": 0,
-      "errors": [],
-      "pendingCount": 0,
-      "testCount": 0,
-      "valid": true,
       "warnCount": 0,
       "warnings": [],
     },
@@ -502,7 +448,7 @@ exports[`omitWhen > when conditional is truthy > function conditional > should s
   "pendingCount": 0,
   "testCount": 2,
   "tests": {
-    "field_1": {
+    "field_1": SummaryBase {
       "errorCount": 0,
       "errors": [],
       "pendingCount": 0,
@@ -517,24 +463,6 @@ exports[`omitWhen > when conditional is truthy > function conditional > should s
       "pendingCount": 0,
       "testCount": 1,
       "valid": false,
-      "warnCount": 0,
-      "warnings": [],
-    },
-    "field_3": SummaryBase {
-      "errorCount": 0,
-      "errors": [],
-      "pendingCount": 0,
-      "testCount": 0,
-      "valid": true,
-      "warnCount": 0,
-      "warnings": [],
-    },
-    "field_4": SummaryBase {
-      "errorCount": 0,
-      "errors": [],
-      "pendingCount": 0,
-      "testCount": 0,
-      "valid": true,
       "warnCount": 0,
       "warnings": [],
     },

--- a/packages/vest/src/isolates/__tests__/omitWhen.test.ts
+++ b/packages/vest/src/isolates/__tests__/omitWhen.test.ts
@@ -250,22 +250,26 @@ describe('omitWhen', () => {
   });
 
   describe('stateful omitWhen', () => {
+    function setupStatefulSuite(isAsync = false) {
+      const cbs = [vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn()];
+      const testFn = (cb: () => void) => (isAsync ? async () => cb() : cb);
+
+      const suite = vest.create((shouldOmit: boolean) => {
+        vest.test('field_0', testFn(cbs[0]));
+        vest.test('field_1', testFn(cbs[1]));
+        vest.omitWhen(shouldOmit, () => {
+          vest.test('field_2', testFn(cbs[2]));
+          vest.test('field_3', testFn(cbs[3]));
+        });
+        vest.test('field_4', testFn(cbs[4]));
+      });
+
+      return { suite, cbs };
+    }
+
     describe('sync tests', () => {
       it('should omit previously run fields when changing to true without causing reorder issues', () => {
-        const cb0 = vi.fn();
-        const cb1 = vi.fn();
-        const cb2 = vi.fn();
-        const cb3 = vi.fn();
-        const cb4 = vi.fn();
-        const suite = vest.create((shouldOmit: boolean) => {
-          vest.test('field_0', cb0);
-          vest.test('field_1', cb1);
-          vest.omitWhen(shouldOmit, () => {
-            vest.test('field_2', cb2);
-            vest.test('field_3', cb3);
-          });
-          vest.test('field_4', cb4);
-        });
+        const { suite, cbs } = setupStatefulSuite();
 
         suite.run(false);
         expect(suite.get().tests.field_0.testCount).toBe(1);
@@ -273,11 +277,7 @@ describe('omitWhen', () => {
         expect(suite.get().tests.field_2.testCount).toBe(1);
         expect(suite.get().tests.field_3.testCount).toBe(1);
         expect(suite.get().tests.field_4.testCount).toBe(1);
-        expect(cb0).toHaveBeenCalledTimes(1);
-        expect(cb1).toHaveBeenCalledTimes(1);
-        expect(cb2).toHaveBeenCalledTimes(1);
-        expect(cb3).toHaveBeenCalledTimes(1);
-        expect(cb4).toHaveBeenCalledTimes(1);
+        cbs.forEach(cb => expect(cb).toHaveBeenCalledTimes(1));
 
         suite.run(true);
         expect(suite.get().tests.field_0.testCount).toBe(1);
@@ -285,28 +285,15 @@ describe('omitWhen', () => {
         expect(suite.get().tests.field_2?.testCount).toBeUndefined();
         expect(suite.get().tests.field_3?.testCount).toBeUndefined();
         expect(suite.get().tests.field_4.testCount).toBe(1);
-        expect(cb0).toHaveBeenCalledTimes(2);
-        expect(cb1).toHaveBeenCalledTimes(2);
-        expect(cb2).toHaveBeenCalledTimes(1);
-        expect(cb3).toHaveBeenCalledTimes(1);
-        expect(cb4).toHaveBeenCalledTimes(2);
+        expect(cbs[0]).toHaveBeenCalledTimes(2);
+        expect(cbs[1]).toHaveBeenCalledTimes(2);
+        expect(cbs[2]).toHaveBeenCalledTimes(1);
+        expect(cbs[3]).toHaveBeenCalledTimes(1);
+        expect(cbs[4]).toHaveBeenCalledTimes(2);
       });
 
       it('should run fields that were previously omitted when changing to false without causing reorder issues', () => {
-        const cb0 = vi.fn();
-        const cb1 = vi.fn();
-        const cb2 = vi.fn();
-        const cb3 = vi.fn();
-        const cb4 = vi.fn();
-        const suite = vest.create((shouldOmit: boolean) => {
-          vest.test('field_0', cb0);
-          vest.test('field_1', cb1);
-          vest.omitWhen(shouldOmit, () => {
-            vest.test('field_2', cb2);
-            vest.test('field_3', cb3);
-          });
-          vest.test('field_4', cb4);
-        });
+        const { suite, cbs } = setupStatefulSuite();
 
         suite.run(true);
         expect(suite.get().tests.field_0.testCount).toBe(1);
@@ -314,11 +301,11 @@ describe('omitWhen', () => {
         expect(suite.get().tests.field_2?.testCount).toBeUndefined();
         expect(suite.get().tests.field_3?.testCount).toBeUndefined();
         expect(suite.get().tests.field_4.testCount).toBe(1);
-        expect(cb0).toHaveBeenCalledTimes(1);
-        expect(cb1).toHaveBeenCalledTimes(1);
-        expect(cb2).toHaveBeenCalledTimes(0);
-        expect(cb3).toHaveBeenCalledTimes(0);
-        expect(cb4).toHaveBeenCalledTimes(1);
+        expect(cbs[0]).toHaveBeenCalledTimes(1);
+        expect(cbs[1]).toHaveBeenCalledTimes(1);
+        expect(cbs[2]).toHaveBeenCalledTimes(0);
+        expect(cbs[3]).toHaveBeenCalledTimes(0);
+        expect(cbs[4]).toHaveBeenCalledTimes(1);
 
         suite.run(false);
         expect(suite.get().tests.field_0.testCount).toBe(1);
@@ -326,40 +313,17 @@ describe('omitWhen', () => {
         expect(suite.get().tests.field_2.testCount).toBe(1);
         expect(suite.get().tests.field_3.testCount).toBe(1);
         expect(suite.get().tests.field_4.testCount).toBe(1);
-        expect(cb0).toHaveBeenCalledTimes(2);
-        expect(cb1).toHaveBeenCalledTimes(2);
-        expect(cb2).toHaveBeenCalledTimes(1);
-        expect(cb3).toHaveBeenCalledTimes(1);
-        expect(cb4).toHaveBeenCalledTimes(2);
+        expect(cbs[0]).toHaveBeenCalledTimes(2);
+        expect(cbs[1]).toHaveBeenCalledTimes(2);
+        expect(cbs[2]).toHaveBeenCalledTimes(1);
+        expect(cbs[3]).toHaveBeenCalledTimes(1);
+        expect(cbs[4]).toHaveBeenCalledTimes(2);
       });
     });
 
     describe('async tests', () => {
       it('should omit previously run async tests when changing to true without causing reorder issues', async () => {
-        const cb0 = vi.fn();
-        const cb1 = vi.fn();
-        const cb2 = vi.fn();
-        const cb3 = vi.fn();
-        const cb4 = vi.fn();
-        const suite = vest.create((shouldOmit: boolean) => {
-          vest.test('field_0', async () => {
-            cb0();
-          });
-          vest.test('field_1', async () => {
-            cb1();
-          });
-          vest.omitWhen(shouldOmit, () => {
-            vest.test('field_2', async () => {
-              cb2();
-            });
-            vest.test('field_3', async () => {
-              cb3();
-            });
-          });
-          vest.test('field_4', async () => {
-            cb4();
-          });
-        });
+        const { suite, cbs } = setupStatefulSuite(true);
 
         await suite.run(false);
         expect(suite.get().tests.field_0.testCount).toBe(1);
@@ -367,11 +331,7 @@ describe('omitWhen', () => {
         expect(suite.get().tests.field_2.testCount).toBe(1);
         expect(suite.get().tests.field_3.testCount).toBe(1);
         expect(suite.get().tests.field_4.testCount).toBe(1);
-        expect(cb0).toHaveBeenCalledTimes(1);
-        expect(cb1).toHaveBeenCalledTimes(1);
-        expect(cb2).toHaveBeenCalledTimes(1);
-        expect(cb3).toHaveBeenCalledTimes(1);
-        expect(cb4).toHaveBeenCalledTimes(1);
+        cbs.forEach(cb => expect(cb).toHaveBeenCalledTimes(1));
 
         await suite.run(true);
         expect(suite.get().tests.field_0.testCount).toBe(1);
@@ -379,38 +339,15 @@ describe('omitWhen', () => {
         expect(suite.get().tests.field_2?.testCount).toBeUndefined();
         expect(suite.get().tests.field_3?.testCount).toBeUndefined();
         expect(suite.get().tests.field_4.testCount).toBe(1);
-        expect(cb0).toHaveBeenCalledTimes(2);
-        expect(cb1).toHaveBeenCalledTimes(2);
-        expect(cb2).toHaveBeenCalledTimes(1);
-        expect(cb3).toHaveBeenCalledTimes(1);
-        expect(cb4).toHaveBeenCalledTimes(2);
+        expect(cbs[0]).toHaveBeenCalledTimes(2);
+        expect(cbs[1]).toHaveBeenCalledTimes(2);
+        expect(cbs[2]).toHaveBeenCalledTimes(1);
+        expect(cbs[3]).toHaveBeenCalledTimes(1);
+        expect(cbs[4]).toHaveBeenCalledTimes(2);
       });
 
       it('should run async tests that were previously omitted when changing to false without causing reorder issues', async () => {
-        const cb0 = vi.fn();
-        const cb1 = vi.fn();
-        const cb2 = vi.fn();
-        const cb3 = vi.fn();
-        const cb4 = vi.fn();
-        const suite = vest.create((shouldOmit: boolean) => {
-          vest.test('field_0', async () => {
-            cb0();
-          });
-          vest.test('field_1', async () => {
-            cb1();
-          });
-          vest.omitWhen(shouldOmit, () => {
-            vest.test('field_2', async () => {
-              cb2();
-            });
-            vest.test('field_3', async () => {
-              cb3();
-            });
-          });
-          vest.test('field_4', async () => {
-            cb4();
-          });
-        });
+        const { suite, cbs } = setupStatefulSuite(true);
 
         await suite.run(true);
         expect(suite.get().tests.field_0.testCount).toBe(1);
@@ -418,11 +355,11 @@ describe('omitWhen', () => {
         expect(suite.get().tests.field_2?.testCount).toBeUndefined();
         expect(suite.get().tests.field_3?.testCount).toBeUndefined();
         expect(suite.get().tests.field_4.testCount).toBe(1);
-        expect(cb0).toHaveBeenCalledTimes(1);
-        expect(cb1).toHaveBeenCalledTimes(1);
-        expect(cb2).toHaveBeenCalledTimes(0);
-        expect(cb3).toHaveBeenCalledTimes(0);
-        expect(cb4).toHaveBeenCalledTimes(1);
+        expect(cbs[0]).toHaveBeenCalledTimes(1);
+        expect(cbs[1]).toHaveBeenCalledTimes(1);
+        expect(cbs[2]).toHaveBeenCalledTimes(0);
+        expect(cbs[3]).toHaveBeenCalledTimes(0);
+        expect(cbs[4]).toHaveBeenCalledTimes(1);
 
         await suite.run(false);
         expect(suite.get().tests.field_0.testCount).toBe(1);
@@ -430,11 +367,11 @@ describe('omitWhen', () => {
         expect(suite.get().tests.field_2.testCount).toBe(1);
         expect(suite.get().tests.field_3.testCount).toBe(1);
         expect(suite.get().tests.field_4.testCount).toBe(1);
-        expect(cb0).toHaveBeenCalledTimes(2);
-        expect(cb1).toHaveBeenCalledTimes(2);
-        expect(cb2).toHaveBeenCalledTimes(1);
-        expect(cb3).toHaveBeenCalledTimes(1);
-        expect(cb4).toHaveBeenCalledTimes(2);
+        expect(cbs[0]).toHaveBeenCalledTimes(2);
+        expect(cbs[1]).toHaveBeenCalledTimes(2);
+        expect(cbs[2]).toHaveBeenCalledTimes(1);
+        expect(cbs[3]).toHaveBeenCalledTimes(1);
+        expect(cbs[4]).toHaveBeenCalledTimes(2);
       });
     });
   });

--- a/packages/vest/src/isolates/__tests__/omitWhen.test.ts
+++ b/packages/vest/src/isolates/__tests__/omitWhen.test.ts
@@ -104,9 +104,9 @@ describe('omitWhen', () => {
         suite.run(omitConditional, 'field_2');
         expect(suite.get().tests.field_2.testCount).toBe(1);
         suite.run(omitConditional, 'field_3');
-        expect(suite.get().tests.field_3.testCount).toBe(0);
+        expect(suite.get().tests.field_3?.testCount).toBeUndefined();
         suite.run(omitConditional, 'field_4');
-        expect(suite.get().tests.field_4.testCount).toBe(0);
+        expect(suite.get().tests.field_4?.testCount).toBeUndefined();
         expect(cb1).toHaveBeenCalledTimes(1);
         expect(cb2).toHaveBeenCalledTimes(1);
         expect(cb3).toHaveBeenCalledTimes(0);
@@ -131,8 +131,8 @@ describe('omitWhen', () => {
         suite.run(omitConditional, 'field_2');
         expect(suite.get().tests.field_1.testCount).toBe(1);
         expect(suite.get().tests.field_2.testCount).toBe(1);
-        expect(suite.get().tests.field_3.testCount).toBe(0);
-        expect(suite.get().tests.field_4.testCount).toBe(0);
+        expect(suite.get().tests.field_3?.testCount).toBeUndefined();
+        expect(suite.get().tests.field_4?.testCount).toBeUndefined();
 
         expect(suite.get().isValid()).toBe(true);
       });
@@ -141,8 +141,8 @@ describe('omitWhen', () => {
         suite.run(omitConditional);
         expect(suite.get().tests.field_1.testCount).toBe(1);
         expect(suite.get().tests.field_2.testCount).toBe(1);
-        expect(suite.get().tests.field_3.testCount).toBe(0);
-        expect(suite.get().tests.field_4.testCount).toBe(0);
+        expect(suite.get().tests.field_3?.testCount).toBeUndefined();
+        expect(suite.get().tests.field_4?.testCount).toBeUndefined();
         expect(suite.get()).toMatchSnapshot();
       });
     });
@@ -162,7 +162,7 @@ describe('omitWhen', () => {
 
     it('should run fields that were previously omitted when changing to false', () => {
       suite.run(true, 'field_3');
-      expect(suite.get().tests.field_3.testCount).toBe(0);
+      expect(suite.get().tests.field_3?.testCount).toBeUndefined();
       expect(cb4).toHaveBeenCalledTimes(0);
       suite.run(false, 'field_3');
       expect(suite.get().tests.field_3.testCount).toBe(1);
@@ -246,6 +246,196 @@ describe('omitWhen', () => {
         .run();
       expect(res.isValid()).toBe(false);
       expect(res.isValid('f1')).toBe(false);
+    });
+  });
+
+  describe('stateful omitWhen', () => {
+    describe('sync tests', () => {
+      it('should omit previously run fields when changing to true without causing reorder issues', () => {
+        const cb0 = vi.fn();
+        const cb1 = vi.fn();
+        const cb2 = vi.fn();
+        const cb3 = vi.fn();
+        const cb4 = vi.fn();
+        const suite = vest.create((shouldOmit: boolean) => {
+          vest.test('field_0', cb0);
+          vest.test('field_1', cb1);
+          vest.omitWhen(shouldOmit, () => {
+            vest.test('field_2', cb2);
+            vest.test('field_3', cb3);
+          });
+          vest.test('field_4', cb4);
+        });
+
+        suite.run(false);
+        expect(suite.get().tests.field_0.testCount).toBe(1);
+        expect(suite.get().tests.field_1.testCount).toBe(1);
+        expect(suite.get().tests.field_2.testCount).toBe(1);
+        expect(suite.get().tests.field_3.testCount).toBe(1);
+        expect(suite.get().tests.field_4.testCount).toBe(1);
+        expect(cb0).toHaveBeenCalledTimes(1);
+        expect(cb1).toHaveBeenCalledTimes(1);
+        expect(cb2).toHaveBeenCalledTimes(1);
+        expect(cb3).toHaveBeenCalledTimes(1);
+        expect(cb4).toHaveBeenCalledTimes(1);
+
+        suite.run(true);
+        expect(suite.get().tests.field_0.testCount).toBe(1);
+        expect(suite.get().tests.field_1.testCount).toBe(1);
+        expect(suite.get().tests.field_2?.testCount).toBeUndefined();
+        expect(suite.get().tests.field_3?.testCount).toBeUndefined();
+        expect(suite.get().tests.field_4.testCount).toBe(1);
+        expect(cb0).toHaveBeenCalledTimes(2);
+        expect(cb1).toHaveBeenCalledTimes(2);
+        expect(cb2).toHaveBeenCalledTimes(1);
+        expect(cb3).toHaveBeenCalledTimes(1);
+        expect(cb4).toHaveBeenCalledTimes(2);
+      });
+
+      it('should run fields that were previously omitted when changing to false without causing reorder issues', () => {
+        const cb0 = vi.fn();
+        const cb1 = vi.fn();
+        const cb2 = vi.fn();
+        const cb3 = vi.fn();
+        const cb4 = vi.fn();
+        const suite = vest.create((shouldOmit: boolean) => {
+          vest.test('field_0', cb0);
+          vest.test('field_1', cb1);
+          vest.omitWhen(shouldOmit, () => {
+            vest.test('field_2', cb2);
+            vest.test('field_3', cb3);
+          });
+          vest.test('field_4', cb4);
+        });
+
+        suite.run(true);
+        expect(suite.get().tests.field_0.testCount).toBe(1);
+        expect(suite.get().tests.field_1.testCount).toBe(1);
+        expect(suite.get().tests.field_2?.testCount).toBeUndefined();
+        expect(suite.get().tests.field_3?.testCount).toBeUndefined();
+        expect(suite.get().tests.field_4.testCount).toBe(1);
+        expect(cb0).toHaveBeenCalledTimes(1);
+        expect(cb1).toHaveBeenCalledTimes(1);
+        expect(cb2).toHaveBeenCalledTimes(0);
+        expect(cb3).toHaveBeenCalledTimes(0);
+        expect(cb4).toHaveBeenCalledTimes(1);
+
+        suite.run(false);
+        expect(suite.get().tests.field_0.testCount).toBe(1);
+        expect(suite.get().tests.field_1.testCount).toBe(1);
+        expect(suite.get().tests.field_2.testCount).toBe(1);
+        expect(suite.get().tests.field_3.testCount).toBe(1);
+        expect(suite.get().tests.field_4.testCount).toBe(1);
+        expect(cb0).toHaveBeenCalledTimes(2);
+        expect(cb1).toHaveBeenCalledTimes(2);
+        expect(cb2).toHaveBeenCalledTimes(1);
+        expect(cb3).toHaveBeenCalledTimes(1);
+        expect(cb4).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('async tests', () => {
+      it('should omit previously run async tests when changing to true without causing reorder issues', async () => {
+        const cb0 = vi.fn();
+        const cb1 = vi.fn();
+        const cb2 = vi.fn();
+        const cb3 = vi.fn();
+        const cb4 = vi.fn();
+        const suite = vest.create((shouldOmit: boolean) => {
+          vest.test('field_0', async () => {
+            cb0();
+          });
+          vest.test('field_1', async () => {
+            cb1();
+          });
+          vest.omitWhen(shouldOmit, () => {
+            vest.test('field_2', async () => {
+              cb2();
+            });
+            vest.test('field_3', async () => {
+              cb3();
+            });
+          });
+          vest.test('field_4', async () => {
+            cb4();
+          });
+        });
+
+        await suite.run(false);
+        expect(suite.get().tests.field_0.testCount).toBe(1);
+        expect(suite.get().tests.field_1.testCount).toBe(1);
+        expect(suite.get().tests.field_2.testCount).toBe(1);
+        expect(suite.get().tests.field_3.testCount).toBe(1);
+        expect(suite.get().tests.field_4.testCount).toBe(1);
+        expect(cb0).toHaveBeenCalledTimes(1);
+        expect(cb1).toHaveBeenCalledTimes(1);
+        expect(cb2).toHaveBeenCalledTimes(1);
+        expect(cb3).toHaveBeenCalledTimes(1);
+        expect(cb4).toHaveBeenCalledTimes(1);
+
+        await suite.run(true);
+        expect(suite.get().tests.field_0.testCount).toBe(1);
+        expect(suite.get().tests.field_1.testCount).toBe(1);
+        expect(suite.get().tests.field_2?.testCount).toBeUndefined();
+        expect(suite.get().tests.field_3?.testCount).toBeUndefined();
+        expect(suite.get().tests.field_4.testCount).toBe(1);
+        expect(cb0).toHaveBeenCalledTimes(2);
+        expect(cb1).toHaveBeenCalledTimes(2);
+        expect(cb2).toHaveBeenCalledTimes(1);
+        expect(cb3).toHaveBeenCalledTimes(1);
+        expect(cb4).toHaveBeenCalledTimes(2);
+      });
+
+      it('should run async tests that were previously omitted when changing to false without causing reorder issues', async () => {
+        const cb0 = vi.fn();
+        const cb1 = vi.fn();
+        const cb2 = vi.fn();
+        const cb3 = vi.fn();
+        const cb4 = vi.fn();
+        const suite = vest.create((shouldOmit: boolean) => {
+          vest.test('field_0', async () => {
+            cb0();
+          });
+          vest.test('field_1', async () => {
+            cb1();
+          });
+          vest.omitWhen(shouldOmit, () => {
+            vest.test('field_2', async () => {
+              cb2();
+            });
+            vest.test('field_3', async () => {
+              cb3();
+            });
+          });
+          vest.test('field_4', async () => {
+            cb4();
+          });
+        });
+
+        await suite.run(true);
+        expect(suite.get().tests.field_0.testCount).toBe(1);
+        expect(suite.get().tests.field_1.testCount).toBe(1);
+        expect(suite.get().tests.field_2?.testCount).toBeUndefined();
+        expect(suite.get().tests.field_3?.testCount).toBeUndefined();
+        expect(suite.get().tests.field_4.testCount).toBe(1);
+        expect(cb0).toHaveBeenCalledTimes(1);
+        expect(cb1).toHaveBeenCalledTimes(1);
+        expect(cb2).toHaveBeenCalledTimes(0);
+        expect(cb3).toHaveBeenCalledTimes(0);
+        expect(cb4).toHaveBeenCalledTimes(1);
+
+        await suite.run(false);
+        expect(suite.get().tests.field_0.testCount).toBe(1);
+        expect(suite.get().tests.field_1.testCount).toBe(1);
+        expect(suite.get().tests.field_2.testCount).toBe(1);
+        expect(suite.get().tests.field_3.testCount).toBe(1);
+        expect(suite.get().tests.field_4.testCount).toBe(1);
+        expect(cb0).toHaveBeenCalledTimes(2);
+        expect(cb1).toHaveBeenCalledTimes(2);
+        expect(cb2).toHaveBeenCalledTimes(1);
+        expect(cb3).toHaveBeenCalledTimes(1);
+        expect(cb4).toHaveBeenCalledTimes(2);
+      });
     });
   });
 });

--- a/packages/vest/src/isolates/omitWhen.ts
+++ b/packages/vest/src/isolates/omitWhen.ts
@@ -2,7 +2,6 @@ import type { CB } from 'vest-utils';
 import { dynamicValue } from 'vest-utils';
 import { TIsolate } from 'vestjs-runtime';
 
-import { SuiteContext, useOmitted } from '../core/context/SuiteContext';
 import {
   createVestIsolate,
   VestIsolateType,
@@ -28,22 +27,14 @@ export function omitWhen<F extends TFieldName, G extends TGroupName>(
   return createVestIsolate(
     VestIsolateType.OmitWhen,
     () => {
-      SuiteContext.run(
-        {
-          omitted:
-            useWithinActiveOmitWhen() ||
-            dynamicValue(conditional, LazyDraft<F, G>()),
-        },
-        callback,
-      );
+      const isOmitted = dynamicValue(conditional, LazyDraft<F, G>());
+
+      if (!isOmitted) {
+        callback();
+      }
     },
     {
       tests: [],
     },
   );
-}
-
-// Checks that we're currently in an active omitWhen block
-export function useWithinActiveOmitWhen(): boolean {
-  return useOmitted();
 }

--- a/packages/vest/src/isolates/omitWhen.ts
+++ b/packages/vest/src/isolates/omitWhen.ts
@@ -13,6 +13,9 @@ import { LazyDraft } from '../suiteResult/selectors/LazyDraft';
 /**
  * Conditionally omits tests from the suite.
  *
+ * When the condition is met, the tests within the callback will be omitted
+ * and will not be executed. The callback itself will also be skipped.
+ *
  * @example
  *
  * omitWhen(res => res.hasErrors('username'), () => {

--- a/website/docs/writing_your_suite/including_and_excluding/omitWhen.md
+++ b/website/docs/writing_your_suite/including_and_excluding/omitWhen.md
@@ -99,12 +99,12 @@ omitWhen(
 );
 ```
 
-:::caution IMPORTANT
-The code within omitWhen will always run, regardless of whether the condition is met or not. `omitWhen` only affects the validation result, but if you call a function within `omitWhen`, it will run regardless of the condition.
+:::info IMPORTANT
+The code within `omitWhen` will only run if the condition is not met. If the condition is truthy, `omitWhen` skip calling the callback altogether, and the tests within it will not be executed or registered.
 
 ```js
 omitWhen(true, () => {
-  console.log('This will always run');
+  console.log('This will NOT run');
 });
 ```
 

--- a/website/versioned_docs/version-5.x/writing_your_suite/including_and_excluding/omitWhen.md
+++ b/website/versioned_docs/version-5.x/writing_your_suite/including_and_excluding/omitWhen.md
@@ -99,12 +99,12 @@ omitWhen(
 );
 ```
 
-:::caution IMPORTANT
-The code within omitWhen will always run, regardless of whether the condition is met or not. `omitWhen` only affects the validation result, but if you call a function within `omitWhen`, it will run regardless of the condition.
+:::info IMPORTANT
+The code within `omitWhen` will only run if the condition is not met. If the condition is truthy, `omitWhen` skip calling the callback altogether, and the tests within it will not be executed or registered.
 
 ```js
 omitWhen(true, () => {
-  console.log('This will always run');
+  console.log('This will NOT run');
 });
 ```
 


### PR DESCRIPTION
This PR modifies the `omitWhen` isolate to evaluate its conditional earlier and entirely skip executing the provided callback if the condition evaluates to true. 

This correctly resolves issues where fields within `omitWhen` loops would incorrectly register with a `testCount` of 0 rather than being excluded from the test suite entirely. As a result of this optimization, the unused `omitted` state has also been removed from `SuiteContext`.

Along with this fix, several new stateful async and sync test validation suits have been added covering testing states and ensuring execution context evaluation remains unbalkanized across reordered tests or dynamic omission phases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Omitted fields are now treated as invalid (validation state now reflects omission).

* **Tests**
  * Expanded and adjusted tests for omission behavior, including new stateful scenarios and parity between sync/async flows.

* **Documentation**
  * Updated omitWhen docs and examples to reflect conditional execution semantics.

* **Breaking Changes**
  * Removed previously exposed omission-related hooks/APIs; adjust integrations accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->