### PR TITLE
feat(n4s): add enforce.record for dynamic object validation

### DIFF
--- a/benchmark-results.md
+++ b/benchmark-results.md
@@ -56,7 +56,7 @@
 | Deep Nesting Stress               | depth 10                           | **78.512**   | 35.3061  | 7.05%           | 0          | 0.00%    |
 | Deep Nesting Stress               | depth 50                           | **32.109**   | 38.3066  | 2.14%           | 0          | 0.00%    |
 | Deep Nesting Stress               | depth 100                          | **20.985**   | 52.4618  | 1.41%           | 0          | 0.00%    |
-| Complex Combinations & Edge Cases | High Frequency test Creation       | **191.36**   | 8.738    | 2.68%           | 0          | 0.00%    |
+| Complex Combinations & Edge Cases | High-Frequency Test Creation       | **191.36**   | 8.738    | 2.68%           | 0          | 0.00%    |
 | Conditional isolates              | skip even indices                  | **594.62**   | 3.2584   | 6.44%           | 0          | 0.00%    |
 | Conditional isolates              | omit multiples of 4                | **464.11**   | 5.8324   | 12.11%          | 0          | 0.00%    |
 | Field Volume Stress               | 10 fields                          | **354.74**   | 8.7396   | 4.90%           | 0          | 0.00%    |

--- a/benchmark-results.md
+++ b/benchmark-results.md
@@ -2,67 +2,67 @@
 
 | Suite                             | Benchmark                          | Ops/sec (Hz) | P99 (ms) | Margin of Error | Diff (Abs) | Diff (%) |
 | :-------------------------------- | :--------------------------------- | :----------- | :------- | :-------------- | :--------- | :------- |
