### PR TITLE
feat(n4s): add enforce.lazy() for recursive schemas

### DIFF
--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -13,6 +13,7 @@ import * as generalRules from './rules/generalRules';
 import type { ObjectRulesUnion } from './rules/objectRules';
 import * as objectRules from './rules/objectRules';
 import * as schemaRules from './rules/schemaRules/schemaRules';
+import { lazy as lazyRule } from './rules/schemaRules/lazy';
 import type { SchemaRuleLazyTypes } from './rules/schemaRules/schemaRules';
 import { type RuleInstance } from './utils/RuleInstance';
 import { RuleRunReturn } from './utils/RuleRunReturn';
@@ -92,6 +93,7 @@ const schemaRulesWithArrayChaining = {
       );
       return RuleRunReturn.create(result, value);
     }),
+  lazy: lazyRule,
   loose: schemaAttacher(schemaEvaluators.loose),
   record: recordEvaluators.record,
   shape: schemaAttacher(schemaEvaluators.shape),

--- a/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
@@ -1,6 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest';
 
 import { enforce } from '../../../n4s';
+import type { RuleInstance } from '../../../utils/RuleInstance';
 import type { ShapeType } from '../shape';
 
 // schema combinators are consumed via enforce
@@ -197,5 +198,52 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     expectTypeOf(listSchema.parse).returns.toMatchTypeOf<
       { id: number; label: string }[]
     >();
+  });
+
+  it('lazy: standalone preserves inner rule type for .infer and .parse()', () => {
+    const lazyNum = enforce.lazy(() => enforce.isNumber());
+    expectTypeOf(lazyNum.infer).toEqualTypeOf<number>();
+    // eslint-disable-next-line vitest/valid-expect
+    expectTypeOf(lazyNum.parse).returns.toEqualTypeOf<number>();
+
+    const lazyStr = enforce.lazy(() => enforce.isString());
+    expectTypeOf(lazyStr.infer).toEqualTypeOf<string>();
+    // eslint-disable-next-line vitest/valid-expect
+    expectTypeOf(lazyStr.parse).returns.toEqualTypeOf<string>();
+  });
+
+  it('lazy: inside shape preserves field types in .infer and .parse()', () => {
+    const schema = enforce.shape({
+      name: enforce.isString(),
+      count: enforce.lazy(() => enforce.isNumber()),
+    });
+
+    type S = typeof schema.infer;
+
+    const ok: S = { name: 'a', count: 1 };
+    void ok;
+
+    // @ts-expect-error - count must be number, not string
+    const bad: S = { name: 'a', count: 'not a number' };
+    void bad;
+
+    // eslint-disable-next-line vitest/valid-expect
+    expectTypeOf(schema.parse).returns.toMatchTypeOf<{
+      name: string;
+      count: number;
+    }>();
+  });
+
+  it('lazy: recursive schema with explicit annotation preserves types', () => {
+    type Tree = { value: number; children: Tree[] };
+
+    const treeSchema: RuleInstance<Tree> = enforce.shape({
+      value: enforce.isNumber(),
+      children: enforce.isArrayOf(enforce.lazy(() => treeSchema)),
+    });
+
+    expectTypeOf(treeSchema.infer).toEqualTypeOf<Tree>();
+    // eslint-disable-next-line vitest/valid-expect
+    expectTypeOf(treeSchema.parse).returns.toEqualTypeOf<Tree>();
   });
 });

