### PR TITLE
Omit undefined schema messages and preserve empty schema assertion messages

### DIFF
--- a/packages/vest/src/core/test/TestTypes.ts
+++ b/packages/vest/src/core/test/TestTypes.ts
@@ -8,6 +8,8 @@ export type TestFn = (payload: TestFnPayload) => TestResult;
 export type AsyncTest = Promise<void>;
 export type TestResult = Maybe<AsyncTest | boolean> | void;
 
+export type TestMessage = string | undefined;
+
 export type WithFieldName<F extends TFieldName = TFieldName> = {
   fieldName: F;
 };

--- a/packages/vest/src/core/test/test.ts
+++ b/packages/vest/src/core/test/test.ts
@@ -3,19 +3,19 @@ import { useEmit } from '../VestBus/VestBus';
 
 import { IsolateTest, TIsolateTest } from '../isolate/IsolateTest/IsolateTest';
 
-import { TestFn } from './TestTypes';
+import { TestFn, TestMessage } from './TestTypes';
 import { useAttemptRunTest } from './testLevelFlowControl/runTest';
 import { validateTestParams } from './validateTestParams';
 
 function vestTest(
   fieldName: string,
-  message: string | undefined,
+  message: TestMessage,
   cb: TestFn,
 ): TIsolateTest;
 function vestTest(fieldName: string, cb: TestFn): TIsolateTest;
 function vestTest(
   fieldName: string,
-  message: string | undefined,
+  message: TestMessage,
   cb: TestFn,
   key: IsolateKey,
 ): TIsolateTest;