-| Reconciler & History Diffing      | Reconciler (Stable List)           | **4.068**    | 272.59   | 3.39%           | 0          | 0.00%    |
-| Reconciler & History Diffing      | Reconciler (Full Invalidation)     | **4.246**    | 239.47   | 0.51%           | 0          | 0.00%    |
-| Reconciler & History Diffing      | Reconciler (Prepend Item)          | **4.214**    | 241.32   | 0.77%           | 0          | 0.00%    |
-| Reconciler & History Diffing      | Reconciler (Append Item)           | **4.249**    | 239.18   | 0.50%           | 0          | 0.00%    |
-| Reconciler & History Diffing      | Reconciler (Interleaved)           | **4.268**    | 235.23   | 0.20%           | 0          | 0.00%    |
-| Reconciler & History Diffing      | Isolate Reordering (Reverse)       | **4.228**    | 245.46   | 1.08%           | 0          | 0.00%    |
-| Reconciler & History Diffing      | Isolate Reordering (Shuffle)       | **4.249**    | 236.61   | 0.23%           | 0          | 0.00%    |
-| Reconciler & History Diffing      | Orphan GC Pressure                 | **8.272**    | 121.81   | 0.42%           | 0          | 0.00%    |
-| Result Selectors & Reporting      | hasErrors (Volume)                 | **884.51**   | 1.4245   | 1.04%           | 0          | 0.00%    |
-| Result Selectors & Reporting      | getErrors (Group Lookup)           | **419.83**   | 8.6045   | 9.11%           | 0          | 0.00%    |
-| Result Selectors & Reporting      | Summary Generation (Large)         | **3.682**    | 276.12   | 0.62%           | 0          | 0.00%    |
-| Async & Concurrency Stress        | Pending Storm (Memory)             | **4.171**    | 243.6    | 0.67%           | 0          | 0.00%    |
-| Async & Concurrency Stress        | Resolve Storm (Throughput)         | **4.164**    | 248.38   | 0.98%           | 0          | 0.00%    |
-| Async & Concurrency Stress        | Reject Storm                       | **4.148**    | 243.31   | 0.42%           | 0          | 0.00%    |
-| Async & Concurrency Stress        | Async Race                         | **170.75**   | 9.4561   | 3.09%           | 0          | 0.00%    |
-| Control Flow & Hooks Internals    | test.memo (Thrashing)              | **164.55**   | 7.4143   | 1.89%           | 0          | 0.00%    |
-| Control Flow & Hooks Internals    | test.memo (Stagnation)             | **626.68**   | 2.7831   | 1.59%           | 0          | 0.00%    |
-| Control Flow & Hooks Internals    | skipWhen (Active)                  | **8.815**    | 116.47   | 0.73%           | 0          | 0.00%    |
-| Control Flow & Hooks Internals    | only Starvation (Early)            | **7.394**    | 141.63   | 1.71%           | 0          | 0.00%    |
-| Control Flow & Hooks Internals    | only Starvation (Late)             | **7.436**    | 135.83   | 0.42%           | 0          | 0.00%    |
-| VestBus & Internals               | Bus Scaling                        | **199.86**   | 6.0699   | 1.92%           | 0          | 0.00%    |
-| VestBus & Internals               | State Refill                       | **127.15**   | 11.6232  | 2.95%           | 0          | 0.00%    |
-| Memory & Object Lifecycle         | Test Object Allocator              | **8.813**    | 114.86   | 0.38%           | 0          | 0.00%    |
-| Memory & Object Lifecycle         | Garbage Collection Friendly        | **8.832**    | 114.69   | 0.52%           | 0          | 0.00%    |
-| Serialization                     | Serialize (Large)                  | **143.65**   | 8.8777   | 2.99%           | 0          | 0.00%    |
-| Serialization                     | Deserialize (Large)                | **90.098**   | 14.8071  | 3.54%           | 0          | 0.00%    |
-| Edge Cases & Integration          | Broad Group                        | **4.144**    | 285.23   | 4.88%           | 0          | 0.00%    |
-| Edge Cases & Integration          | Namespace Collision                | **4.297**    | 233.63   | 0.15%           | 0          | 0.00%    |
-| Edge Cases & Integration          | Large Field Names                  | **196.8**    | 8.2963   | 2.22%           | 0          | 0.00%    |
-| Edge Cases & Integration          | Large Failure Messages             | **339.53**   | 5.6311   | 3.07%           | 0          | 0.00%    |
-| Complex Data Validation           | Enforce Huge String                | **362.67**   | 8.0814   | 6.63%           | 0          | 0.00%    |
-| State Management                  | Serialize Large                    | **305.56**   | 4.4331   | 1.71%           | 0          | 0.00%    |
-| Integration & Edge Cases          | Callback Overhead                  | **4.233**    | 239.31   | 0.53%           | 0          | 0.00%    |
-| Reordering & Reconciliation       | each (Reorder - Reverse)           | **107.18**   | 16.3319  | 5.83%           | 0          | 0.00%    |
-| Reordering & Reconciliation       | each (Reorder - Insert Middle)     | **101.83**   | 15.6118  | 5.02%           | 0          | 0.00%    |
-| Reordering & Reconciliation       | each (Reorder - Delete Middle)     | **111.43**   | 11.1566  | 3.64%           | 0          | 0.00%    |
-| Reordering & Reconciliation       | each (Key Thrashing)               | **267.34**   | 7.0798   | 5.22%           | 0          | 0.00%    |
-| State Mutation & Reset            | suite.remove() (Many Fields)       | **171.75**   | 6.7265   | 1.11%           | 0          | 0.00%    |
-| State Mutation & Reset            | suite.reset() (Memory Reclamation) | **8.802**    | 116.65   | 0.89%           | 0          | 0.00%    |
-| Concurrency & Events              | Bus Stress                         | **4.302**    | 236.24   | 0.47%           | 0          | 0.00%    |
-| Feature Coverage Matrix           | enforce matrix (small payload)     | **410.66**   | 5.7659   | 7.43%           | 0          | 0.00%    |
-| Feature Coverage Matrix           | enforce matrix (larger payload)    | **710.81**   | 6.859    | 9.00%           | 0          | 0.00%    |
-| Feature Coverage Matrix           | flow control eager mode            | **337.87**   | 7.5058   | 8.15%           | 0          | 0.00%    |
-| Feature Coverage Matrix           | flow control one mode              | **316.14**   | 8.2589   | 7.57%           | 0          | 0.00%    |
-| Core Test Functionality           | test (High Volume, Same Name)      | **4.395**    | 230.46   | 0.51%           | 0          | 0.00%    |
-| Core Test Functionality           | test (High Volume, Unique Names)   | **4.288**    | 252.89   | 2.18%           | 0          | 0.00%    |
-| Nested Fields with Hooks          | depth 3 with 40 fields per level   | **11.891**   | 95.1728  | 10.67%          | 0          | 0.00%    |
-| Nested Fields with Hooks          | depth 4 with 60 fields per level   | **6.338**    | 184.88   | 37.53%          | 0          | 0.00%    |
-| Nested Fields with Hooks          | depth 5 with 80 fields per level   | **6.396**    | 156.49   | 1.17%           | 0          | 0.00%    |
-| Complex Feature Mix               | full run with feature flags        | **141.37**   | 12.7091  | 8.29%           | 0          | 0.00%    |
-| Complex Feature Mix               | focused/conditional run            | **250.78**   | 8.9055   | 3.39%           | 0          | 0.00%    |
-| Deep Nesting Stress               | depth 10                           | **78.656**   | 35.4185  | 7.26%           | 0          | 0.00%    |
-| Deep Nesting Stress               | depth 50                           | **32.199**   | 36.2827  | 1.80%           | 0          | 0.00%    |
-| Deep Nesting Stress               | depth 100                          | **20.332**   | 52.6112  | 1.20%           | 0          | 0.00%    |
-| Complex Combinations & Edge Cases | High Frequency test Creation       | **187.52**   | 9.8282   | 3.37%           | 0          | 0.00%    |
-| Conditional isolates              | skip even indices                  | **604.64**   | 3.4422   | 7.22%           | 0          | 0.00%    |
-| Conditional isolates              | omit multiples of 4                | **456.27**   | 5.7962   | 12.24%          | 0          | 0.00%    |
-| Field Volume Stress               | 10 fields                          | **349.94**   | 9.3032   | 7.74%           | 0          | 0.00%    |
-| Field Volume Stress               | 500 fields                         | **4.914**    | 207.75   | 0.57%           | 0          | 0.00%    |
-| Field Volume Stress               | 1000 fields                        | **2.15**     | 468.69   | 0.34%           | 0          | 0.00%    |
-| Dynamic each and groups           | longer list                        | **205.42**   | 13.4141  | 22.00%          | 0          | 0.00%    |
+| Reconciler & History Diffing      | Reconciler (Stable List)           | **4.167**    | 262.69   | 2.95%           | 0          | 0.00%    |
+| Reconciler & History Diffing      | Reconciler (Full Invalidation)     | **4.314**    | 236.97   | 0.65%           | 0          | 0.00%    |
+| Reconciler & History Diffing      | Reconciler (Prepend Item)          | **4.33**     | 236.02   | 0.89%           | 0          | 0.00%    |
+| Reconciler & History Diffing      | Reconciler (Append Item)           | **4.308**    | 251.36   | 2.28%           | 0          | 0.00%    |
+| Reconciler & History Diffing      | Reconciler (Interleaved)           | **4.319**    | 236.77   | 0.67%           | 0          | 0.00%    |
+| Reconciler & History Diffing      | Isolate Reordering (Reverse)       | **4.33**     | 233.22   | 0.29%           | 0          | 0.00%    |
+| Reconciler & History Diffing      | Isolate Reordering (Shuffle)       | **4.296**    | 244.1    | 1.36%           | 0          | 0.00%    |
+| Reconciler & History Diffing      | Orphan GC Pressure                 | **8.414**    | 122.04   | 0.93%           | 0          | 0.00%    |
+| Result Selectors & Reporting      | hasErrors (Volume)                 | **912.72**   | 1.3673   | 0.53%           | 0          | 0.00%    |
+| Result Selectors & Reporting      | getErrors (Group Lookup)           | **467.09**   | 2.319    | 0.31%           | 0          | 0.00%    |
+| Result Selectors & Reporting      | Summary Generation (Large)         | **3.762**    | 272.05   | 1.18%           | 0          | 0.00%    |
+| Async & Concurrency Stress        | Pending Storm (Memory)             | **4.113**    | 267.62   | 2.63%           | 0          | 0.00%    |
+| Async & Concurrency Stress        | Resolve Storm (Throughput)         | **4.222**    | 244.89   | 0.99%           | 0          | 0.00%    |
+| Async & Concurrency Stress        | Reject Storm                       | **4.195**    | 240.59   | 0.42%           | 0          | 0.00%    |
+| Async & Concurrency Stress        | Async Race                         | **171.68**   | 7.6339   | 2.57%           | 0          | 0.00%    |
+| Control Flow & Hooks Internals    | test.memo (Thrashing)              | **165.71**   | 7.5406   | 2.00%           | 0          | 0.00%    |
+| Control Flow & Hooks Internals    | test.memo (Stagnation)             | **643.08**   | 2.6113   | 1.32%           | 0          | 0.00%    |
+| Control Flow & Hooks Internals    | skipWhen (Active)                  | **9.008**    | 112.91   | 0.82%           | 0          | 0.00%    |
+| Control Flow & Hooks Internals    | only Starvation (Early)            | **7.528**    | 135.21   | 0.81%           | 0          | 0.00%    |
+| Control Flow & Hooks Internals    | only Starvation (Late)             | **7.587**    | 132.57   | 0.21%           | 0          | 0.00%    |
+| VestBus & Internals               | Bus Scaling                        | **201.75**   | 5.991    | 1.71%           | 0          | 0.00%    |
+| VestBus & Internals               | State Refill                       | **125.64**   | 11.8961  | 3.26%           | 0          | 0.00%    |
+| Memory & Object Lifecycle         | Test Object Allocator              | **8.852**    | 119.05   | 1.39%           | 0          | 0.00%    |
+| Memory & Object Lifecycle         | Garbage Collection Friendly        | **8.894**    | 117.23   | 1.17%           | 0          | 0.00%    |
+| Serialization                     | Serialize (Large)                  | **132.74**   | 10.9731  | 3.64%           | 0          | 0.00%    |
+| Serialization                     | Deserialize (Large)                | **92.902**   | 12.9363  | 2.43%           | 0          | 0.00%    |
+| Edge Cases & Integration          | Broad Group                        | **4.314**    | 247.4    | 1.75%           | 0          | 0.00%    |
+| Edge Cases & Integration          | Namespace Collision                | **4.381**    | 230.84   | 0.47%           | 0          | 0.00%    |
+| Edge Cases & Integration          | Large Field Names                  | **203.94**   | 6.0184   | 1.89%           | 0          | 0.00%    |
+| Edge Cases & Integration          | Large Failure Messages             | **356.79**   | 5.3432   | 3.27%           | 0          | 0.00%    |
+| Complex Data Validation           | Enforce Huge String                | **344**      | 8.393    | 5.96%           | 0          | 0.00%    |
+| State Management                  | Serialize Large                    | **291.74**   | 4.5542   | 1.81%           | 0          | 0.00%    |
+| Integration & Edge Cases          | Callback Overhead                  | **4.196**    | 239.55   | 0.20%           | 0          | 0.00%    |
+| Reordering & Reconciliation       | each (Reorder - Reverse)           | **109.77**   | 15.2962  | 5.69%           | 0          | 0.00%    |
+| Reordering & Reconciliation       | each (Reorder - Insert Middle)     | **103.23**   | 17.7105  | 4.98%           | 0          | 0.00%    |
+| Reordering & Reconciliation       | each (Reorder - Delete Middle)     | **114.16**   | 11.6653  | 2.95%           | 0          | 0.00%    |
+| Reordering & Reconciliation       | each (Key Thrashing)               | **282.98**   | 6.0428   | 4.10%           | 0          | 0.00%    |
+| State Mutation & Reset            | suite.remove() (Many Fields)       | **175.53**   | 6.6092   | 1.04%           | 0          | 0.00%    |
+| State Mutation & Reset            | suite.reset() (Memory Reclamation) | **9.131**    | 110.16   | 0.34%           | 0          | 0.00%    |
+| Concurrency & Events              | Bus Stress                         | **4.519**    | 223.91   | 0.76%           | 0          | 0.00%    |
+| Feature Coverage Matrix           | enforce matrix (small payload)     | **408.77**   | 5.4601   | 6.81%           | 0          | 0.00%    |
+| Feature Coverage Matrix           | enforce matrix (larger payload)    | **641.55**   | 8.8655   | 11.19%          | 0          | 0.00%    |
+| Feature Coverage Matrix           | flow control eager mode            | **342.03**   | 7.0127   | 7.30%           | 0          | 0.00%    |
+| Feature Coverage Matrix           | flow control one mode              | **305.57**   | 8.2793   | 6.99%           | 0          | 0.00%    |
+| Core Test Functionality           | test (High Volume, Same Name)      | **4.353**    | 233.58   | 0.67%           | 0          | 0.00%    |
+| Core Test Functionality           | test (High Volume, Unique Names)   | **4.205**    | 255.76   | 1.94%           | 0          | 0.00%    |
+| Nested Fields with Hooks          | depth 3 with 40 fields per level   | **11.992**   | 93.6752  | 10.15%          | 0          | 0.00%    |
+| Nested Fields with Hooks          | depth 4 with 60 fields per level   | **6.369**    | 180.58   | 32.42%          | 0          | 0.00%    |
+| Nested Fields with Hooks          | depth 5 with 80 fields per level   | **6.254**    | 161.94   | 16.12%          | 0          | 0.00%    |
+| Complex Feature Mix               | full run with feature flags        | **135.67**   | 12.2272  | 7.84%           | 0          | 0.00%    |
+| Complex Feature Mix               | focused/conditional run            | **234.4**    | 7.7559   | 2.69%           | 0          | 0.00%    |
+| Deep Nesting Stress               | depth 10                           | **78.512**   | 35.3061  | 7.05%           | 0          | 0.00%    |
+| Deep Nesting Stress               | depth 50                           | **32.109**   | 38.3066  | 2.14%           | 0          | 0.00%    |
+| Deep Nesting Stress               | depth 100                          | **20.985**   | 52.4618  | 1.41%           | 0          | 0.00%    |
+| Complex Combinations & Edge Cases | High Frequency test Creation       | **191.36**   | 8.738    | 2.68%           | 0          | 0.00%    |
+| Conditional isolates              | skip even indices                  | **594.62**   | 3.2584   | 6.44%           | 0          | 0.00%    |
+| Conditional isolates              | omit multiples of 4                | **464.11**   | 5.8324   | 12.11%          | 0          | 0.00%    |
+| Field Volume Stress               | 10 fields                          | **354.74**   | 8.7396   | 4.90%           | 0          | 0.00%    |
+| Field Volume Stress               | 500 fields                         | **4.915**    | 209.45   | 0.87%           | 0          | 0.00%    |
+| Field Volume Stress               | 1000 fields                        | **2.158**    | 465.96   | 0.24%           | 0          | 0.00%    |
+| Dynamic each and groups           | longer list                        | **221.46**   | 12.869   | 22.56%          | 0          | 0.00%    |
 
 <details>
 <summary>Raw Output</summary>

