### PR TITLE
feat(memo): add cacheSize and ttl configuration options

### DIFF
--- a/packages/vest-utils/src/__tests__/cache.test.ts
+++ b/packages/vest-utils/src/__tests__/cache.test.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { cache } from '../vest-utils';
 
@@ -80,6 +80,64 @@ describe('lib: cache', () => {
       });
     });
   });
+
+  describe('Configuration Options', () => {
+    it('Should allow setting maxSize through a config object', () => {
+      const c = cache({ maxSize: 2 });
+      const cb = vi.fn(() => Math.random());
+
+      c([1], cb);
+      c([2], cb);
+      c([3], cb);
+
+      expect(c.get([1])).toBeNull();
+      expect(c.get([2])?.[0]).toEqual([2]);
+      expect(c.get([3])?.[0]).toEqual([3]);
+    });
+
+    describe('ttl', () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(1000);
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('Should retain cache item if ttl has not passed', () => {
+        const c = cache({ ttl: 50 });
+        const cb = vi.fn(() => Math.random());
+        c([1], cb);
+
+        vi.setSystemTime(1040); // 40ms later, inside 50ms ttl
+        c([1], cb);
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(c.get([1])).not.toBeNull();
+      });
+
+      it('Should evict cache item if ttl has passed', () => {
+        const c = cache({ ttl: 50 });
+        const cb = vi.fn(() => Math.random());
+        c([1], cb);
+
+        vi.setSystemTime(1060); // 60ms later, exceeded 50ms ttl
+        c([1], cb);
+
+        expect(cb).toHaveBeenCalledTimes(2);
+      });
+
+      it('get() should return null and evict from storage if ttl has passed', () => {
+        const c = cache({ ttl: 50 });
+        const cb = vi.fn(() => Math.random());
+        c([1], cb);
+
+        vi.setSystemTime(1060);
+        expect(c.get([1])).toBeNull();
+      });
+    });
+  });
+
   it('Should take into account the deps array in its entirety', () => {
     const deps = Array.from({ length: 100 }, () =>
       _.sample([{}, false, Math.random(), true, () => null]),

--- a/packages/vest-utils/src/cache.ts
+++ b/packages/vest-utils/src/cache.ts
@@ -1,7 +1,7 @@
 import { lengthEquals } from './lengthEquals';
 import { longerThan } from './longerThan';
 import { DynamicValue, Nullable } from './utilityTypes';
-import { dynamicValue } from './vest-utils';
+import { dynamicValue, isNullish, isObject } from './vest-utils';
 
 export type CacheConfig = {
   maxSize?: number;
@@ -44,7 +44,7 @@ export default function createCache<T = unknown>(
 
     if (!item) return null;
 
-    if (ttl !== undefined && Date.now() - item[2] > ttl) {
+    if (!isNullish(ttl) && Date.now() - item[2] > ttl) {
       cacheStorage.splice(index, 1);
       return null;
     }
@@ -90,10 +90,9 @@ export type CacheApi<T = unknown> = {
 function getCacheConfig(
   maxSizeOrConfig?: number | CacheConfig,
 ): Required<Pick<CacheConfig, 'maxSize'>> & Pick<CacheConfig, 'ttl'> {
-  const config =
-    typeof maxSizeOrConfig === 'object' && maxSizeOrConfig !== null
-      ? maxSizeOrConfig
-      : { maxSize: maxSizeOrConfig as number | undefined };
+  const config = isObject(maxSizeOrConfig)
+    ? maxSizeOrConfig
+    : { maxSize: maxSizeOrConfig as number | undefined };
   return {
     maxSize: config.maxSize ?? 1,
     ttl: config.ttl,

--- a/packages/vest-utils/src/cache.ts
+++ b/packages/vest-utils/src/cache.ts
@@ -3,11 +3,20 @@ import { longerThan } from './longerThan';
 import { DynamicValue, Nullable } from './utilityTypes';
 import { dynamicValue } from './vest-utils';
 
+export type CacheConfig = {
+  maxSize?: number;
+  ttl?: number;
+};
+
 /**
  * Creates a cache function
  */
-export default function createCache<T = unknown>(maxSize = 1): CacheApi<T> {
-  const cacheStorage: Array<[unknown[], T]> = [];
+export default function createCache<T = unknown>(
+  maxSizeOrConfig?: number | CacheConfig,
+): CacheApi<T> {
+  const { maxSize, ttl } = getCacheConfig(maxSizeOrConfig);
+
+  const cacheStorage: Array<[unknown[], T, number]> = [];
 
   const cache = (deps: unknown[], cacheAction: DynamicValue<T>): T => {
     const cacheHit = cache.get(deps);
@@ -15,7 +24,7 @@ export default function createCache<T = unknown>(maxSize = 1): CacheApi<T> {
     if (cacheHit) return cacheHit[1];
 
     const result = dynamicValue(cacheAction);
-    cacheStorage.unshift([deps.concat(), result]);
+    cacheStorage.unshift([deps.concat(), result, Date.now()]);
 
     trimToSize();
 
@@ -29,16 +38,27 @@ export default function createCache<T = unknown>(maxSize = 1): CacheApi<T> {
   };
 
   // Retrieves an item from the cache.
-  cache.get = (deps: unknown[]): Nullable<[unknown[], T]> =>
-    cacheStorage[findIndex(deps)] || null;
+  cache.get = (deps: unknown[]): Nullable<[unknown[], T]> => {
+    const index = findIndex(deps);
+    const item = cacheStorage[index];
+
+    if (!item) return null;
+
+    if (ttl !== undefined && Date.now() - item[2] > ttl) {
+      cacheStorage.splice(index, 1);
+      return null;
+    }
+
+    return [item[0], item[1]];
+  };
 
   // sets a value to the cache by its dependencies, updating if a hit is found.
   cache.set = (deps: unknown[], value: T): void => {
     const index = findIndex(deps);
     if (index > -1) {
-      cacheStorage[index] = [deps, value];
+      cacheStorage[index] = [deps, value, Date.now()];
     } else {
-      cacheStorage.unshift([deps, value]);
+      cacheStorage.unshift([deps, value, Date.now()]);
     }
     trimToSize();
   };
@@ -66,3 +86,16 @@ export type CacheApi<T = unknown> = {
   set(deps: unknown[], value: T): void;
   invalidate(item: any): void;
 };
+
+function getCacheConfig(
+  maxSizeOrConfig?: number | CacheConfig,
+): Required<Pick<CacheConfig, 'maxSize'>> & Pick<CacheConfig, 'ttl'> {
+  const config =
+    typeof maxSizeOrConfig === 'object' && maxSizeOrConfig !== null
+      ? maxSizeOrConfig
+      : { maxSize: maxSizeOrConfig as number | undefined };
+  return {
+    maxSize: config.maxSize ?? 1,
+    ttl: config.ttl,
+  };
+}

--- a/packages/vest-utils/src/vest-utils.ts
+++ b/packages/vest-utils/src/vest-utils.ts
@@ -1,6 +1,6 @@
 export { withResolvers } from './withResolvers';
 export { default as cache } from './cache';
-export type { CacheApi } from './cache';
+export type { CacheApi, CacheConfig } from './cache';
 export type { BusType } from './bus';
 export type { TinyState } from './tinyState';
 export { isNullish, isNotNullish } from './isNullish';

--- a/packages/vest/src/exports/__tests__/memo.test.ts
+++ b/packages/vest/src/exports/__tests__/memo.test.ts
@@ -279,6 +279,71 @@ describe('memo', () => {
       expect(suite.getError('f1')).toBe('CacheKey is a, index is: 600');
     });
 
+    describe('Configuration Options', () => {
+      it('should respect custom cacheSize configuration', () => {
+        const suite = vest.create(
+          ({ cacheKey, index }: { cacheKey: string; index: number }) => {
+            memo(
+              () => {
+                vestTest(
+                  'f1',
+                  `CacheKey is ${cacheKey}, index is: ${index}`,
+                  () => false,
+                );
+              },
+              [cacheKey],
+              { cacheSize: 2 },
+            );
+          },
+        );
+
+        suite.run({ cacheKey: 'a', index: 0 });
+        expect(suite.getError('f1')).toBe('CacheKey is a, index is: 0');
+        suite.run({ cacheKey: 'b', index: 1 });
+        expect(suite.getError('f1')).toBe('CacheKey is b, index is: 1');
+        suite.run({ cacheKey: 'c', index: 2 });
+        expect(suite.getError('f1')).toBe('CacheKey is c, index is: 2');
+
+        // Cache limit breached (size was 2), 'a' should be evicted
+        suite.run({ cacheKey: 'a', index: 3 });
+        expect(suite.getError('f1')).toBe('CacheKey is a, index is: 3');
+      });
+
+      it('should invalidate cache if ttl expires', async () => {
+        let executionCount = 0;
+        const suite = vest.create(
+          ({ cacheKey, index }: { cacheKey: string; index: number }) => {
+            memo(
+              () => {
+                executionCount++;
+                vestTest(
+                  'f1',
+                  `CacheKey is ${cacheKey}, index is: ${index}`,
+                  () => false,
+                );
+              },
+              [cacheKey],
+              { ttl: 50 },
+            );
+          },
+        );
+
+        suite.run({ cacheKey: 'a', index: 0 });
+        expect(suite.getError('f1')).toBe('CacheKey is a, index is: 0');
+        expect(executionCount).toBe(1);
+
+        suite.run({ cacheKey: 'a', index: 1 });
+        expect(suite.getError('f1')).toBe('CacheKey is a, index is: 0');
+        expect(executionCount).toBe(1); // Cache hit
+
+        await wait(60);
+
+        suite.run({ cacheKey: 'a', index: 2 });
+        expect(suite.getError('f1')).toBe('CacheKey is a, index is: 2');
+        expect(executionCount).toBe(2); // Cache miss, ttl expired
+      });
+    });
+
     it('Should correctly restore async tests', async () => {
       const tests = [];
       const suite = vest.create(({ key, index }) => {

--- a/packages/vest/src/exports/__tests__/memo.test.ts
+++ b/packages/vest/src/exports/__tests__/memo.test.ts
@@ -279,71 +279,6 @@ describe('memo', () => {
       expect(suite.getError('f1')).toBe('CacheKey is a, index is: 600');
     });
 
-    describe('Configuration Options', () => {
-      it('should respect custom cacheSize configuration', () => {
-        const suite = vest.create(
-          ({ cacheKey, index }: { cacheKey: string; index: number }) => {
-            memo(
-              () => {
-                vestTest(
-                  'f1',
-                  `CacheKey is ${cacheKey}, index is: ${index}`,
-                  () => false,
-                );
-              },
-              [cacheKey],
-              { cacheSize: 2 },
-            );
-          },
-        );
-
-        suite.run({ cacheKey: 'a', index: 0 });
-        expect(suite.getError('f1')).toBe('CacheKey is a, index is: 0');
-        suite.run({ cacheKey: 'b', index: 1 });
-        expect(suite.getError('f1')).toBe('CacheKey is b, index is: 1');
-        suite.run({ cacheKey: 'c', index: 2 });
-        expect(suite.getError('f1')).toBe('CacheKey is c, index is: 2');
-
-        // Cache limit breached (size was 2), 'a' should be evicted
-        suite.run({ cacheKey: 'a', index: 3 });
-        expect(suite.getError('f1')).toBe('CacheKey is a, index is: 3');
-      });
-
-      it('should invalidate cache if ttl expires', async () => {
-        let executionCount = 0;
-        const suite = vest.create(
-          ({ cacheKey, index }: { cacheKey: string; index: number }) => {
-            memo(
-              () => {
-                executionCount++;
-                vestTest(
-                  'f1',
-                  `CacheKey is ${cacheKey}, index is: ${index}`,
-                  () => false,
-                );
-              },
-              [cacheKey],
-              { ttl: 50 },
-            );
-          },
-        );
-
-        suite.run({ cacheKey: 'a', index: 0 });
-        expect(suite.getError('f1')).toBe('CacheKey is a, index is: 0');
-        expect(executionCount).toBe(1);
-
-        suite.run({ cacheKey: 'a', index: 1 });
-        expect(suite.getError('f1')).toBe('CacheKey is a, index is: 0');
-        expect(executionCount).toBe(1); // Cache hit
-
-        await wait(60);
-
-        suite.run({ cacheKey: 'a', index: 2 });
-        expect(suite.getError('f1')).toBe('CacheKey is a, index is: 2');
-        expect(executionCount).toBe(2); // Cache miss, ttl expired
-      });
-    });
-
     it('Should correctly restore async tests', async () => {
       const tests = [];
       const suite = vest.create(({ key, index }) => {
@@ -363,6 +298,71 @@ describe('memo', () => {
       expect(res.getError('f1')).toBe(undefined);
       res = await suite.run({ key: 'b', index: 2 });
       expect(res.getError('f1')).toBe('key: b, index: 1');
+    });
+  });
+
+  describe('Configuration Options', () => {
+    it('should respect custom cacheSize configuration', () => {
+      const suite = vest.create(
+        ({ cacheKey, index }: { cacheKey: string; index: number }) => {
+          memo(
+            () => {
+              vestTest(
+                'f1',
+                `CacheKey is ${cacheKey}, index is: ${index}`,
+                () => false,
+              );
+            },
+            [cacheKey],
+            { cacheSize: 2 },
+          );
+        },
+      );
+
+      suite.run({ cacheKey: 'a', index: 0 });
+      expect(suite.getError('f1')).toBe('CacheKey is a, index is: 0');
+      suite.run({ cacheKey: 'b', index: 1 });
+      expect(suite.getError('f1')).toBe('CacheKey is b, index is: 1');
+      suite.run({ cacheKey: 'c', index: 2 });
+      expect(suite.getError('f1')).toBe('CacheKey is c, index is: 2');
+
+      // Cache limit breached (size was 2), 'a' should be evicted
+      suite.run({ cacheKey: 'a', index: 3 });
+      expect(suite.getError('f1')).toBe('CacheKey is a, index is: 3');
+    });
+
+    it('should invalidate cache if ttl expires', async () => {
+      let executionCount = 0;
+      const suite = vest.create(
+        ({ cacheKey, index }: { cacheKey: string; index: number }) => {
+          memo(
+            () => {
+              executionCount++;
+              vestTest(
+                'f1',
+                `CacheKey is ${cacheKey}, index is: ${index}`,
+                () => false,
+              );
+            },
+            [cacheKey],
+            { ttl: 50 },
+          );
+        },
+      );
+
+      suite.run({ cacheKey: 'a', index: 0 });
+      expect(suite.getError('f1')).toBe('CacheKey is a, index is: 0');
+      expect(executionCount).toBe(1);
+
+      suite.run({ cacheKey: 'a', index: 1 });
+      expect(suite.getError('f1')).toBe('CacheKey is a, index is: 0');
+      expect(executionCount).toBe(1); // Cache hit
+
+      await wait(100);
+
+      suite.run({ cacheKey: 'a', index: 2 });
+      expect(suite.getError('f1')).toBe('CacheKey is a, index is: 2');
+      expect(executionCount).toBe(2); // Cache miss, ttl expired
     });
   });
 

--- a/packages/vest/src/exports/memo.ts
+++ b/packages/vest/src/exports/memo.ts
@@ -7,6 +7,7 @@ import {
   makeResult,
   Result,
   unwrap,
+  CacheConfig,
 } from 'vest-utils';
 import { TIsolate, IsolateSelectors, Walker } from 'vestjs-runtime';
 
@@ -20,13 +21,20 @@ import { registerReconciler } from '../vest';
 
 const isolateType = 'Memo';
 
+export type MemoOptions = {
+  cacheSize?: number;
+  ttl?: number;
+};
+
 export function memo<Callback extends CB = CB>(
   callback: Callback,
   dependencies: unknown[],
+  options?: MemoOptions,
 ): TIsolateMemo {
   return createVestIsolate(isolateType, callback, {
     dependencies,
     cache: null,
+    options,
   });
 }
 
@@ -68,6 +76,7 @@ type TIsolateMemoWithCache = TIsolateMemo & {
 type IsolateMemoPayload = {
   dependencies: unknown[];
   cache: Nullable<CacheApi<TIsolateMemo>>;
+  options?: MemoOptions;
 };
 
 registerReconciler(IsolateMemoReconciler);
@@ -76,7 +85,9 @@ function initializeCache(
   history: TIsolateMemo,
 ): Result<TIsolateMemoWithCache, string> {
   if (isNullish(history.data.cache)) {
-    history.data.cache = cache<TIsolateMemo>(5);
+    history.data.cache = cache<TIsolateMemo>(
+      getMemoCacheConfig(history.data.options),
+    );
     history.data.cache(history.data.dependencies, () => history);
   }
 
@@ -99,4 +110,11 @@ function isCanceledTest(historicHit: TIsolateMemo): boolean {
     i => VestTest.isCanceled(i as TIsolateTest).unwrap(),
     VestTest.is,
   );
+}
+
+function getMemoCacheConfig(options?: MemoOptions): CacheConfig {
+  return {
+    maxSize: options?.cacheSize ?? 5,
+    ttl: options?.ttl,
+  };
 }

--- a/website/docs/api_reference.md
+++ b/website/docs/api_reference.md
@@ -173,6 +173,10 @@ Extends Vest's enforce with custom validation rules.
 
 Memoizes a block of tests.
 
+- `callback`: The function to execute if dependencies change.
+- `deps`: Array of dependencies determining if the callback executes.
+- `options` (Optional): Configuration object with `cacheSize` (max cached results) and `ttl` (Time-to-Live in ms).
+
 - [Read more about `memo`](./writing_tests/advanced_test_features/memo.md)
 
 #### `compose(...rules)`

--- a/website/docs/api_reference.md
+++ b/website/docs/api_reference.md
@@ -169,7 +169,7 @@ Extends Vest's enforce with custom validation rules.
 
 - **Tip**: To add TypeScript support for your custom rules, see [TypeScript Support](./typescript_support.md#custom-enforce-rules).
 
-#### `memo(callback, deps)`
+#### `memo(callback, deps, options?)`
 
 Memoizes a block of tests.
 

--- a/website/docs/upgrade_guide.md
+++ b/website/docs/upgrade_guide.md
@@ -64,7 +64,7 @@ create(data => {
 
 + memo(() => {
 +   test('field', 'msg', () => { ... });
-+ }, [data.field]);
++ }, [data.field], { cacheSize: 5 });
 });
 ```
 
@@ -141,7 +141,7 @@ I am migrating my Vest validation suites from version 5 to version 6. Please ref
     - Remove `.done()` callbacks. Use `await suite.afterField('fieldName', callback)` or `suite.afterEach(callback)`.
 
 4.  **Memoization**:
-    - Change `test.memo(...)` to `memo(() => { test(...) }, deps)`.
+    - Change `test.memo(...)` to `memo(() => { test(...) }, deps, options?)`.
     - Ensure `memo` is imported from 'vest/memo': `import { memo } from 'vest/memo';`.
 
 5.  **Field-Focused Validation**:

--- a/website/docs/upgrade_guide.md
+++ b/website/docs/upgrade_guide.md
@@ -64,7 +64,7 @@ create(data => {
 
 + memo(() => {
 +   test('field', 'msg', () => { ... });
-+ }, [data.field], { cacheSize: 5 });
++ }, [data.field]);
 });
 ```
 
@@ -141,7 +141,7 @@ I am migrating my Vest validation suites from version 5 to version 6. Please ref
     - Remove `.done()` callbacks. Use `await suite.afterField('fieldName', callback)` or `suite.afterEach(callback)`.
 
 4.  **Memoization**:
-    - Change `test.memo(...)` to `memo(() => { test(...) }, deps, options?)`.
+    - Change `test.memo(...)` to `memo(() => { test(...) }, deps)`.
     - Ensure `memo` is imported from 'vest/memo': `import { memo } from 'vest/memo';`.
 
 5.  **Field-Focused Validation**:

--- a/website/docs/writing_tests/advanced_test_features/memo.md
+++ b/website/docs/writing_tests/advanced_test_features/memo.md
@@ -57,6 +57,32 @@ memo(() => {
 }, [data.shipping_address]);
 ```
 
+## Advanced Configuration
+
+`memo` accepts an optional third parameter: an options object to further control caching behavior.
+
+```javascript
+memo(
+  () => {
+    test('username', 'Username is taken', async () => {
+      await checkAvailability(data.username);
+    });
+  },
+  [data.username],
+  {
+    cacheSize: 5, // Keep up to 5 previous results
+    ttl: 10000, // Invalidate cache after 10 seconds
+  },
+);
+```
+
+### Options
+
+| Option      | Type     | Default     | Description                                                                                                                                    |
+| :---------- | :------- | :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cacheSize` | `number` | `5`         | The maximum number of previous memo results to retain in the cache. When the limit is reached, the oldest result is evicted.                   |
+| `ttl`       | `number` | `undefined` | Time-to-Live in milliseconds. If the cached result is older than the `ttl`, the cache will be invalidated and the test blocked will be re-run. |
+
 ## How it works
 
 1.  Vest checks the dependency array passed as the second argument.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -234,7 +234,7 @@ After running your suite, the results object is returned. It has the following f
 - `isValidByGroup(groupName)`: Returns true if a certain group or a field in a group is valid or not.
 - `value`: The parsed schema output when the suite is valid. Typed as the schema's output type. `undefined` when invalid or when no schema is used.
 - `types`: When a schema is present, an object with `input` and `output` properties typed from the schema. `undefined` when no schema is used.
-- `run`: Metadata about the latest run, including `run.data.raw` (current run data), `run.data.parsed` (cumulative parsed data across focused runs), and `run.time` (timestamp).
+- `run`: Metadata about the latest run, including `run.data.raw` (current run data), `run.data.parsed` (parsed data for the current run), and `run.time` (timestamp).
 
 
 # community_resources/integrations.md
@@ -5977,6 +5977,28 @@ Use this playground to see how the result object properties change as you intera
 
 <AccessingResultSandpack />
 
+## `run`
+
+The `run` object contains metadata about the current suite execution.
+
+```js
+result.run.data; // { raw: ..., parsed: ... }
+result.run.time; // Date object
+result.run.focus; // { only: ..., skip: ..., onlyGroup: ..., skipGroup: ... }
+```
+
+### `run.focus`
+
+Provides insight into the exact modifiers that were used to focus the current run. This is either populated by calling `.focus(...)` or `.only(...)`/`.skip(...)`.
+
+```js
+suite.only('username').run().run.focus;
+// { only: ['username'] }
+
+suite.focus({ skipGroup: 'groupA' }).run().run.focus;
+// { skipGroup: ['groupA'] }
+```
+
 ## `isValid`
 
 `isValid` returns whether the validation suite as a whole or a single field is valid or not.
@@ -7127,12 +7149,12 @@ omitWhen(
 );
 ```
 
-:::caution IMPORTANT
-The code within omitWhen will always run, regardless of whether the condition is met or not. `omitWhen` only affects the validation result, but if you call a function within `omitWhen`, it will run regardless of the condition.
+:::info IMPORTANT
+The code within `omitWhen` will only run if the condition is not met. If the condition is truthy, `omitWhen` skip calling the callback altogether, and the tests within it will not be executed or registered.
 
 ```js
 omitWhen(true, () => {
-  console.log('This will always run');
+  console.log('This will NOT run');
 });
 ```
 
@@ -7763,7 +7785,7 @@ The suite result includes typed properties for accessing validated and parsed da
 - `result.types.input` — Carries the schema's input type for static analysis. At runtime, holds the parsed output value.
 - `result.types.output` — Carries the schema's output type. At runtime, holds the parsed output value.
 - `result.run.data.raw` — The current run data passed into the suite callback (parsed when schema validation succeeds; original input when it fails).
-- `result.run.data.parsed` — Cumulatively merged parsed data across focused runs.
+- `result.run.data.parsed` — Parsed data for the current run.
 
 ```typescript
 const schema = enforce.shape({


### PR DESCRIPTION
Adds `cacheSize` and `ttl` configuration options to `memo` API allowing fine-grained caching strategies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cache gains configurable max size, optional TTL-based expirations, and per-entry invalidation.
  * Memo accepts an optional options parameter to customize cacheSize and ttl.

* **Documentation**
  * Added advanced memo configuration docs, updated API reference and upgrade guide.
  * Clarified run metadata semantics and omitWhen behavior.

* **Tests**
  * Added tests for cache configuration, TTL behavior, eviction, and memo caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->