--- a/packages/n4s/src/rules/schemaRules/__tests__/lazy.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/lazy.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from 'vitest';
+
+import { enforce, compose } from '../../../n4s';
+import type { RuleInstance } from '../../../utils/RuleInstance';
+
+describe('enforce.lazy()', () => {
+  describe('recursive shape validation', () => {
+    it('validates a simple recursive tree', () => {
+      const treeSchema: RuleInstance<any> = enforce.shape({
+        value: enforce.isNumber(),
+        children: enforce.isArrayOf(enforce.lazy(() => treeSchema)),
+      });
+
+      expect(
+        treeSchema.test({
+          value: 1,
+          children: [
+            { value: 2, children: [] },
+            {
+              value: 3,
+              children: [{ value: 4, children: [] }],
+            },
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    it('fails on invalid nested node', () => {
+      const treeSchema: RuleInstance<any> = enforce.shape({
+        value: enforce.isNumber(),
+        children: enforce.isArrayOf(enforce.lazy(() => treeSchema)),
+      });
+
+      expect(
+        treeSchema.test({
+          value: 1,
+          children: [{ value: 'not a number', children: [] }],
+        }),
+      ).toBe(false);
+    });
+
+    it('validates leaf nodes (empty children array)', () => {
+      const treeSchema: RuleInstance<any> = enforce.shape({
+        value: enforce.isString(),
+        children: enforce.isArrayOf(enforce.lazy(() => treeSchema)),
+      });
+
+      expect(treeSchema.test({ value: 'leaf', children: [] })).toBe(true);
+    });
+
+    it('fails when nested node is missing required fields', () => {
+      const treeSchema: RuleInstance<any> = enforce.shape({
+        value: enforce.isNumber(),
+        children: enforce.isArrayOf(enforce.lazy(() => treeSchema)),
+      });
+
+      expect(
+        treeSchema.test({
+          value: 1,
+          children: [{ value: 2 }],
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('optional recursive fields', () => {
+    it('validates a binary tree with optional left/right', () => {
+      const binaryTree: RuleInstance<any> = enforce.shape({
+        value: enforce.isNumber(),
+        left: enforce.optional(enforce.lazy(() => binaryTree)),
+        right: enforce.optional(enforce.lazy(() => binaryTree)),
+      });
+
+      expect(binaryTree.test({ value: 1 })).toBe(true);
+      expect(binaryTree.test({ value: 1, left: { value: 2 } })).toBe(true);
+      expect(
+        binaryTree.test({
+          value: 1,
+          left: { value: 2, right: { value: 3 } },
+        }),
+      ).toBe(true);
+    });
+
+    it('fails on invalid optional nested node', () => {
+      const binaryTree: RuleInstance<any> = enforce.shape({
+        value: enforce.isNumber(),
+        left: enforce.optional(enforce.lazy(() => binaryTree)),
+        right: enforce.optional(enforce.lazy(() => binaryTree)),
+      });
+
+      expect(
+        binaryTree.test({
+          value: 1,
+          left: { value: 'invalid' },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('factory caching', () => {
+    it('calls the factory only once across recursive calls', () => {
+      let callCount = 0;
+      const schema: RuleInstance<any> = enforce.shape({
+        val: enforce.isNumber(),
+        next: enforce.optional(
+          enforce.lazy(() => {
+            callCount++;
+            return schema;
+          }),
+        ),
+      });
+
+      schema.test({ val: 1, next: { val: 2, next: { val: 3 } } });
+      expect(callCount).toBe(1);
+    });
+
+    it('reuses cached schema across multiple validations', () => {
+      let callCount = 0;
+      const schema: RuleInstance<any> = enforce.shape({
+        val: enforce.isNumber(),
+        next: enforce.optional(
+          enforce.lazy(() => {
+            callCount++;
+            return schema;
+          }),
+        ),
+      });
+
+      schema.test({ val: 1, next: { val: 2 } });
+      schema.test({ val: 3, next: { val: 4 } });
+      expect(callCount).toBe(1);
+    });
+  });
+
+  describe('deep nesting', () => {
+    it('validates a deeply nested structure (5+ levels)', () => {
+      const nodeSchema: RuleInstance<any> = enforce.shape({
+        id: enforce.isNumber(),
+        child: enforce.optional(enforce.lazy(() => nodeSchema)),
+      });
+
+      expect(
+        nodeSchema.test({
+          id: 1,
+          child: {
+            id: 2,
+            child: {
+              id: 3,
+              child: {
+                id: 4,
+                child: {
+                  id: 5,
+                  child: { id: 6 },
+                },
+              },
+            },
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('detects failure deep in nested structure', () => {
+      const nodeSchema: RuleInstance<any> = enforce.shape({
+        id: enforce.isNumber(),
+        child: enforce.optional(enforce.lazy(() => nodeSchema)),
+      });
+
+      expect(
+        nodeSchema.test({
+          id: 1,
+          child: {
+            id: 2,
+            child: {
+              id: 3,
+              child: {
+                id: 'invalid',
+              },
+            },
+          },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('RuleInstance methods', () => {
+    it('.test() returns boolean', () => {
+      const schema: RuleInstance<any> = enforce.shape({
+        val: enforce.isNumber(),
+        children: enforce.isArrayOf(enforce.lazy(() => schema)),
+      });
+
+      expect(typeof schema.test({ val: 1, children: [] })).toBe('boolean');
+    });
+
+    it('.run() returns RuleRunReturn', () => {
+      const schema: RuleInstance<any> = enforce.shape({
+        val: enforce.isNumber(),
+        children: enforce.isArrayOf(enforce.lazy(() => schema)),
+      });
+
+      const passing = schema.run({ val: 1, children: [] });
+      expect(passing.pass).toBe(true);
+
+      const failing = schema.run({ val: 'bad', children: [] });
+      expect(failing.pass).toBe(false);
+    });
+
+    it('.validate() returns StandardSchema result', () => {
+      const schema: RuleInstance<any> = enforce.shape({
+        val: enforce.isNumber(),
+        children: enforce.isArrayOf(enforce.lazy(() => schema)),
+      });
+
+      const passing = schema.validate({ val: 1, children: [] });
+      expect(passing).toHaveProperty('value');
+      expect(passing).not.toHaveProperty('issues');
+
+      const failing = schema.validate({ val: 'bad', children: [] });
+      expect(failing).toHaveProperty('issues');
+    });
+
+    it('.parse() returns value on success and throws on failure', () => {
+      const schema: RuleInstance<any> = enforce.shape({
+        val: enforce.isNumber(),
+        children: enforce.isArrayOf(enforce.lazy(() => schema)),
+      });
+
+      const data = { val: 1, children: [] };
+      expect(schema.parse(data)).toEqual(data);
+
+      expect(() => schema.parse({ val: 'bad', children: [] })).toThrow();
+    });
+  });
+
+  describe('.message() override', () => {
+    it('supports custom message on lazy wrapper', () => {
+      const inner = enforce.shape({
+        val: enforce.isNumber(),
+      });
+
+      const lazyInner = enforce.lazy(() => inner).message('Custom lazy error');
+      const result = lazyInner.run({ val: 'bad' });
+
+      expect(result.pass).toBe(false);
+      expect(result.message).toBe('Custom lazy error');
+    });
+  });
+
+  describe('compose + lazy', () => {
+    it('works with compose()', () => {
+      const nodeSchema: RuleInstance<any> = enforce.shape({
+        id: enforce.isString(),
+        children: enforce.isArrayOf(enforce.lazy(() => nodeSchema)),
+      });
+
+      const validatedNode = compose(nodeSchema, enforce.isNotEmpty());
+
+      expect(
+        validatedNode.test({
+          id: 'root',
+          children: [{ id: 'a', children: [] }],
+        }),
+      ).toBe(true);
+
+      expect(validatedNode.test({})).toBe(false);
+    });
+  });
+
+  describe('eager API integration', () => {
+    it('works when lazy is used inside an eager shape call', () => {
+      const treeSchema: RuleInstance<any> = enforce.shape({
+        value: enforce.isNumber(),
+        children: enforce.isArrayOf(enforce.lazy(() => treeSchema)),
+      });
+
+      expect(() => {
+        enforce({
+          value: 1,
+          children: [{ value: 2, children: [] }],
+        }).shape(treeSchema.__schema);
+      }).not.toThrow();
+    });
+  });
+
+  describe('standalone lazy', () => {
+    it('works as a standalone rule', () => {
+      const numberRule = enforce.isNumber();
+      const lazyNumber = enforce.lazy(() => numberRule);
+
+      expect(lazyNumber.test(42)).toBe(true);
+      // @ts-expect-error - testing runtime failure with invalid type
+      expect(lazyNumber.test('not a number')).toBe(false);
+    });
+  });
+
+  describe('error path propagation', () => {
+    it('propagates error path through lazy boundary', () => {
+      const schema: RuleInstance<any> = enforce.shape({
+        name: enforce.isString(),
+        children: enforce.isArrayOf(enforce.lazy(() => schema)),
+      });
+
+      const result = schema.run({
+        name: 'root',
+        children: [{ name: 123, children: [] }],
+      });
+
+      expect(result.pass).toBe(false);
+      expect(result.path).toBeDefined();
+    });
+  });
+});

--- a/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { enforce } from '../../../n4s';
+import type { RuleInstance } from '../../../utils/RuleInstance';
 
 declare global {
   namespace n4s {
@@ -154,5 +155,44 @@ describe('schema parse integration', () => {
     // @ts-expect-error - testing nullish input against string schema
     expect(schema.parse({ label: undefined })).toEqual({ label: 'N/A' });
     expect(schema.parse({ label: 'hello' })).toEqual({ label: 'hello' });
+  });
+
+  it('lazy propagates parse transformations from inner schema', () => {
+    const inner = enforce.shape({
+      name: enforce.trimString(),
+      age: enforce.toNumber(),
+    });
+
+    const schema = enforce.lazy(() => inner);
+    // @ts-expect-error - input type differs from output due to coercions
+    const result = schema.parse({ name: '  Jane  ', age: '34' });
+    expect(result).toEqual({ name: 'Jane', age: 34 });
+  });
+
+  it('lazy propagates parse transformations through recursive schemas', () => {
+    const schema: RuleInstance<any> = enforce.shape({
+      name: enforce.trimString(),
+      children: enforce.isArrayOf(enforce.lazy(() => schema)),
+    });
+
+    const result = schema.parse({
+      name: '  Root  ',
+      children: [
+        {
+          name: '  Child  ',
+          children: [{ name: '  Grandchild  ', children: [] }],
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      name: 'Root',
+      children: [
+        {
+          name: 'Child',
+          children: [{ name: 'Grandchild', children: [] }],
+        },
+      ],
+    });
   });
 });

--- a/packages/n4s/src/rules/schemaRules/lazy.ts
+++ b/packages/n4s/src/rules/schemaRules/lazy.ts
@@ -1,0 +1,48 @@
+import { ctx } from '../../enforceContext';
+import { RuleInstance } from '../../utils/RuleInstance';
+import { RuleRunReturn } from '../../utils/RuleRunReturn';
+import { addToChain } from '../genRuleChain';
+
+export type LazyRuleInstance<T> = RuleInstance<T, [T]>;
+
+/**
+ * Creates a lazy schema wrapper for recursive/self-referencing schemas.
+ * The factory function is called on first validation and cached.
+ *
+ * @param factory - A function that returns the RuleInstance to delegate to
+ * @returns A RuleInstance that defers schema resolution to validation time
+ *
+ * @example
+ * ```typescript
+ * type Category = { name: string; children: Category[] };
+ *
+ * const categorySchema = enforce.shape({
+ *   name: enforce.isString(),
+ *   children: enforce.isArrayOf(enforce.lazy(() => categorySchema)),
+ * });
+ *
+ * categorySchema.test({
+ *   name: 'Root',
+ *   children: [
+ *     { name: 'Child', children: [] },
+ *   ],
+ * }); // true
+ * ```
+ */
+export function lazy<T>(
+  factory: () => RuleInstance<T, any>,
+): LazyRuleInstance<T> {
+  let cached: RuleInstance<T, any> | null = null;
+
+  const resolve = (): RuleInstance<T, any> => {
+    if (!cached) {
+      cached = factory();
+    }
+    return cached;
+  };
+
+  return addToChain<LazyRuleInstance<T>>({}, (value: any) => {
+    const result = ctx.run({ value }, () => resolve().run(value));
+    return RuleRunReturn.create(result, value);
+  });
+}

--- a/packages/n4s/src/rules/schemaRules/schemaRules.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRules.ts
@@ -1,6 +1,7 @@
 import './schemaRulesLazyTypes';
 
 export { isArrayOf, type IsArrayOfRuleInstance } from './isArrayOf';
+export { lazy, type LazyRuleInstance } from './lazy';
 export { loose, type LooseRuleInstance } from './loose';
 export { optional, type OptionalRuleInstance } from './optional';
 export { partial, type PartialRuleInstance } from './partial';

--- a/packages/n4s/src/rules/schemaRules/schemaRules.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRules.ts
@@ -1,7 +1,7 @@
 import './schemaRulesLazyTypes';
 
 export { isArrayOf, type IsArrayOfRuleInstance } from './isArrayOf';
-export { lazy, type LazyRuleInstance } from './lazy';
+export { type LazyRuleInstance } from './lazy';
 export { loose, type LooseRuleInstance } from './loose';
 export { optional, type OptionalRuleInstance } from './optional';
 export { partial, type PartialRuleInstance } from './partial';

--- a/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
@@ -15,6 +15,7 @@ import { MultiTypeInput, MultiTypeInputArgs } from './schemaRulesTypes';
 
 import type {
   IsArrayOfRuleInstance,
+  LazyRuleInstance,
   LooseRuleInstance,
   OptionalRuleInstance,
   PartialRuleInstance,
@@ -31,6 +32,7 @@ export type SchemaRuleLazyTypes = {
   isArrayOf: <Rules extends RuleInstance<any, any>[]>(
     ...rules: Rules
   ) => IsArrayOfRuleInstance<MultiTypeInput<Rules>, MultiTypeInputArgs<Rules>>;
+  lazy: <T>(factory: () => RuleInstance<T, any>) => LazyRuleInstance<T>;
   loose: <S extends Record<string, RuleInstance<any>>>(
     schema: S,
   ) => LooseRuleInstance<S>;

--- a/packages/vest/src/suite/__tests__/schema.types.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.types.test.ts
@@ -849,3 +849,52 @@ describe('comprehensive typed API coverage', () => {
     result.getErrors('anything');
   });
 });
+
+describe('lazy schema in suite types', () => {
+  it('infers data type from schema containing lazy fields', () => {
+    const schema = enforce.shape({
+      name: enforce.isString(),
+      metadata: enforce.lazy(() =>
+        enforce.shape({
+          key: enforce.isString(),
+          value: enforce.isNumber(),
+        }),
+      ),
+    });
+
+    const suite = create(data => {
+      void (0 as unknown as AssertTrue<
+        IsEqual<
+          typeof data,
+          { name: string; metadata: { key: string; value: number } }
+        >
+      >);
+      void (0 as unknown as AssertTrue<IsEqual<(typeof data)['name'], string>>);
+      void (0 as unknown as AssertTrue<
+        IsEqual<(typeof data)['metadata'], { key: string; value: number }>
+      >);
+    }, schema);
+
+    void (0 as unknown as AssertTrue<
+      IsEqual<
+        Parameters<typeof suite.run>[0],
+        { name: string; metadata: { key: string; value: number } }
+      >
+    >);
+
+    void (0 as unknown as AssertTrue<
+      IsEqual<
+        ReturnType<typeof suite.get>['types']['output'],
+        { name: string; metadata: { key: string; value: number } }
+      >
+    >);
+
+    suite.run({ name: 'test', metadata: { key: 'k', value: 1 } });
+
+    // @ts-expect-error - metadata.value must be number
+    suite.run({ name: 'test', metadata: { key: 'k', value: 'bad' } });
+
+    // @ts-expect-error - missing metadata field
+    suite.run({ name: 'test' });
+  });
+});

--- a/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
+++ b/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
@@ -253,7 +253,7 @@ binaryTree.test({
 }); // true
 ```
 
-The factory function is called once on first validation and cached, so there is no performance overhead from repeated resolution.
+The factory function is called once on first validation and cached, avoiding repeated schema resolution overhead.
 
 ### TypeScript
 

--- a/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
+++ b/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
@@ -3,7 +3,19 @@ sidebar_position: 5
 title: Schema Validation with Enforce
 description: While less common when using Vest, sometimes it might be useful to validate a value against a schema. Vest comes with some schema validation rules that are handy for data-shape validation.
 keywords:
-  [Vest, schema, validation, rules, shape, optional, partial, loose, isArrayOf]
+  [
+    Vest,
+    schema,
+    validation,
+    rules,
+    shape,
+    optional,
+    partial,
+    loose,
+    isArrayOf,
+    lazy,
+    recursive,
+  ]
 ---
 
 # Schema rules
@@ -22,6 +34,7 @@ These rules are available in `enforce`:
   - [enforce.omit() - omit a subset of fields](#enforceomit---omit-a-subset-of-fields)
   - [enforce.isArrayOf() - array shape matching](#enforceisarrayof---array-shape-matching)
   - [enforce.record() - dynamic object matching](#enforcerecord---dynamic-object-matching)
+  - [enforce.lazy() - recursive schemas](#enforcelazy---recursive-schemas)
 
 ## enforce.shape() - Lean schema validation.
 
@@ -201,6 +214,81 @@ enforce(exactMapping).record(
 ```
 
 Just like `isArrayOf`, `record` can be nested in shapes or other arrays, and properly populates accurate error paths (e.g. `settings.darkMode`).
+
+## enforce.lazy() - recursive schemas
+
+Use `enforce.lazy()` to validate self-referencing data structures like trees, nested comments, or recursive menus. It wraps a factory function that returns the schema, deferring resolution to validation time to avoid infinite recursion during definition.
+
+```js
+const treeSchema = enforce.shape({
+  value: enforce.isNumber(),
+  children: enforce.isArrayOf(enforce.lazy(() => treeSchema)),
+});
+
+treeSchema.test({
+  value: 1,
+  children: [
+    { value: 2, children: [] },
+    {
+      value: 3,
+      children: [{ value: 4, children: [] }],
+    },
+  ],
+}); // true
+```
+
+`lazy` works with `enforce.optional()` for optional recursive fields, such as binary trees:
+
+```js
+const binaryTree = enforce.shape({
+  value: enforce.isNumber(),
+  left: enforce.optional(enforce.lazy(() => binaryTree)),
+  right: enforce.optional(enforce.lazy(() => binaryTree)),
+});
+
+binaryTree.test({ value: 1 }); // true (leaf node)
+binaryTree.test({
+  value: 1,
+  left: { value: 2, right: { value: 3 } },
+}); // true
+```
+
+The factory function is called once on first validation and cached, so there is no performance overhead from repeated resolution.
+
+### TypeScript
+
+TypeScript cannot infer recursive types automatically. When using `enforce.lazy()` for recursive schemas, provide an explicit type annotation:
+
+```ts
+import type { RuleInstance } from 'n4s';
+
+type Category = {
+  name: string;
+  children: Category[];
+};
+
+const categorySchema: RuleInstance<Category> = enforce.shape({
+  name: enforce.isString(),
+  children: enforce.isArrayOf(enforce.lazy(() => categorySchema)),
+});
+```
+
+For non-recursive uses, the type is inferred automatically:
+
+```ts
+const schema = enforce.shape({
+  name: enforce.isString(),
+  metadata: enforce.lazy(() =>
+    enforce.shape({
+      key: enforce.isString(),
+      value: enforce.isNumber(),
+    }),
+  ),
+});
+
+type Data = typeof schema.infer;
+// { name: string; metadata: { key: string; value: number } }
+```
 
 ## Schema Parsing
 


### PR DESCRIPTION
## Summary

- Adds `enforce.lazy(() => schema)` to enable validation of recursive/self-referencing data structures (trees, nested comments, org charts, recursive menus)
- The factory function is deferred to validation time and cached after first resolution, avoiding infinite recursion at definition time and redundant re-creation
- Integrates with existing schema rules: `shape`, `optional`, `isArrayOf`, `compose`, and all `RuleInstance` methods (`.test`, `.run`, `.validate`, `.parse`, `.message`)
- Excludes `lazy` from the eager API (`schemaRulesMap`) since it returns a `RuleInstance`, not a boolean/`RuleRunReturn`
- Adds documentation to the schema validation page with examples and TypeScript guidance

## Test plan

- [x] Validates simple recursive trees (pass and fail cases)
- [x] Validates leaf nodes with empty children arrays
- [x] Fails when nested nodes are missing required fields
- [x] Optional recursive fields (binary tree with optional left/right)
- [x] Factory caching — called only once across recursive calls and multiple validations
- [x] Deep nesting (5+ levels, including failure detection deep in the structure)
- [x] All RuleInstance methods work (`.test`, `.run`, `.validate`, `.parse`)
- [x] `.message()` override on lazy wrapper
- [x] `compose()` integration
- [x] Eager API integration (`enforce(value).shape(...)`)
- [x] Standalone lazy wrapping non-schema rules
- [x] Error path propagation through lazy boundaries
- [x] Type inference: standalone lazy preserves `.infer` and `.parse()` return types
- [x] Type inference: lazy inside shape preserves field types
- [x] Type inference: recursive schema with explicit `RuleInstance<T>` annotation
- [x] Parser: lazy propagates parse coercions (`trimString`, `toNumber`)
- [x] Parser: recursive lazy propagates parse at all nesting levels
- [x] Vest: `create()` with lazy schema correctly types `data`, `suite.run()` params, and `suite.get().types.output`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enforce.lazy() to support deferred, self-referencing schemas with one-time factory caching and preserved runtime behavior.

* **Types**
  * Exposed a LazyRuleInstance type so lazy schemas are reflected in public typings.

* **Documentation**
  * Added examples, guidance, and TypeScript notes for recursive/optional schemas.

* **Tests**
  * Added comprehensive tests for recursion, deep nesting, optional recursion, caching, parse propagation, API methods, type inference, and error-path reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->