@@ -24,9 +24,9 @@ function vestTest(fieldName: string, cb: TestFn, key: IsolateKey): TIsolateTest;
 function vestTest(
   fieldName: string,
   ...args:
-    | [message: string | undefined, cb: TestFn]
+    | [message: TestMessage, cb: TestFn]
     | [cb: TestFn]
-    | [message: string | undefined, cb: TestFn, key: IsolateKey]
+    | [message: TestMessage, cb: TestFn, key: IsolateKey]
     | [cb: TestFn, key: IsolateKey]
 ): TIsolateTest {
   const {

--- a/packages/vest/src/core/test/test.ts
+++ b/packages/vest/src/core/test/test.ts
@@ -7,11 +7,15 @@ import { TestFn } from './TestTypes';
 import { useAttemptRunTest } from './testLevelFlowControl/runTest';
 import { validateTestParams } from './validateTestParams';
 
-function vestTest(fieldName: string, message: string, cb: TestFn): TIsolateTest;
+function vestTest(
+  fieldName: string,
+  message: string | undefined,
+  cb: TestFn,
+): TIsolateTest;
 function vestTest(fieldName: string, cb: TestFn): TIsolateTest;
 function vestTest(
   fieldName: string,
-  message: string,
+  message: string | undefined,
   cb: TestFn,
   key: IsolateKey,
 ): TIsolateTest;
@@ -20,9 +24,9 @@ function vestTest(fieldName: string, cb: TestFn, key: IsolateKey): TIsolateTest;
 function vestTest(
   fieldName: string,
   ...args:
-    | [message: string, cb: TestFn]
+    | [message: string | undefined, cb: TestFn]
     | [cb: TestFn]
-    | [message: string, cb: TestFn, key: IsolateKey]
+    | [message: string | undefined, cb: TestFn, key: IsolateKey]
     | [cb: TestFn, key: IsolateKey]
 ): TIsolateTest {
   const {

--- a/packages/vest/src/core/test/validateTestParams.ts
+++ b/packages/vest/src/core/test/validateTestParams.ts
@@ -11,12 +11,12 @@ import { IsolateKey } from 'vestjs-runtime';
 import { ErrorStrings } from '../../errors/ErrorStrings';
 import { TFieldName } from '../../suiteResult/SuiteResultTypes';
 
-import { TestFn } from './TestTypes';
+import { TestFn, TestMessage } from './TestTypes';
 
 export type TestParams<F extends TFieldName = TFieldName> = {
   fieldName: F;
   key?: IsolateKey;
-  message?: string;
+  message?: TestMessage;
   testFn: TestFn;
 };
 
@@ -36,7 +36,7 @@ export function validateTestParams(
 
   const [message, testFn, key] = (
     isFunction(rest[1]) ? rest : [undefined, ...rest]
-  ) as [string | undefined, TestFn, IsolateKey | undefined];
+  ) as [TestMessage, TestFn, IsolateKey | undefined];
 
   if (!isFunction(testFn)) {
     return makeResult.Err(

--- a/packages/vest/src/suite/__tests__/getStandardSchema.test.ts
+++ b/packages/vest/src/suite/__tests__/getStandardSchema.test.ts
@@ -41,6 +41,19 @@ describe('getStandardSchema', () => {
       ]);
     });
 
+    it('Should keep issue message empty when no message exists', () => {
+      const errors = [{ fieldName: 'field1' }];
+      const runner = vi.fn().mockReturnValue({
+        hasErrors: () => true,
+        errors,
+      });
+      const schema = getStandardSchema(runner);
+
+      const result = schema.validate({});
+      // @ts-ignore
+      expect(result.issues).toEqual([{ path: ['field1'] }]);
+    });
+
     it('Should split nested field names', () => {
       const errors = [{ message: 'error1', fieldName: 'field1.nested' }];
       const runner = vi.fn().mockReturnValue({

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -141,6 +141,7 @@ describe('Schema Runtime Validation', () => {
       // Schema validation should create a test failure
       expect(result.hasErrors('count')).toBe(true);
       expect(result.isValid()).toBe(false);
+      expect(result.getMessage('count')).toBeUndefined();
     });
 
     it('should handle nested schema failures with custom messages', () => {
@@ -172,10 +173,24 @@ describe('Schema Runtime Validation', () => {
 
       const testSuite = create(() => {}, schemaWithMessage);
 
-      const result = testSuite.run({ price: 'free' });
+      const result = testSuite.run({ price: 'free' } as any);
 
       expect(result.hasErrors('price')).toBe(true);
       expect(result.getErrors('price')).toContain('Price must be a number');
+    });
+
+    it('should keep schema assertion messages empty when none are provided', () => {
+      const schemaWithoutMessage = enforce.shape({
+        price: enforce.isNumber(),
+      });
+
+      const testSuite = create(() => {}, schemaWithoutMessage);
+
+      const result = testSuite.run({ price: 'free' } as any);
+
+      expect(result.hasErrors('price')).toBe(true);
+      expect(result.getMessage('price')).toBeUndefined();
+      expect(result.getErrors('price')).toEqual([]);
     });
 
     it('should only validate focused schema fields with focus enabled', () => {

--- a/packages/vest/src/suite/getStandardSchema.ts
+++ b/packages/vest/src/suite/getStandardSchema.ts
@@ -14,7 +14,7 @@ export function getStandardSchema<S extends TSchema = undefined>(
       }
       return {
         issues: result.errors.map((error: any) => ({
-          message: error.message,
+          ...(error.message === undefined ? {} : { message: error.message }),
           path: error.fieldName ? error.fieldName.split('.') : undefined,
         })),
       };

--- a/packages/vest/src/suite/getTypedMethods.ts
+++ b/packages/vest/src/suite/getTypedMethods.ts
@@ -2,7 +2,7 @@ import { CB, DynamicValue } from 'vest-utils';
 import { TIsolate, IsolateKey } from 'vestjs-runtime';
 
 import { TIsolateTest } from '../core/isolate/IsolateTest/IsolateTest';
-import { TestFn } from '../core/test/TestTypes';
+import { TestFn, TestMessage } from '../core/test/TestTypes';
 import { test } from '../core/test/test';
 import { FieldExclusion, only, skip } from '../hooks/focused/focused';
 import { include } from '../hooks/include';
@@ -48,11 +48,11 @@ export type TTypedMethods<F extends TFieldName, G extends TGroupName> = {
   };
   skipWhen: (condition: TDraftCondition<F, G>, callback: CB) => void;
   test: {
-    (fieldName: F, message: string | undefined, cb: TestFn): TIsolateTest;
+    (fieldName: F, message: TestMessage, cb: TestFn): TIsolateTest;
     (fieldName: F, cb: TestFn): TIsolateTest;
     (
       fieldName: F,
-      message: string | undefined,
+      message: TestMessage,
       cb: TestFn,
       key: IsolateKey,
     ): TIsolateTest;

--- a/packages/vest/src/suite/getTypedMethods.ts
+++ b/packages/vest/src/suite/getTypedMethods.ts
@@ -48,9 +48,14 @@ export type TTypedMethods<F extends TFieldName, G extends TGroupName> = {
   };
   skipWhen: (condition: TDraftCondition<F, G>, callback: CB) => void;
   test: {
-    (fieldName: F, message: string, cb: TestFn): TIsolateTest;
+    (fieldName: F, message: string | undefined, cb: TestFn): TIsolateTest;
     (fieldName: F, cb: TestFn): TIsolateTest;
-    (fieldName: F, message: string, cb: TestFn, key: IsolateKey): TIsolateTest;
+    (
+      fieldName: F,
+      message: string | undefined,
+      cb: TestFn,
+      key: IsolateKey,
+    ): TIsolateTest;
     (fieldName: F, cb: TestFn, key: IsolateKey): TIsolateTest;
   };
   group: {

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -281,12 +281,12 @@ function runSchemaValidation<S extends TSchema = undefined>(
       }
 
       const fieldName = error.path?.length ? error.path.join('.') : '__root__';
-
-      test(
+      const testKey = `${fieldName}_${i}`;
+      (test as typeof test & ((...args: any[]) => void))(
         fieldName,
-        error.message ?? 'Validation failed',
+        error.message,
         () => false,
-        `${fieldName}_${i}`,
+        testKey,
       );
     }
   };

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -282,12 +282,7 @@ function runSchemaValidation<S extends TSchema = undefined>(
 
       const fieldName = error.path?.length ? error.path.join('.') : '__root__';
       const testKey = `${fieldName}_${i}`;
-      (test as typeof test & ((...args: any[]) => void))(
-        fieldName,
-        error.message,
-        () => false,
-        testKey,
-      );
+      test(fieldName, error.message, () => false, testKey);
     }
   };
 }


### PR DESCRIPTION
### Motivation

- Ensure schema validation issues do not emit an explicit `message` property when no message is provided by the assertion library.
- Surface the absence of schema assertion messages through the runtime so callers see `undefined` rather than an empty or defaulted string.

### Description

- Update `getStandardSchema` to only include `message` on issues when `error.message` is defined, omitting the property otherwise.
- Change `runSchemaValidation` to pass the original `error.message` (which may be `undefined`) and use a stable `testKey` id when emitting tests for schema failures.
- Add and adjust unit tests in `getStandardSchema.test.ts` and `schema.runtime.test.ts` to cover cases where schema errors lack messages and to reflect the new runtime behavior, including a couple of `as any` casts to satisfy TypeScript in tests.

### Testing

- Ran the updated unit tests for the suite package (`packages/vest/src/suite`), including `getStandardSchema.test.ts` and `schema.runtime.test.ts`, and the modified tests passed.
- Executed the package test command (`yarn test packages/vest`) locally and observed a successful test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc571985c483309ceb8a3015a348d9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schema validation now omits undefined messages and reports field issues consistently when no custom message is provided.

* **Tests**
  * Added and updated runtime tests to cover missing custom messages and the resulting validation behavior.

* **Chores**
  * Typing updated to allow an optional/undefined test message in test APIs, improving TypeScript ergonomics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->