### PR TITLE
fix(vest): map the suite data internally to the schema output type

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 tsconfig.json linguist-generated
+website/static/llms.txt linguist-generated
+website/static/llms-full.txt linguist-generated

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -9,6 +9,7 @@ import {
   TFieldName,
   TGroupName,
   InferSchemaData,
+  InferSchemaOutput,
   TSchema,
 } from '../suiteResult/SuiteResultTypes';
 import { SuiteSelectors } from '../suiteResult/selectors/suiteSelectors';
@@ -20,7 +21,7 @@ export type SuiteCallbackWithSchema<
   T extends CB,
 > = S extends undefined
   ? T
-  : (data: InferSchemaData<S>, ...args: any[]) => void;
+  : (data: InferSchemaOutput<S>, ...args: any[]) => void;
 
 export type Suite<
   F extends TFieldName,

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -5,7 +5,7 @@ import { useCreateVestState } from '../core/Runtime';
 import { useInitVestBus } from '../core/VestBus/VestBus';
 import { VestReconciler } from '../core/isolate/VestReconciler';
 import {
-  InferSchemaData,
+  InferSchemaOutput,
   TFieldName,
   TGroupName,
   TSchema,
@@ -48,14 +48,14 @@ function createSuite<
 // @vx-allow use-use
 function createSuite<
   S extends TSchema,
-  T extends (data: InferSchemaData<S>, ...args: any[]) => void = (
-    data: InferSchemaData<S>,
+  T extends (data: InferSchemaOutput<S>, ...args: any[]) => void = (
+    data: InferSchemaOutput<S>,
     ...args: any[]
   ) => void,
 >(
   suiteCallback: T,
   schema: S,
-): Suite<Extract<keyof InferSchemaData<S>, string>, TGroupName, T, S>;
+): Suite<Extract<keyof InferSchemaOutput<S>, string>, TGroupName, T, S>;
 // @vx-allow use-use
 function createSuite<
   F extends TFieldName = TFieldName,

--- a/website/docs/writing_tests/advanced_test_features/memo.md
+++ b/website/docs/writing_tests/advanced_test_features/memo.md
@@ -78,10 +78,10 @@ memo(
 
 ### Options
 
-| Option      | Type     | Default     | Description                                                                                                                                    |
-| :---------- | :------- | :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cacheSize` | `number` | `5`         | The maximum number of previous memo results to retain in the cache. When the limit is reached, the oldest result is evicted.                   |
-| `ttl`       | `number` | `undefined` | Time-to-Live in milliseconds. If the cached result is older than the `ttl`, the cache will be invalidated and the test blocked will be re-run. |
+| Option      | Type     | Default     | Description                                                                                                                                  |
+| :---------- | :------- | :---------- | :------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cacheSize` | `number` | `5`         | The maximum number of previous memo results to retain in the cache. When the limit is reached, the oldest result is evicted.                 |
+| `ttl`       | `number` | `undefined` | Time-to-Live in milliseconds. If the cached result is older than the `ttl`, the cache will be invalidated and the test block will be re-run. |
 
 ## How it works
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -124,9 +124,13 @@ Extends Vest's enforce with custom validation rules.
 
 - **Tip**: To add TypeScript support for your custom rules, see [TypeScript Support](./typescript_support.md#custom-enforce-rules).
 
-#### `memo(callback, deps)`
+#### `memo(callback, deps, options?)`
 
 Memoizes a block of tests.
+
+- `callback`: The function to execute if dependencies change.
+- `deps`: Array of dependencies determining if the callback executes.
+- `options` (Optional): Configuration object with `cacheSize` (max cached results) and `ttl` (Time-to-Live in ms).
 
 - [Read more about `memo`](./writing_tests/advanced_test_features/memo.md)
 
@@ -5533,6 +5537,32 @@ memo(() => {
   });
 }, [data.shipping_address]);
 ```
+
+## Advanced Configuration
+
+`memo` accepts an optional third parameter: an options object to further control caching behavior.
+
+```javascript
+memo(
+  () => {
+    test('username', 'Username is taken', async () => {
+      await checkAvailability(data.username);
+    });
+  },
+  [data.username],
+  {
+    cacheSize: 5, // Keep up to 5 previous results
+    ttl: 10000, // Invalidate cache after 10 seconds
+  },
+);
+```
+
+### Options
+
+| Option      | Type     | Default     | Description                                                                                                                                    |
+| :---------- | :------- | :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cacheSize` | `number` | `5`         | The maximum number of previous memo results to retain in the cache. When the limit is reached, the oldest result is evicted.                   |
+| `ttl`       | `number` | `undefined` | Time-to-Live in milliseconds. If the cached result is older than the `ttl`, the cache will be invalidated and the test blocked will be re-run. |
 
 ## How it works
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -5562,7 +5562,7 @@ memo(
 | Option      | Type     | Default     | Description                                                                                                                                    |
 | :---------- | :------- | :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cacheSize` | `number` | `5`         | The maximum number of previous memo results to retain in the cache. When the limit is reached, the oldest result is evicted.                   |
-| `ttl`       | `number` | `undefined` | Time-to-Live in milliseconds. If the cached result is older than the `ttl`, the cache will be invalidated and the test blocked will be re-run. |
+| `ttl`       | `number` | `undefined` | Time-to-Live in milliseconds. If the cached result is older than the `ttl`, the cache will be invalidated and the test block will be re-run. |
 
 ## How it works
 


### PR DESCRIPTION
Fixes the typings so the suite factory data input uses the schema output type, addressing type coercion like `toNumber()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added optional caching configuration to the memo API (new third parameter: options with cacheSize and ttl) and updated docs with examples and an advanced configuration table.
  * Minor formatting fixes to the memo options table.

* **Refactor**
  * Improved schema-driven callback typing to yield more accurate inferred data shapes in schema-aware suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->