--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -62,6 +62,13 @@ const schemaEvaluators = adaptDynamicRules<
   loose: schemaRules.loose,
 });
 
+const recordEvaluators = adaptDynamicRules<
+  RuleInstance<any, [any]>,
+  Pick<typeof schemaRules, 'record'>
+>({
+  record: schemaRules.record,
+});
+
 /**
  * Wraps a lazy schema evaluator so the resulting RuleInstance carries
  * a `__schema` reference to the original schema definition.
@@ -86,6 +93,7 @@ const schemaRulesWithArrayChaining = {
       return RuleRunReturn.create(result, value);
     }),
   loose: schemaAttacher(schemaEvaluators.loose),
+  record: recordEvaluators.record,
   shape: schemaAttacher(schemaEvaluators.shape),
 };
 

--- a/packages/n4s/src/rules/schemaRules/__tests__/record.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/record.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+
+import { enforce } from '../../../n4s';
+
+describe('enforce.record()', () => {
+  describe('lazy', () => {
+    it('should return a rule instance', () => {
+      const rule = enforce.record(enforce.isNumber());
+      expect(rule).toHaveProperty('run');
+      expect(rule).toHaveProperty('infer');
+    });
+
+    describe('value-only validation', () => {
+      it('passes when all values match rule', () => {
+        const rule = enforce.record(enforce.isNumber());
+        expect(rule.run({ a: 1, b: 2, c: 3 }).pass).toBe(true);
+      });
+
+      it('fails when any value does not match', () => {
+        const rule = enforce.record(enforce.isNumber());
+        expect(rule.run({ a: 1, b: 'two', c: 3 } as any).pass).toBe(false);
+      });
+
+      it('passes for empty objects', () => {
+        const rule = enforce.record(enforce.isNumber());
+        expect(rule.run({}).pass).toBe(true);
+      });
+
+      it('fails for non-object values', () => {
+        const rule = enforce.record(enforce.isNumber());
+        expect(rule.run('not an object' as any).pass).toBe(false);
+      });
+
+      it('fails for arrays', () => {
+        const rule = enforce.record(enforce.isNumber());
+        expect(rule.run([1, 2, 3] as any).pass).toBe(false);
+      });
+
+      it('skips prototype keys', () => {
+        const obj = Object.create({ inherited: 'bad' });
+        obj.own = 42;
+        const rule = enforce.record(enforce.isNumber());
+        expect(rule.run(obj).pass).toBe(true);
+      });
+
+      it('fails on prototype pollution keys', () => {
+        const rule = enforce.record(enforce.isNumber());
+        const polluter = JSON.parse('{"__proto__": {"malicious": true}}');
+        const res = rule.run(polluter);
+        expect(res.pass).toBe(false);
+        expect(res.path).toEqual(['__proto__']);
+      });
+    });
+
+    describe('key + value validation', () => {
+      it('validates both keys and values', () => {
+        const rule = enforce.record(
+          enforce.isString().matches(/^[a-z]+$/),
+          enforce.isNumber(),
+        );
+        expect(rule.run({ abc: 1, def: 2 }).pass).toBe(true);
+      });
+
+      it('fails when key does not match', () => {
+        const rule = enforce.record(
+          enforce.isString().matches(/^[a-z]+$/),
+          enforce.isNumber(),
+        );
+        const res = rule.run({ INVALID: 1 });
+        expect(res.pass).toBe(false);
+        expect(res.path).toEqual(['INVALID']);
+      });
+
+      it('fails when value does not match', () => {
+        const rule = enforce.record(
+          enforce.isString().matches(/^[a-z]+$/),
+          enforce.isNumber(),
+        );
+        const res = rule.run({ valid: 'text' } as any);
+        expect(res.pass).toBe(false);
+        expect(res.path).toEqual(['valid']);
+      });
+    });
+
+    describe('nested schemas', () => {
+      it('validates nested shapes as values', () => {
+        const rule = enforce.record(
+          enforce.shape({
+            name: enforce.isString(),
+            age: enforce.isNumber(),
+          }),
+        );
+
+        expect(
+          rule.run({
+            user1: { name: 'Alice', age: 30 },
+            user2: { name: 'Bob', age: 25 },
+          }).pass,
+        ).toBe(true);
+
+        const failing = rule.run({
+          user1: { name: 'Alice', age: 30 },
+          user2: { name: 'Bob', age: '25' },
+        } as any);
+
+        expect(failing.pass).toBe(false);
+        expect(failing.path).toEqual(['user2', 'age']);
+      });
+
+      it('validates nested records', () => {
+        const rule = enforce.record(enforce.record(enforce.isBoolean()));
+
+        expect(
+          rule.run({
+            group1: { a: true, b: false },
+            group2: { c: true },
+          }).pass,
+        ).toBe(true);
+      });
+    });
+
+    describe('lazy chain type tests', () => {
+      it('works with .test()', () => {
+        const rule = enforce.record(enforce.isString());
+        expect(rule.test({ a: 'hello' })).toBe(true);
+      });
+
+      it('chains with message() correctly', () => {
+        const rule = enforce.record(enforce.isNumber().message('custom error'));
+        const result = rule.run({ a: 1, b: 'err' });
+        expect(result.pass).toBe(false);
+        expect(result.message).toEqual('custom error');
+      });
+    });
+  });
+
+  describe('eager', () => {
+    describe('value-only validation', () => {
+      it('passes when all values match rule', () => {
+        expect(() => {
+          enforce({ a: 1, b: 2, c: 3 }).record(enforce.isNumber());
+        }).not.toThrow();
+      });
+
+      it('fails when any value does not match', () => {
+        expect(() => {
+          enforce({ a: 1, b: 'two', c: 3 }).record(enforce.isNumber());
+        }).toThrow();
+      });
+
+      it('passes for empty objects', () => {
+        expect(() => {
+          enforce({}).record(enforce.isNumber());
+        }).not.toThrow();
+      });
+
+      it('fails for non-object values', () => {
+        expect(() => {
+          (enforce('not an object') as any).record(enforce.isNumber());
+        }).toThrow();
+      });
+
+      it('fails for arrays', () => {
+        expect(() => {
+          (enforce([1, 2, 3]) as any).record(enforce.isNumber());
+        }).toThrow();
+      });
+
+      it('skips prototype keys', () => {
+        const obj = Object.create({ inherited: 'bad' });
+        obj.own = 42;
+        expect(() => {
+          enforce(obj).record(enforce.isNumber());
+        }).not.toThrow();
+      });
+    });
+
+    describe('key + value validation', () => {
+      it('validates both keys and values', () => {
+        expect(() => {
+          enforce({ abc: 1, def: 2 }).record(
+            enforce.isString().matches(/^[a-z]+$/),
+            enforce.isNumber(),
+          );
+        }).not.toThrow();
+      });
+
+      it('fails when key does not match', () => {
+        expect(() => {
+          enforce({ INVALID: 1 }).record(
+            enforce.isString().matches(/^[a-z]+$/),
+            enforce.isNumber(),
+          );
+        }).toThrow();
+      });
+    });
+  });
+});

--- a/packages/n4s/src/rules/schemaRules/__tests__/record.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/record.test.ts
@@ -18,7 +18,8 @@ describe('enforce.record()', () => {
 
       it('fails when any value does not match', () => {
         const rule = enforce.record(enforce.isNumber());
-        expect(rule.run({ a: 1, b: 'two', c: 3 } as any).pass).toBe(false);
+        // @ts-expect-error - testing runtime with invalid value type
+        expect(rule.run({ a: 1, b: 'two', c: 3 }).pass).toBe(false);
       });
 
       it('passes for empty objects', () => {
@@ -28,12 +29,14 @@ describe('enforce.record()', () => {
 
       it('fails for non-object values', () => {
         const rule = enforce.record(enforce.isNumber());
-        expect(rule.run('not an object' as any).pass).toBe(false);
+        // @ts-expect-error - testing runtime with non-object
+        expect(rule.run('not an object').pass).toBe(false);
       });
 
       it('fails for arrays', () => {
         const rule = enforce.record(enforce.isNumber());
-        expect(rule.run([1, 2, 3] as any).pass).toBe(false);
+        // @ts-expect-error - testing runtime with array
+        expect(rule.run([1, 2, 3]).pass).toBe(false);
       });
 
       it('skips prototype keys', () => {
@@ -76,7 +79,8 @@ describe('enforce.record()', () => {
           enforce.isString().matches(/^[a-z]+$/),
           enforce.isNumber(),
         );
-        const res = rule.run({ valid: 'text' } as any);
+        // @ts-expect-error - testing runtime with invalid value type
+        const res = rule.run({ valid: 'text' });
         expect(res.pass).toBe(false);
         expect(res.path).toEqual(['valid']);
       });
@@ -100,8 +104,9 @@ describe('enforce.record()', () => {
 
         const failing = rule.run({
           user1: { name: 'Alice', age: 30 },
+          // @ts-expect-error - testing runtime with invalid nested value
           user2: { name: 'Bob', age: '25' },
-        } as any);
+        });
 
         expect(failing.pass).toBe(false);
         expect(failing.path).toEqual(['user2', 'age']);
@@ -156,13 +161,15 @@ describe('enforce.record()', () => {
 
       it('fails for non-object values', () => {
         expect(() => {
-          (enforce('not an object') as any).record(enforce.isNumber());
+          // @ts-expect-error - testing runtime with non-object
+          enforce('not an object').record(enforce.isNumber());
         }).toThrow();
       });
 
       it('fails for arrays', () => {
         expect(() => {
-          (enforce([1, 2, 3]) as any).record(enforce.isNumber());
+          // @ts-expect-error - testing runtime with array
+          enforce([1, 2, 3]).record(enforce.isNumber());
         }).toThrow();
       });
 

--- a/packages/n4s/src/rules/schemaRules/record.ts
+++ b/packages/n4s/src/rules/schemaRules/record.ts
@@ -57,6 +57,13 @@ function parseRules(arg1: any, arg2?: any) {
   return { keyRule: undefined, valueRule: arg1 };
 }
 
+function validateKey(
+  key: string,
+  keyRule: RuleInstance<any, any>,
+): RuleRunReturn<any> {
+  return ctx.run({ value: key, set: true }, () => keyRule.run(key));
+}
+
 function evaluateRecordEntry<T extends Record<string, any>>(
   key: string,
   value: T,
@@ -66,26 +73,21 @@ function evaluateRecordEntry<T extends Record<string, any>>(
   },
   parsedValue: Record<string, any>,
 ): RuleRunReturn<T> | void {
-  let parsedKey = key;
   if (rules.keyRule) {
-    const keyRes = ctx.run({ value: key, set: true }, () =>
-      rules.keyRule!.run(key),
-    );
+    const keyRes = validateKey(key, rules.keyRule);
     if (!keyRes.pass) return createRecordFailure(value, key, keyRes);
-    parsedKey = keyRes.type;
+    if (keyRes.type !== key) {
+      delete parsedValue[key];
+      key = keyRes.type;
+    }
   }
 
-  const fieldValue = value[key];
-  const valRes = ctx.run({ value: fieldValue, set: true, meta: { key } }, () =>
-    rules.valueRule.run(fieldValue),
+  const valRes = ctx.run({ value: value[key], set: true, meta: { key } }, () =>
+    rules.valueRule.run(value[key]),
   );
 
   if (!valRes.pass) return createRecordFailure(value, key, valRes);
-
-  parsedValue[parsedKey] = valRes.type;
-  if (parsedKey !== key) {
-    delete parsedValue[key];
-  }
+  parsedValue[key] = valRes.type;
 }
 
 function createRecordFailure<T extends Record<string, any>>(

--- a/packages/n4s/src/rules/schemaRules/record.ts
+++ b/packages/n4s/src/rules/schemaRules/record.ts
@@ -99,26 +99,26 @@ function createRecordFailure<T extends Record<string, any>>(
   return newRes as RuleRunReturn<T>;
 }
 
+type RecordKey<K> = [K] extends [never]
+  ? string
+  : K extends RuleInstance<any, any>
+    ? K['infer'] extends PropertyKey
+      ? K['infer']
+      : string
+    : string;
+
+type RecordInputKey<K> = [K] extends [never]
+  ? string
+  : K extends RuleInstance<any, any>
+    ? InferShapeInput<K> extends PropertyKey
+      ? InferShapeInput<K>
+      : string
+    : string;
+
 export type RecordRuleInstance<
   K extends RuleInstance<any, any> | never,
   V extends RuleInstance<any, any>,
 > = RuleInstance<
-  Record<
-    K extends RuleInstance<any, any>
-      ? K['infer'] extends PropertyKey
-        ? K['infer']
-        : string
-      : string,
-    V['infer']
-  >,
-  [
-    Record<
-      K extends RuleInstance<any, any>
-        ? InferShapeInput<K> extends PropertyKey
-          ? InferShapeInput<K>
-          : string
-        : string,
-      InferShapeInput<V>
-    >,
-  ]
+  Record<RecordKey<K>, V['infer']>,
+  [Record<RecordInputKey<K>, InferShapeInput<V>>]
 >;

--- a/packages/n4s/src/rules/schemaRules/record.ts
+++ b/packages/n4s/src/rules/schemaRules/record.ts
@@ -66,11 +66,13 @@ function evaluateRecordEntry<T extends Record<string, any>>(
   },
   parsedValue: Record<string, any>,
 ): RuleRunReturn<T> | void {
+  let parsedKey = key;
   if (rules.keyRule) {
     const keyRes = ctx.run({ value: key, set: true }, () =>
       rules.keyRule!.run(key),
     );
     if (!keyRes.pass) return createRecordFailure(value, key, keyRes);
+    parsedKey = keyRes.type;
   }
 
   const fieldValue = value[key];
@@ -80,7 +82,10 @@ function evaluateRecordEntry<T extends Record<string, any>>(
 
   if (!valRes.pass) return createRecordFailure(value, key, valRes);
 
-  parsedValue[key] = valRes.type;
+  parsedValue[parsedKey] = valRes.type;
+  if (parsedKey !== key) {
+    delete parsedValue[key];
+  }
 }
 
 function createRecordFailure<T extends Record<string, any>>(
@@ -95,9 +100,25 @@ function createRecordFailure<T extends Record<string, any>>(
 }
 
 export type RecordRuleInstance<
-  _K,
+  K extends RuleInstance<any, any> | never,
   V extends RuleInstance<any, any>,
 > = RuleInstance<
-  Record<string, V['infer']>,
-  [Record<string, InferShapeInput<V>>]
+  Record<
+    K extends RuleInstance<any, any>
+      ? K['infer'] extends PropertyKey
+        ? K['infer']
+        : string
+      : string,
+    V['infer']
+  >,
+  [
+    Record<
+      K extends RuleInstance<any, any>
+        ? InferShapeInput<K> extends PropertyKey
+          ? InferShapeInput<K>
+          : string
+        : string,
+      InferShapeInput<V>
+    >,
+  ]
 >;

--- a/packages/n4s/src/rules/schemaRules/record.ts
+++ b/packages/n4s/src/rules/schemaRules/record.ts
@@ -1,0 +1,103 @@
+import { isObject, mapFirst } from 'vest-utils';
+
+import { ctx } from '../../enforceContext';
+import type { RuleInstance } from '../../utils/RuleInstance';
+import { RuleRunReturn } from '../../utils/RuleRunReturn';
+
+import {
+  findDangerousOwnKey,
+  ownKeys,
+  safeShallowCopy,
+} from './schemaObjectUtils';
+import type { InferShapeInput } from './schemaRulesTypes';
+
+/**
+ * Validates that an object's dynamic keys and/or values match provided rules.
+ * Like TypeScript's Record<K, V>, it checks elements against shape rules.
+ *
+ * @param value - The object to validate
+ * @param arg1 - Either the key rule (if arg2 is present) or the value rule
+ * @param arg2 - The value rule (if arg1 is the key rule)
+ * @returns RuleRunReturn indicating success or failure
+ */
+export function record<T extends Record<string, any>>(
+  value: T,
+  arg1: any,
+  arg2?: any,
+): RuleRunReturn<T> {
+  if (!isObject(value) || Array.isArray(value))
+    return RuleRunReturn.Failing(value);
+
+  const rules = parseRules(arg1, arg2);
+  const dangerousKey = findDangerousOwnKey(value);
+  if (dangerousKey)
+    return createRecordFailure(
+      value,
+      dangerousKey,
+      RuleRunReturn.Failing(value),
+    );
+
+  const parsedValue: Record<string, any> = safeShallowCopy(value);
+
+  const failingResult = mapFirst(ownKeys(value), (key, breakout) => {
+    const errorRes = evaluateRecordEntry(key, value, rules, parsedValue);
+    if (errorRes) {
+      breakout(true, errorRes);
+    }
+  });
+
+  return (
+    (failingResult as RuleRunReturn<T>) ||
+    RuleRunReturn.Passing(parsedValue as T)
+  );
+}
+
+function parseRules(arg1: any, arg2?: any) {
+  if (arg2 !== undefined) return { keyRule: arg1, valueRule: arg2 };
+  return { keyRule: undefined, valueRule: arg1 };
+}
+
+function evaluateRecordEntry<T extends Record<string, any>>(
+  key: string,
+  value: T,
+  rules: {
+    keyRule?: RuleInstance<any, any>;
+    valueRule: RuleInstance<any, any>;
+  },
+  parsedValue: Record<string, any>,
+): RuleRunReturn<T> | void {
+  if (rules.keyRule) {
+    const keyRes = ctx.run({ value: key, set: true }, () =>
+      rules.keyRule!.run(key),
+    );
+    if (!keyRes.pass) return createRecordFailure(value, key, keyRes);
+  }
+
+  const fieldValue = value[key];
+  const valRes = ctx.run({ value: fieldValue, set: true, meta: { key } }, () =>
+    rules.valueRule.run(fieldValue),
+  );
+
+  if (!valRes.pass) return createRecordFailure(value, key, valRes);
+
+  parsedValue[key] = valRes.type;
+}
+
+function createRecordFailure<T extends Record<string, any>>(
+  value: T,
+  key: string,
+  ruleRes: RuleRunReturn<any>,
+): RuleRunReturn<T> {
+  const currentPath = ruleRes.path || [];
+  const newRes = RuleRunReturn.Failing(value, ruleRes.message);
+  newRes.path = [key, ...currentPath];
+  return newRes as RuleRunReturn<T>;
+}
+
+export type RecordRuleInstance<
+  _K,
+  V extends RuleInstance<any, any>,
+> = RuleInstance<
+  Record<string, V['infer']>,
+  [Record<string, InferShapeInput<V>>]
+>;

