### PR TITLE
feat: isolate parsedData per run rather than cumulatively merging

### DIFF
--- a/packages/vest/src/core/Runtime.ts
+++ b/packages/vest/src/core/Runtime.ts
@@ -19,7 +19,6 @@ type DoneCallbacks = Array<DoneCallback>;
 type StateExtra = {
   doneCallbacks: TinyState<DoneCallbacks>;
   fieldCallbacks: TinyState<FieldCallbacks>;
-  parsedDataCache: TinyState<Record<string, unknown>>;
   suiteId: string;
   suiteResultCache: CacheApi<SuiteResult<TFieldName, TGroupName, TSchema>>;
 };
@@ -34,9 +33,6 @@ export function useCreateVestState({
   const stateRef: StateExtra = {
     doneCallbacks: tinyState.createTinyState<DoneCallbacks>(() => []),
     fieldCallbacks: tinyState.createTinyState<FieldCallbacks>(() => ({})),
-    parsedDataCache: tinyState.createTinyState<Record<string, unknown>>(
-      () => ({}),
-    ),
     suiteId: seq(),
     suiteResultCache: createSuiteResultCache(),
   };
@@ -58,10 +54,6 @@ export function useFieldCallbacks() {
 
 function useSuiteId() {
   return useVestState().suiteId;
-}
-
-export function useParsedDataCache() {
-  return useVestState().parsedDataCache();
 }
 
 export function useSuiteResultCache<
@@ -101,10 +93,8 @@ export function useResetCallbacks() {
 }
 
 export function useResetSuite() {
-  const [, , resetParsedData] = useParsedDataCache();
   useExpireSuiteResultCache();
   useResetCallbacks();
-  resetParsedData();
   VestRuntime.reset();
 }
 

--- a/packages/vest/src/suite/__tests__/runSummary.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/runSummary.integration.test.ts
@@ -89,7 +89,7 @@ describe('suite result run summary metadata', () => {
       });
     });
 
-    it('should cumulatively merge parsed data over successive focused runs with parsers', () => {
+    it('should return isolated parsed data over successive focused runs with parsers', () => {
       const schema = enforce.shape({
         firstName: enforce.isString().trim().toUpper(),
         lastName: enforce.isString().trim(),
@@ -115,11 +115,8 @@ describe('suite result run summary metadata', () => {
       // raw is ONLY the current run's transformed value
       expect(res2.run.data.raw).toEqual({ lastName: 'doe' });
 
-      // parsed cumulatively merges: firstName from Run 1 is retained as 'JOHN'
-      expect(res2.run.data.parsed).toEqual({
-        firstName: 'JOHN',
-        lastName: 'doe',
-      });
+      // parsed only holds the new transformed value
+      expect(res2.run.data.parsed).toEqual({ lastName: 'doe' });
     });
 
     it('should overwrite previously parsed values with new transformed values on subsequent runs', () => {
@@ -136,15 +133,15 @@ describe('suite result run summary metadata', () => {
 
       // Run 2: focus on score only, update it
       const res2 = suite.focus({ only: 'score' }).run({ score: '99' });
-      // parsed retains the previous label and updates score
-      expect(res2.run.data.parsed).toEqual({ score: 99, label: 'HELLO' });
+      // parsed only contains score
+      expect(res2.run.data.parsed).toEqual({ score: 99 });
 
       // Run 3: update both again
       const res3 = suite.run({ score: '7', label: '  world  ' });
       expect(res3.run.data.parsed).toEqual({ score: 7, label: 'WORLD' });
     });
 
-    it('should retain parsed values from previous runs even when current run fails schema validation', () => {
+    it('should not retain parsed values from previous runs when current run fails schema validation', () => {
       const schema = enforce.shape({
         age: enforce.isNumber(),
         name: enforce.isString().trim().toUpper(),
@@ -163,8 +160,8 @@ describe('suite result run summary metadata', () => {
 
       // raw is the failing input
       expect(res2.run.data.raw).toEqual(payload);
-      // parsed retains the previous valid 'name' since the current chunk failed
-      expect(res2.run.data.parsed).toEqual({ name: 'VALID' });
+      // parsed is empty since the current chunk failed
+      expect(res2.run.data.parsed).toEqual({});
     });
 
     it('should prove parsed values are transformed types (number vs string) that persist across runs', () => {
@@ -182,11 +179,7 @@ describe('suite result run summary metadata', () => {
 
       // Run 2: focus on tag
       const res2 = suite.focus({ only: 'tag' }).run({ tag: '  trimmed  ' });
-      expect(res2.run.data.parsed).toEqual({ count: 10, tag: 'trimmed' });
-
-      // Verify the count from Run 1 is still a number, not reverted to string
-      expect(typeof res2.run.data.parsed?.count).toBe('number');
-      expect(res2.run.data.parsed?.count).toBe(10);
+      expect(res2.run.data.parsed).toEqual({ tag: 'trimmed' });
     });
   });
 });

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -328,7 +328,7 @@ describe('Schema Runtime Validation', () => {
       expect(result.run.data.parsed?.name).toBe('BOB');
     });
 
-    it('should cumulatively assign parsed data across focused suite runs using enforce parsers', () => {
+    it('should assign isolated parsed data across focused suite runs using enforce parsers', () => {
       const schema = enforce.shape({
         username: enforce.isString().trim().toLower(),
         score: enforce.isNumeric().toNumber(),
@@ -350,13 +350,13 @@ describe('Schema Runtime Validation', () => {
       // raw is ONLY the current run's transformed value
       expect(res2.run.data.raw).toEqual({ score: 99 });
 
-      // parsed cumulatively merges: username from Run 1 is still 'alice' (trimmed + lowercased)
-      expect(res2.run.data.parsed).toEqual({ username: 'alice', score: 99 });
+      // parsed only contains the score
+      expect(res2.run.data.parsed).toEqual({ score: 99 });
 
       // Prove type persistence: score is number, not string
       expect(typeof res2.run.data.parsed?.score).toBe('number');
-      // And username from Run 1 is still present as 'alice'
-      expect(res2.run.data.parsed?.username).toBe('alice');
+
+      expect(res2.run.data.parsed?.username).toBeUndefined();
     });
   });
 
@@ -679,7 +679,7 @@ describe('Schema input vs output type inference', () => {
       expect(result.hasErrors('score')).toBe(false);
     });
 
-    it('should cumulatively merge parsed values across focused runs', () => {
+    it('should isolate parsed values across focused runs', () => {
       const schema = enforce.shape({
         a: enforce.isString().trim(),
         b: enforce.isNumeric().toNumber(),
@@ -698,7 +698,7 @@ describe('Schema input vs output type inference', () => {
       expect(r1.run.data.parsed).toEqual({ a: 'x' });
 
       const r2 = suite.focus({ only: 'b' }).run({ b: '7' });
-      expect(r2.run.data.parsed).toEqual({ a: 'x', b: 7 });
+      expect(r2.run.data.parsed).toEqual({ b: 7 });
     });
   });
 

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -360,6 +360,23 @@ describe('Schema Runtime Validation', () => {
     });
   });
 
+  describe('Mutation resilience', () => {
+    it('should freeze parsed data snapshot so callback mutations do not affect run metadata', () => {
+      const schema = enforce.shape({
+        score: enforce.isNumeric().toNumber(),
+      });
+
+      const suite = create(data => {
+        // Maliciously mutate the input
+        data.score = 500;
+      }, schema);
+
+      const result = suite.run({ score: '42' });
+
+      expect(result.run.data.parsed).toEqual({ score: 42 });
+    });
+  });
+
   describe('Stateful behavior', () => {
     it('should run schema validation dynamically based on focus per execution', () => {
       const schema = enforce.shape({

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -374,6 +374,7 @@ describe('Schema Runtime Validation', () => {
       const result = suite.run({ score: '42' });
 
       expect(result.run.data.parsed).toEqual({ score: 42 });
+      expect(Object.isFrozen(result.run.data.parsed)).toBe(true);
     });
   });
 

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -366,13 +366,17 @@ describe('Schema Runtime Validation', () => {
         score: enforce.isNumeric().toNumber(),
       });
 
+      let callbackRan = false;
+
       const suite = create(data => {
+        callbackRan = true;
         // Maliciously mutate the input
         data.score = 500;
       }, schema);
 
       const result = suite.run({ score: '42' });
 
+      expect(callbackRan).toBe(true);
       expect(result.run.data.parsed).toEqual({ score: 42 });
       expect(Object.isFrozen(result.run.data.parsed)).toBe(true);
     });

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -13,7 +13,6 @@ import {
 import { useEmit } from '../core/VestBus/VestBus';
 
 import { SuiteContext } from '../core/context/SuiteContext';
-import { useParsedDataCache } from '../core/Runtime';
 import { IsolateReorderable } from 'vestjs-runtime';
 import { IsolateSuite } from '../core/isolate/IsolateSuite/IsolateSuite';
 import { test } from '../core/test/test';
@@ -70,15 +69,10 @@ export function useCreateSuiteRunner<
       : undefined;
 
     const parsedDataChunk = getParsedDataChunk(schemaRunResult);
-    const [previousParsedData, setParsedData] = useParsedDataCache();
 
-    const mergedParsedData = (
-      schema
-        ? freezeAssign({}, previousParsedData, parsedDataChunk as object)
-        : undefined
-    ) as Partial<InferSchemaOutput<S>> | undefined;
-
-    setParsedData(mergedParsedData ?? {});
+    const parsedData = (schema ? parsedDataChunk : undefined) as
+      | Partial<InferSchemaOutput<S>>
+      | undefined;
 
     const callbackInput = getCallbackInput(schemaRunResult, schemaInput);
     const callbackArgs = [callbackInput, ...args.slice(1)] as Parameters<T>;
@@ -99,7 +93,7 @@ export function useCreateSuiteRunner<
             callbackInput,
             runData,
             runTime,
-            mergedParsedData,
+            parsedData,
             snapshotFocus(transformedModifiers),
           );
 

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -70,9 +70,9 @@ export function useCreateSuiteRunner<
 
     const parsedDataChunk = getParsedDataChunk(schemaRunResult);
 
-    const parsedData = (schema ? parsedDataChunk : undefined) as
-      | Partial<InferSchemaOutput<S>>
-      | undefined;
+    const parsedData = (
+      schema ? snapshotParsedData(parsedDataChunk) : undefined
+    ) as Partial<InferSchemaOutput<S>> | undefined;
 
     const callbackInput = getCallbackInput(schemaRunResult, schemaInput);
     const callbackArgs = [callbackInput, ...args.slice(1)] as Parameters<T>;
@@ -134,6 +134,20 @@ function getParsedDataChunk(
 
   const [firstResult] = schemaRunResult;
   return firstResult?.type ?? {};
+}
+
+/**
+ * Creates a defensive snapshot of the parsed data to prevent mutations
+ * in the suite callback from affecting the result object.
+ */
+function snapshotParsedData(data: unknown): unknown {
+  if (isArray(data)) {
+    return Object.freeze([...(data as unknown[])]);
+  }
+  if (isObject(data)) {
+    return freezeAssign({}, data as object);
+  }
+  return data;
 }
 
 /**

--- a/website/docs/api_reference.md
+++ b/website/docs/api_reference.md
@@ -279,4 +279,4 @@ After running your suite, the results object is returned. It has the following f
 - `isValidByGroup(groupName)`: Returns true if a certain group or a field in a group is valid or not.
 - `value`: The parsed schema output when the suite is valid. Typed as the schema's output type. `undefined` when invalid or when no schema is used.
 - `types`: When a schema is present, an object with `input` and `output` properties typed from the schema. `undefined` when no schema is used.
-- `run`: Metadata about the latest run, including `run.data.raw` (current run data), `run.data.parsed` (cumulative parsed data across focused runs), and `run.time` (timestamp).
+- `run`: Metadata about the latest run, including `run.data.raw` (current run data), `run.data.parsed` (parsed data for the current run), and `run.time` (timestamp).

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -172,7 +172,7 @@ The suite result includes typed properties for accessing validated and parsed da
 - `result.types.input` — Carries the schema's input type for static analysis. At runtime, holds the parsed output value.
 - `result.types.output` — Carries the schema's output type. At runtime, holds the parsed output value.
 - `result.run.data.raw` — The current run data passed into the suite callback (parsed when schema validation succeeds; original input when it fails).
-- `result.run.data.parsed` — Cumulatively merged parsed data across focused runs.
+- `result.run.data.parsed` — Parsed data for the current run.
 
 ```typescript
 const schema = enforce.shape({


### PR DESCRIPTION
This PR refactors the parsedData logic in SuiteResult to avoid returning cumulative merged parsed data. It removes parsedDataCache and related utilities from Runtime.ts, ensuring that only the specific run's parsed data is returned rather than a merged output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parsed data is now isolated to each run (no cross-run accumulation); run results contain only that run’s transformed fields.

* **Refactor**
  * Removed internal parsed-data caching and merged-state behavior, simplifying reset semantics and preventing parsed data leakage between runs.

* **Tests**
  * Tests updated to assert per-run parsed isolation and immutability of run snapshots.

* **Documentation**
  * API and schema docs updated to describe per-run parsed data behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->