--- a/packages/n4s/src/rules/schemaRules/schemaRules.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRules.ts
@@ -7,4 +7,5 @@ export { partial, type PartialRuleInstance } from './partial';
 export { pick, type PickRuleInstance } from './pick';
 export { omit, type OmitRuleInstance } from './omit';
 export { shape, type ShapeRuleInstance } from './shape';
+export { record, type RecordRuleInstance } from './record';
 export type { SchemaRuleLazyTypes } from './schemaRulesLazyTypes';

--- a/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
@@ -8,6 +8,7 @@ import './partial';
 import './pick';
 import './omit';
 import './shape';
+import './record';
 
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { MultiTypeInput, MultiTypeInputArgs } from './schemaRulesTypes';
@@ -20,6 +21,7 @@ import type {
   PickRuleInstance,
   OmitRuleInstance,
   ShapeRuleInstance,
+  RecordRuleInstance,
 } from './schemaRules';
 
 /**
@@ -49,4 +51,13 @@ export type SchemaRuleLazyTypes = {
   shape: <S extends Record<string, RuleInstance<any>>>(
     schema: S,
   ) => ShapeRuleInstance<S>;
+  record: {
+    <V extends RuleInstance<any, any>>(
+      valueRule: V,
+    ): RecordRuleInstance<never, V>;
+    <K extends RuleInstance<string, any>, V extends RuleInstance<any, any>>(
+      keyRule: K,
+      valueRule: V,
+    ): RecordRuleInstance<K, V>;
+  };
 };

--- a/packages/vest/src/suite/__tests__/recordValidation.test.ts
+++ b/packages/vest/src/suite/__tests__/recordValidation.test.ts
@@ -1,0 +1,109 @@
+import { enforce } from 'n4s';
+import { describe, it, expect } from 'vitest';
+
+import { create, test } from '../../vest';
+
+describe('enforce.record() in Vest', () => {
+  it('validates record fields correctly in schema', () => {
+    const schema = enforce.shape({
+      name: enforce.isString(),
+      settings: enforce.record(enforce.isBoolean()),
+    });
+
+    const suite = create(data => {
+      test('name', () => {
+        enforce(data.name).isNotEmpty();
+      });
+    }, schema);
+
+    const result = suite.run({
+      name: 'Alice',
+      // @ts-expect-error - Invalid data: not all booleans
+      settings: { darkMode: true, notifications: 'yes' },
+    });
+
+    expect(result.isValid()).toBe(false);
+    expect(result.hasErrors('settings.notifications' as any)).toBe(true);
+  });
+
+  it('works with focus modifiers when dropping entirely via focus', () => {
+    const schema = enforce.shape({
+      name: enforce.isString(),
+      permissions: enforce.record(enforce.isBoolean()),
+    });
+
+    const suite = create(_data => {
+      test('name', () => {});
+    }, schema);
+
+    const result = suite
+      .focus({ only: 'name' })
+      .run({ name: '', permissions: { bad: 'value' } } as any);
+
+    // permissions.bad should not be validated because we focused on name
+    expect(result.hasErrors('permissions.bad' as any)).toBe(false);
+    expect(result.isValid()).toBe(true);
+  });
+
+  it('propagates nested error paths to the result', () => {
+    const schema = enforce.record(
+      enforce.shape({
+        active: enforce.isBoolean(),
+      }),
+    );
+
+    const suite = create(data => {
+      test('admin', () => {
+        enforce(data.admin).isTruthy();
+      });
+    }, schema);
+
+    const result = suite.run({
+      admin: { active: true },
+      editor: { active: 'yes' }, // invalid
+    } as any);
+
+    // The top-level key is 'editor', meaning 'editor.active' should have a schema validation error.
+    expect(result.hasErrors('editor.active' as any)).toBe(true);
+  });
+
+  it('maintains parsed coerced types using .test() inside suite', () => {
+    const schema = enforce.record(enforce.isNumeric().toNumber());
+
+    const suite = create(data => {
+      test('admin', () => {
+        enforce(data.admin).isNumber();
+      });
+    }, schema);
+
+    const result = suite.run({ admin: '42' });
+
+    // Ensure the record values were actually coerced
+    expect(result.isValid()).toBe(true);
+    expect(result.value).toEqual({ admin: 42 });
+    expect(typeof result.value?.admin).toBe('number');
+  });
+
+  it('works with key + value validation inside suite', () => {
+    const schema = enforce.record(
+      enforce.isString().matches(/^user_.+$/),
+      enforce.isBoolean(),
+    );
+
+    const suite = create(() => {}, schema);
+
+    // Incorrect key formatting
+    const result = suite.run({ guest_1: true } as any);
+    expect(result.hasErrors('guest_1')).toBe(true);
+    expect(result.isValid()).toBe(false);
+
+    // Correct formatting
+    const suite2 = create(_data => {
+      test('user_1', () => {
+        // Mock test ensuring the suite runs
+      });
+    }, schema);
+    const result2 = suite2.run({ user_1: true });
+    expect(result2.isValid()).toBe(true);
+  });
+});

--- a/packages/vest/src/suite/__tests__/recordValidation.test.ts
+++ b/packages/vest/src/suite/__tests__/recordValidation.test.ts
@@ -23,7 +23,8 @@ describe('enforce.record() in Vest', () => {
     });
 
     expect(result.isValid()).toBe(false);
-    expect(result.hasErrors('settings.notifications' as any)).toBe(true);
+    // @ts-expect-error - dot-path field name
+    expect(result.hasErrors('settings.notifications')).toBe(true);
   });
 
   it('works with focus modifiers when dropping entirely via focus', () => {
@@ -38,10 +39,12 @@ describe('enforce.record() in Vest', () => {
 
     const result = suite
       .focus({ only: 'name' })
-      .run({ name: '', permissions: { bad: 'value' } } as any);
+      // @ts-expect-error - testing runtime with invalid value type
+      .run({ name: '', permissions: { bad: 'value' } });
 
     // permissions.bad should not be validated because we focused on name
-    expect(result.hasErrors('permissions.bad' as any)).toBe(false);
+    // @ts-expect-error - dot-path field name
+    expect(result.hasErrors('permissions.bad')).toBe(false);
     expect(result.isValid()).toBe(true);
   });
 
@@ -60,11 +63,12 @@ describe('enforce.record() in Vest', () => {
 
     const result = suite.run({
       admin: { active: true },
+      // @ts-expect-error - testing runtime with invalid nested value
       editor: { active: 'yes' }, // invalid
-    } as any);
+    });
 
     // The top-level key is 'editor', meaning 'editor.active' should have a schema validation error.
-    expect(result.hasErrors('editor.active' as any)).toBe(true);
+    expect(result.hasErrors('editor.active')).toBe(true);
   });
 
   it('maintains parsed coerced types using .test() inside suite', () => {
@@ -93,7 +97,7 @@ describe('enforce.record() in Vest', () => {
     const suite = create(() => {}, schema);
 
     // Incorrect key formatting
-    const result = suite.run({ guest_1: true } as any);
+    const result = suite.run({ guest_1: true });
     expect(result.hasErrors('guest_1')).toBe(true);
     expect(result.isValid()).toBe(false);
 

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -173,7 +173,7 @@ describe('Schema Runtime Validation', () => {
 
       const testSuite = create(() => {}, schemaWithMessage);
 
-      const result = testSuite.run({ price: 'free' } as any);
+      const result = testSuite.run({ price: 'free' });
 
       expect(result.hasErrors('price')).toBe(true);
       expect(result.getErrors('price')).toContain('Price must be a number');
@@ -186,7 +186,8 @@ describe('Schema Runtime Validation', () => {
 
       const testSuite = create(() => {}, schemaWithoutMessage);
 
-      const result = testSuite.run({ price: 'free' } as any);
+      // @ts-expect-error - testing runtime with invalid value type
+      const result = testSuite.run({ price: 'free' });
 
       expect(result.hasErrors('price')).toBe(true);
       expect(result.getMessage('price')).toBeUndefined();

--- a/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
+++ b/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
@@ -21,6 +21,7 @@ These rules are available in `enforce`:
   - [enforce.pick() - pick a subset of fields](#enforcepick---pick-a-subset-of-fields)
   - [enforce.omit() - omit a subset of fields](#enforceomit---omit-a-subset-of-fields)
   - [enforce.isArrayOf() - array shape matching](#enforceisarrayof---array-shape-matching)
+  - [enforce.record() - dynamic object matching](#enforcerecord---dynamic-object-matching)
 
 ## enforce.shape() - Lean schema validation.
 
@@ -178,6 +179,28 @@ enforce({ data: [1, 2, 3] }).shape({
   data: enforce.isArrayOf(enforce.isNumber()),
 });
 ```
+
+## enforce.record() - dynamic object matching
+
+When you need to validate objects acting as key-value mappings (where keys are dynamic), you can use `enforce.record()`. It allows you to validate all values, and optionally all keys, within an object.
+
+```js
+// Validating just values
+const userRoles = { alice: 'admin', bob: 'editor' };
+enforce(userRoles).record(enforce.isString());
+```
+
+```js
+// Validating both keys and values
+// The first argument is the key rule, the second is the value rule
+const exactMapping = { user_123: true, user_456: false };
+enforce(exactMapping).record(
+  enforce.isString().matches(/^user_\d+$/),
+  enforce.isBoolean(),
+);
+```
+
+Just like `isArrayOf`, `record` can be nested in shapes or other arrays, and properly populates accurate error paths (e.g. `settings.darkMode`).
 
 ## Schema Parsing
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1244,6 +1244,7 @@ These rules are available in `enforce`:
   - [enforce.pick() - pick a subset of fields](#enforcepick---pick-a-subset-of-fields)
   - [enforce.omit() - omit a subset of fields](#enforceomit---omit-a-subset-of-fields)
   - [enforce.isArrayOf() - array shape matching](#enforceisarrayof---array-shape-matching)
+  - [enforce.record() - dynamic object matching](#enforcerecord---dynamic-object-matching)
 
 ## enforce.shape() - Lean schema validation.
 
@@ -1401,6 +1402,28 @@ enforce({ data: [1, 2, 3] }).shape({
   data: enforce.isArrayOf(enforce.isNumber()),
 });
 ```
+
+## enforce.record() - dynamic object matching
+
+When you need to validate objects acting as key-value mappings (where keys are dynamic), you can use `enforce.record()`. It allows you to validate all values, and optionally all keys, within an object.
+
+```js
+// Validating just values
+const userRoles = { alice: 'admin', bob: 'editor' };
+enforce(userRoles).record(enforce.isString());
+```
+
+```js
+// Validating both keys and values
+// The first argument is the key rule, the second is the value rule
+const exactMapping = { user_123: true, user_456: false };
+enforce(exactMapping).record(
+  enforce.isString().matches(/^user_\d+$/),
+  enforce.isBoolean(),
+);
+```
+
+Just like `isArrayOf`, `record` can be nested in shapes or other arrays, and properly populates accurate error paths (e.g. `settings.darkMode`).
 
 ## Schema Parsing
 


### PR DESCRIPTION
Implements enforce.record for dynamic object key/value validation. Supports both value-only validation and key+value validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `enforce.record()` rule for validating dynamic key-value objects with support for validating values only or both keys and values simultaneously
  * Supports nesting within shapes and arrays with accurate error path reporting

* **Documentation**
  * Added comprehensive documentation for `enforce.record()` with usage examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->