### PR TITLE
feat(n4s): add enforce.tuple() for fixed-length array validation

### DIFF
--- a/packages/n4s/src/eager/eagerTypes.ts
+++ b/packages/n4s/src/eager/eagerTypes.ts
@@ -40,6 +40,9 @@ export type TArraySchemaRules<T, A, S> = T extends any[]
       isArrayOf: <Rules extends RuleInstance<any, any>[]>(
         ...rules: Rules
       ) => EnforceEagerReturn<MultiTypeInput<Rules>[], A, S>;
+      list: <Rules extends RuleInstance<any, any>[]>(
+        ...rules: Rules
+      ) => EnforceEagerReturn<MultiTypeInput<Rules>[], A, S>;
       tuple: <Rules extends RuleInstance<any, any>[]>(
         ...rules: Rules
       ) => EnforceEagerReturn<

--- a/packages/n4s/src/eager/eagerTypes.ts
+++ b/packages/n4s/src/eager/eagerTypes.ts
@@ -40,6 +40,17 @@ export type TArraySchemaRules<T, A, S> = T extends any[]
       isArrayOf: <Rules extends RuleInstance<any, any>[]>(
         ...rules: Rules
       ) => EnforceEagerReturn<MultiTypeInput<Rules>[], A, S>;
+      tuple: <Rules extends RuleInstance<any, any>[]>(
+        ...rules: Rules
+      ) => EnforceEagerReturn<
+        {
+          [K in keyof Rules]: Rules[K] extends RuleInstance<infer R, any>
+            ? R
+            : never;
+        },
+        A,
+        S
+      >;
     }
   : Record<string, never>;
 

--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -94,6 +94,13 @@ const schemaRulesWithArrayChaining = {
       return RuleRunReturn.create(result, value);
     }),
   lazy: lazyRule,
+  list: <T>(...rules: any[]): ArrayRuleInstance<T> =>
+    addToChain<ArrayRuleInstance<T>>(arrayRules, (value: any) => {
+      const result = ctx.run({ value }, () =>
+        schemaRules.isArrayOf(value, ...rules),
+      );
+      return RuleRunReturn.create(result, value);
+    }),
   loose: schemaAttacher(schemaEvaluators.loose),
   record: recordEvaluators.record,
   shape: schemaAttacher(schemaEvaluators.shape),

--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -97,6 +97,13 @@ const schemaRulesWithArrayChaining = {
   loose: schemaAttacher(schemaEvaluators.loose),
   record: recordEvaluators.record,
   shape: schemaAttacher(schemaEvaluators.shape),
+  tuple: (...rules: any[]) =>
+    addToChain({}, (value: any) => {
+      const result = ctx.run({ value }, () =>
+        schemaRules.tuple(value, ...rules),
+      );
+      return RuleRunReturn.create(result, value);
+    }),
 };
 
 const baseEnforceLazy = {

--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -98,7 +98,7 @@ const schemaRulesWithArrayChaining = {
   record: recordEvaluators.record,
   shape: schemaAttacher(schemaEvaluators.shape),
   tuple: (...rules: any[]) =>
-    addToChain({}, (value: any) => {
+    addToChain(arrayRules, (value: any) => {
       const result = ctx.run({ value }, () =>
         schemaRules.tuple(value, ...rules),
       );

--- a/packages/n4s/src/n4s.ts
+++ b/packages/n4s/src/n4s.ts
@@ -5,6 +5,7 @@ import { ctx } from './enforceContext';
 import type { EnforceContext } from './enforceContext';
 import { extendEnforce } from './extendLogic';
 import { enforceLazy } from './lazy';
+import type { RuleInstance } from './utils/RuleInstance';
 
 /**
  * Context API for accessing validation context.
@@ -42,6 +43,10 @@ type ExtendFn = (rules: Record<string, (...args: any[]) => any>) => void;
 type ContextFn = () => EnforceContext;
 type Enforce = typeof enforceEager &
   typeof enforceLazy & { extend: ExtendFn; context: ContextFn };
+
+export namespace enforce {
+  export type infer<R extends RuleInstance<any, any>> = R['infer'];
+}
 
 /**
  * Main validation function supporting both eager (imperative) and lazy (builder) APIs.

--- a/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
@@ -246,4 +246,22 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     // eslint-disable-next-line vitest/valid-expect
     expectTypeOf(treeSchema.parse).returns.toEqualTypeOf<Tree>();
   });
+
+  it('enforce.infer<> is an alias for typeof schema.infer', () => {
+    const schema = enforce.shape({
+      name: enforce.isString(),
+      age: enforce.isNumber(),
+      tags: enforce.isArrayOf(enforce.isString()),
+    });
+
+    type ViaInferProp = typeof schema.infer;
+    type ViaEnforceInfer = enforce.infer<typeof schema>;
+
+    expectTypeOf<ViaEnforceInfer>().toEqualTypeOf<ViaInferProp>();
+    expectTypeOf<ViaEnforceInfer>().toEqualTypeOf<{
+      name: string;
+      age: number;
+      tags: string[];
+    }>();
+  });
 });

--- a/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/integrationSchemaRules.types.test.ts
@@ -247,6 +247,32 @@ describe('types: compile-time mismatches across rules and composed schemas', () 
     expectTypeOf(treeSchema.parse).returns.toEqualTypeOf<Tree>();
   });
 
+  it('tuple: parse() return type matches inferred tuple type', () => {
+    const schema = enforce.tuple(
+      enforce.isString(),
+      enforce.isNumber(),
+      enforce.isBoolean(),
+    );
+
+    // eslint-disable-next-line vitest/valid-expect
+    expectTypeOf(schema.parse).returns.toEqualTypeOf<
+      [string, number, boolean]
+    >();
+  });
+
+  it('tuple inside shape: parse() preserves tuple in parent shape', () => {
+    const schema = enforce.shape({
+      label: enforce.isString(),
+      coords: enforce.tuple(enforce.isNumber(), enforce.isNumber()),
+    });
+
+    // eslint-disable-next-line vitest/valid-expect
+    expectTypeOf(schema.parse).returns.toEqualTypeOf<{
+      label: string;
+      coords: [number, number];
+    }>();
+  });
+
   it('enforce.infer<> is an alias for typeof schema.infer', () => {
     const schema = enforce.shape({
       name: enforce.isString(),

--- a/packages/n4s/src/rules/schemaRules/__tests__/isArrayOf.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/isArrayOf.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 
 import { enforce } from '../../../n4s';
 
@@ -67,6 +67,42 @@ describe('isArrayOf', () => {
     expect(rule.run([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])).toMatchObject({
       pass: false,
     }); // fails maxLength
+  });
+});
+
+describe('enforce.list() - alias for isArrayOf', () => {
+  it('should validate arrays identically to isArrayOf', () => {
+    const rule = enforce.list(enforce.isNumber());
+    expect(rule.run([1, 2, 3]).pass).toBe(true);
+    expect(runArrayRule(rule, [1, 'x']).pass).toBe(false);
+  });
+
+  it('should support multiple rules', () => {
+    const rule = enforce.list(enforce.isNumber(), enforce.isString());
+    expect(rule.run([1, '2', 3]).pass).toBe(true);
+  });
+
+  it('should chain array methods', () => {
+    const rule = enforce.list(enforce.isNumber()).minLength(1).maxLength(5);
+    expect(rule.run([1, 2]).pass).toBe(true);
+    expect(rule.run([]).pass).toBe(false);
+  });
+
+  it('should infer the same types as isArrayOf', () => {
+    const viaIsArrayOf = enforce.isArrayOf(enforce.isString());
+    const viaList = enforce.list(enforce.isString());
+    expectTypeOf(viaList.infer).toEqualTypeOf(viaIsArrayOf.infer);
+    // eslint-disable-next-line vitest/valid-expect
+    expectTypeOf(viaList.parse).returns.toEqualTypeOf<string[]>();
+  });
+
+  it('should work in the eager API', () => {
+    expect(() => {
+      enforce([1, 2, 3]).list(enforce.isNumber());
+    }).not.toThrow();
+    expect(() => {
+      enforce(['x']).list(enforce.isNumber());
+    }).toThrow();
   });
 });
 

--- a/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/schema.parse.integration.test.ts
@@ -169,6 +169,45 @@ describe('schema parse integration', () => {
     expect(result).toEqual({ name: 'Jane', age: 34 });
   });
 
+  it('tuple parses element values with custom coercions', () => {
+    const schema = enforce.tuple(enforce.trimString(), enforce.toNumber());
+    const result = schema.parse(['  hello  ', '42']);
+    expect(result).toEqual(['hello', 42]);
+  });
+
+  it('tuple parses nested shape elements', () => {
+    const schema = enforce.tuple(
+      enforce.trimString(),
+      enforce.shape({
+        name: enforce.trimString(),
+        age: enforce.toNumber(),
+      }),
+    );
+
+    const result = schema.parse(['  label  ', { name: '  Jane  ', age: '34' }]);
+    expect(result).toEqual(['label', { name: 'Jane', age: 34 }]);
+  });
+
+  it('tuple parses with built-in parser chains', () => {
+    const schema = enforce.tuple(
+      enforce.isString().trim().toTitle(),
+      enforce.isNumeric().toNumber().clamp(0, 100),
+    );
+
+    const result = schema.parse(['  jANE DOE ', '180']);
+    expect(result).toEqual(['Jane Doe', 100]);
+  });
+
+  it('tuple inside shape preserves parse transformations', () => {
+    const schema = enforce.shape({
+      label: enforce.trimString(),
+      coords: enforce.tuple(enforce.toNumber(), enforce.toNumber()),
+    });
+
+    const result = schema.parse({ label: '  origin  ', coords: ['10', '20'] });
+    expect(result).toEqual({ label: 'origin', coords: [10, 20] });
+  });
+
   it('lazy propagates parse transformations through recursive schemas', () => {
     const schema: RuleInstance<any> = enforce.shape({
       name: enforce.trimString(),

--- a/packages/n4s/src/rules/schemaRules/__tests__/tuple.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/tuple.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+
+import { enforce } from '../../../n4s';
+
+describe('enforce.tuple()', () => {
+  describe('basic validation', () => {
+    it('passes for valid tuple', () => {
+      const schema = enforce.tuple(enforce.isString(), enforce.isNumber());
+      expect(schema.test(['hello', 42])).toBe(true);
+    });
+
+    it('fails when element has wrong type', () => {
+      const schema = enforce.tuple(enforce.isString(), enforce.isNumber());
+      // @ts-expect-error - intentionally passing wrong type for first element
+      expect(schema.test([42, 42])).toBe(false);
+      // @ts-expect-error - intentionally passing wrong type for second element
+      expect(schema.test(['hello', 'world'])).toBe(false);
+    });
+
+    it('fails when too few elements', () => {
+      const schema = enforce.tuple(enforce.isString(), enforce.isNumber());
+      // @ts-expect-error - intentionally passing too few elements
+      expect(schema.test(['hello'])).toBe(false);
+    });
+
+    it('fails when too many elements', () => {
+      const schema = enforce.tuple(enforce.isString(), enforce.isNumber());
+      // @ts-expect-error - intentionally passing too many elements
+      expect(schema.test(['hello', 42, true])).toBe(false);
+    });
+
+    it('fails for non-array values', () => {
+      const schema = enforce.tuple(enforce.isString());
+      // @ts-expect-error - intentionally passing non-array
+      expect(schema.test('not an array')).toBe(false);
+      // @ts-expect-error - intentionally passing non-array
+      expect(schema.test({ 0: 'a' })).toBe(false);
+      // @ts-expect-error - intentionally passing null
+      expect(schema.test(null)).toBe(false);
+      // @ts-expect-error - intentionally passing undefined
+      expect(schema.test(undefined)).toBe(false);
+    });
+
+    it('passes for empty tuple schema with empty array', () => {
+      const emptyTuple = enforce.tuple();
+      expect(emptyTuple.test([])).toBe(true);
+      // @ts-expect-error - intentionally passing elements to empty tuple
+      expect(emptyTuple.test(['extra'])).toBe(false);
+    });
+  });
+
+  describe('with optional trailing elements', () => {
+    it('passes without optional element', () => {
+      const schema = enforce.tuple(
+        enforce.isString(),
+        enforce.optional(enforce.isNumber()),
+      );
+      // @ts-expect-error - runtime allows omitting optional trailing elements
+      expect(schema.test(['hello'])).toBe(true);
+    });
+
+    it('passes with optional element present', () => {
+      const schema = enforce.tuple(
+        enforce.isString(),
+        enforce.optional(enforce.isNumber()),
+      );
+      expect(schema.test(['hello', 42])).toBe(true);
+    });
+
+    it('fails when optional element has wrong type', () => {
+      const schema = enforce.tuple(
+        enforce.isString(),
+        enforce.optional(enforce.isNumber()),
+      );
+      // @ts-expect-error - intentionally passing wrong type for optional element
+      expect(schema.test(['hello', 'not a number'])).toBe(false);
+    });
+
+    it('handles multiple trailing optional elements', () => {
+      const schema = enforce.tuple(
+        enforce.isString(),
+        enforce.optional(enforce.isNumber()),
+        enforce.optional(enforce.isBoolean()),
+      );
+      // @ts-expect-error - runtime allows omitting optional trailing elements
+      expect(schema.test(['hello'])).toBe(true);
+      // @ts-expect-error - runtime allows omitting optional trailing elements
+      expect(schema.test(['hello', 42])).toBe(true);
+      expect(schema.test(['hello', 42, true])).toBe(true);
+      // @ts-expect-error - intentionally passing too many elements
+      expect(schema.test(['hello', 42, true, 'extra'])).toBe(false);
+    });
+  });
+
+  describe('nested schemas', () => {
+    it('supports shape elements', () => {
+      const schema = enforce.tuple(
+        enforce.isString(),
+        enforce.shape({ id: enforce.isNumber() }),
+      );
+
+      expect(schema.test(['test', { id: 1 }])).toBe(true);
+      // @ts-expect-error - intentionally passing wrong type for nested field
+      expect(schema.test(['test', { id: 'x' }])).toBe(false);
+    });
+
+    it('supports nested tuples', () => {
+      const schema = enforce.tuple(
+        enforce.isString(),
+        enforce.tuple(enforce.isNumber(), enforce.isNumber()),
+      );
+
+      expect(schema.test(['coords', [1, 2]])).toBe(true);
+      // @ts-expect-error - intentionally passing wrong type in nested tuple
+      expect(schema.test(['coords', [1, 'x']])).toBe(false);
+    });
+
+    it('supports isArrayOf elements', () => {
+      const schema = enforce.tuple(
+        enforce.isString(),
+        enforce.isArrayOf(enforce.isNumber()),
+      );
+
+      expect(schema.test(['tags', [1, 2, 3]])).toBe(true);
+      // @ts-expect-error - intentionally passing wrong type in array
+      expect(schema.test(['tags', [1, 'x']])).toBe(false);
+    });
+  });
+
+  describe('eager API', () => {
+    it('throws on invalid tuple', () => {
+      expect(() => {
+        enforce(['hello', 'world']).tuple(
+          enforce.isString(),
+          enforce.isNumber(),
+        );
+      }).toThrow();
+    });
+
+    it('does not throw on valid tuple', () => {
+      expect(() => {
+        enforce(['hello', 42]).tuple(enforce.isString(), enforce.isNumber());
+      }).not.toThrow();
+    });
+  });
+
+  describe('error reporting', () => {
+    it('reports index of failing element in path', () => {
+      const schema = enforce.tuple(
+        enforce.isString(),
+        enforce.isNumber(),
+        enforce.isBoolean(),
+      );
+
+      // @ts-expect-error - intentionally passing wrong type
+      const result = schema.run(['ok', 'bad', true]);
+      expect(result.pass).toBe(false);
+      expect(result.path).toBeDefined();
+      expect(result.path![0]).toBe('1');
+    });
+
+    it('reports nested error path through tuple boundary', () => {
+      const schema = enforce.tuple(
+        enforce.isString(),
+        enforce.shape({ id: enforce.isNumber() }),
+      );
+
+      // @ts-expect-error - intentionally passing wrong type for nested field
+      const result = schema.run(['ok', { id: 'bad' }]);
+      expect(result.pass).toBe(false);
+      expect(result.path).toEqual(['1', 'id']);
+    });
+  });
+
+  describe('RuleInstance methods', () => {
+    it('.test() returns boolean', () => {
+      const schema = enforce.tuple(enforce.isString(), enforce.isNumber());
+      expect(typeof schema.test(['a', 1])).toBe('boolean');
+    });
+
+    it('.run() returns RuleRunReturn', () => {
+      const schema = enforce.tuple(enforce.isString(), enforce.isNumber());
+      expect(schema.run(['a', 1]).pass).toBe(true);
+      // @ts-expect-error - intentionally passing wrong type
+      expect(schema.run(['a', 'b']).pass).toBe(false);
+    });
+
+    it('.validate() returns StandardSchema result', () => {
+      const schema = enforce.tuple(enforce.isString(), enforce.isNumber());
+      const passing = schema.validate(['a', 1]);
+      expect(passing).toHaveProperty('value');
+      expect(passing).not.toHaveProperty('issues');
+
+      // @ts-expect-error - intentionally passing wrong type
+      const failing = schema.validate(['a', 'b']);
+      expect(failing).toHaveProperty('issues');
+    });
+
+    it('.parse() returns value on success and throws on failure', () => {
+      const schema = enforce.tuple(enforce.isString(), enforce.isNumber());
+      expect(schema.parse(['a', 1])).toEqual(['a', 1]);
+      // @ts-expect-error - intentionally passing wrong type
+      expect(() => schema.parse(['a', 'b'])).toThrow();
+    });
+  });
+
+  describe('.message() override', () => {
+    it('supports custom message', () => {
+      const schema = enforce
+        .tuple(enforce.isString(), enforce.isNumber())
+        .message('Invalid coordinate');
+      const result = schema.run(['a', 'b']);
+      expect(result.pass).toBe(false);
+      expect(result.message).toBe('Invalid coordinate');
+    });
+  });
+
+  describe('type inference', () => {
+    it('infers tuple type from rules', () => {
+      const schema = enforce.tuple(
+        enforce.isString(),
+        enforce.isNumber(),
+        enforce.isBoolean(),
+      );
+
+      type Inferred = typeof schema.infer;
+      expectTypeOf<Inferred>().toEqualTypeOf<[string, number, boolean]>();
+    });
+
+    it('enforce.infer<> works with tuple', () => {
+      const schema = enforce.tuple(enforce.isString(), enforce.isNumber());
+
+      type ViaInfer = enforce.infer<typeof schema>;
+      expectTypeOf<ViaInfer>().toEqualTypeOf<[string, number]>();
+    });
+
+    it('infers tuple inside shape', () => {
+      const schema = enforce.shape({
+        name: enforce.isString(),
+        coords: enforce.tuple(enforce.isNumber(), enforce.isNumber()),
+      });
+
+      type S = typeof schema.infer;
+      expectTypeOf<S>().toEqualTypeOf<{
+        name: string;
+        coords: [number, number];
+      }>();
+    });
+
+    it('parse() return type is correctly inferred', () => {
+      const schema = enforce.tuple(enforce.isString(), enforce.isNumber());
+      // eslint-disable-next-line vitest/valid-expect
+      expectTypeOf(schema.parse).returns.toEqualTypeOf<[string, number]>();
+    });
+  });
+});

--- a/packages/n4s/src/rules/schemaRules/schemaRules.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRules.ts
@@ -9,4 +9,5 @@ export { pick, type PickRuleInstance } from './pick';
 export { omit, type OmitRuleInstance } from './omit';
 export { shape, type ShapeRuleInstance } from './shape';
 export { record, type RecordRuleInstance } from './record';
+export { tuple, type TupleRuleInstance } from './tuple';
 export type { SchemaRuleLazyTypes } from './schemaRulesLazyTypes';

--- a/packages/n4s/src/rules/schemaRules/schemaRules.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRules.ts
@@ -1,6 +1,10 @@
 import './schemaRulesLazyTypes';
 
-export { isArrayOf, type IsArrayOfRuleInstance } from './isArrayOf';
+export {
+  isArrayOf,
+  isArrayOf as list,
+  type IsArrayOfRuleInstance,
+} from './isArrayOf';
 export { type LazyRuleInstance } from './lazy';
 export { loose, type LooseRuleInstance } from './loose';
 export { optional, type OptionalRuleInstance } from './optional';

--- a/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
@@ -34,6 +34,9 @@ export type SchemaRuleLazyTypes = {
   isArrayOf: <Rules extends RuleInstance<any, any>[]>(
     ...rules: Rules
   ) => IsArrayOfRuleInstance<MultiTypeInput<Rules>, MultiTypeInputArgs<Rules>>;
+  list: <Rules extends RuleInstance<any, any>[]>(
+    ...rules: Rules
+  ) => IsArrayOfRuleInstance<MultiTypeInput<Rules>, MultiTypeInputArgs<Rules>>;
   lazy: <T>(factory: () => RuleInstance<T, any>) => LazyRuleInstance<T>;
   loose: <S extends Record<string, RuleInstance<any>>>(
     schema: S,

--- a/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
@@ -9,6 +9,7 @@ import './pick';
 import './omit';
 import './shape';
 import './record';
+import './tuple';
 
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { MultiTypeInput, MultiTypeInputArgs } from './schemaRulesTypes';
@@ -23,6 +24,7 @@ import type {
   OmitRuleInstance,
   ShapeRuleInstance,
   RecordRuleInstance,
+  TupleRuleInstance,
 } from './schemaRules';
 
 /**
@@ -62,4 +64,7 @@ export type SchemaRuleLazyTypes = {
       valueRule: V,
     ): RecordRuleInstance<K, V>;
   };
+  tuple: <Rules extends RuleInstance<any, any>[]>(
+    ...rules: Rules
+  ) => TupleRuleInstance<Rules>;
 };

--- a/packages/n4s/src/rules/schemaRules/tuple.ts
+++ b/packages/n4s/src/rules/schemaRules/tuple.ts
@@ -1,3 +1,5 @@
+import { isFunction } from 'vest-utils';
+
 import { ctx } from '../../enforceContext';
 import type { RuleInstance } from '../../utils/RuleInstance';
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
@@ -89,7 +91,7 @@ function elementFailure(
  * with undefined (the same way shape detects optional fields).
  */
 function isOptionalRule(rule: RuleInstance<any, any>): boolean {
-  if (!rule || typeof rule.test !== 'function') return false;
+  if (!rule || !isFunction(rule.test)) return false;
   return rule.test(undefined);
 }
 

--- a/packages/n4s/src/rules/schemaRules/tuple.ts
+++ b/packages/n4s/src/rules/schemaRules/tuple.ts
@@ -1,4 +1,4 @@
-import { isFunction, longerThan, greaterThan } from 'vest-utils';
+import { greaterThan, isFunction, longerThan } from 'vest-utils';
 
 import { ctx } from '../../enforceContext';
 import type { RuleInstance } from '../../utils/RuleInstance';

--- a/packages/n4s/src/rules/schemaRules/tuple.ts
+++ b/packages/n4s/src/rules/schemaRules/tuple.ts
@@ -9,9 +9,13 @@ import { RuleRunReturn } from '../../utils/RuleRunReturn';
  * matches the corresponding rule. Enforces exact length unless trailing
  * elements use enforce.optional().
  *
+ * Parsed values are propagated: if a rule transforms its input (e.g. toNumber),
+ * the parsed tuple returned via `.parse()` carries the transformed values.
+ *
  * @param value - The array to validate
  * @param rules - One RuleInstance per tuple position
- * @returns RuleRunReturn indicating success or failure
+ * @returns RuleRunReturn indicating success or failure, with `.type` holding
+ *          the parsed tuple on success
  *
  * @example
  * ```typescript
@@ -28,8 +32,10 @@ import { RuleRunReturn } from '../../utils/RuleRunReturn';
 export function tuple(value: unknown, ...rules: any[]): RuleRunReturn<any> {
   if (!Array.isArray(value)) return RuleRunReturn.Failing(value);
 
+  // Determine minimum required length (all rules minus trailing optionals)
   const requiredCount = countRequired(rules);
 
+  // Reject arrays that are too short or too long
   if (value.length < requiredCount || value.length > rules.length) {
     return RuleRunReturn.Failing(value);
   }
@@ -37,6 +43,11 @@ export function tuple(value: unknown, ...rules: any[]): RuleRunReturn<any> {
   return validateElements(value, rules);
 }
 
+/**
+ * Counts the number of required (non-optional) leading positions by scanning
+ * backwards from the end of the rules array. Stops at the first non-optional
+ * rule, so only *trailing* optionals reduce the required count.
+ */
 function countRequired(rules: any[]): number {
   let count = rules.length;
   for (let i = rules.length - 1; i >= 0; i--) {
@@ -46,26 +57,41 @@ function countRequired(rules: any[]): number {
   return count;
 }
 
+/**
+ * Iterates over each rule position, validates the corresponding array element,
+ * and collects parsed output values. Returns early on the first failing element
+ * with an index-based error path.
+ */
 function validateElements(value: any[], rules: any[]): RuleRunReturn<any> {
   const parsedTuple: any[] = [];
 
   for (let i = 0; i < rules.length; i++) {
+    // Skip positions beyond the array length (only reached for trailing optionals)
     if (isBeyondArrayEnd(value, i, rules[i])) continue;
 
     const res = runElementRule(value[i], rules[i], i);
 
     if (!res.pass) return elementFailure(value, res, i);
 
+    // Use the parsed value (res.type) if the rule transformed it, otherwise keep the original
     parsedTuple.push(res.type ?? value[i]);
   }
 
   return RuleRunReturn.Passing(parsedTuple);
 }
 
+/**
+ * Checks whether the given index is past the array's actual length
+ * and the corresponding rule is optional, meaning it can be skipped.
+ */
 function isBeyondArrayEnd(value: any[], index: number, rule: any): boolean {
   return index >= value.length && isOptionalRule(rule);
 }
 
+/**
+ * Runs a single element's rule within an enforce context that carries
+ * the element value and its positional index as metadata.
+ */
 function runElementRule(
   item: any,
   rule: any,
@@ -76,6 +102,11 @@ function runElementRule(
   );
 }
 
+/**
+ * Builds a failing RuleRunReturn with an error path that includes the
+ * tuple index, prepended to any nested path from the inner rule failure.
+ * For example, a shape failure at index 1 on key "id" yields path ["1", "id"].
+ */
 function elementFailure(
   value: any[],
   res: RuleRunReturn<any>,
@@ -87,8 +118,9 @@ function elementFailure(
 }
 
 /**
- * Checks whether a rule is an optional rule by testing if it passes
- * with undefined (the same way shape detects optional fields).
+ * Determines whether a rule is optional by testing if it passes with undefined.
+ * This mirrors how shape/loose detect optional fields — a rule wrapping
+ * enforce.optional() will pass for undefined, while required rules will not.
  */
 function isOptionalRule(rule: RuleInstance<any, any>): boolean {
   if (!rule || !isFunction(rule.test)) return false;
@@ -105,7 +137,8 @@ type InferTuple<T extends RuleInstance<any, any>[]> = {
 
 /**
  * Maps a tuple of RuleInstances to their inferred input types.
- * Used for the Args parameter of the returned RuleInstance.
+ * Used for the Args parameter of the returned RuleInstance so that
+ * .test() and .parse() accept correctly typed tuple input.
  */
 type InferTupleInput<T extends RuleInstance<any, any>[]> = {
   [K in keyof T]: T[K] extends RuleInstance<any, [infer A, ...any[]]>
@@ -113,5 +146,9 @@ type InferTupleInput<T extends RuleInstance<any, any>[]> = {
     : never;
 };
 
+/**
+ * The RuleInstance type returned by enforce.tuple().
+ * Infers both output and input types from the provided rule tuple.
+ */
 export type TupleRuleInstance<T extends RuleInstance<any, any>[]> =
   RuleInstance<InferTuple<T>, [InferTupleInput<T>]>;

--- a/packages/n4s/src/rules/schemaRules/tuple.ts
+++ b/packages/n4s/src/rules/schemaRules/tuple.ts
@@ -1,0 +1,115 @@
+import { ctx } from '../../enforceContext';
+import type { RuleInstance } from '../../utils/RuleInstance';
+import { RuleRunReturn } from '../../utils/RuleRunReturn';
+
+/**
+ * Validates that a value is a fixed-length array (tuple) where each position
+ * matches the corresponding rule. Enforces exact length unless trailing
+ * elements use enforce.optional().
+ *
+ * @param value - The array to validate
+ * @param rules - One RuleInstance per tuple position
+ * @returns RuleRunReturn indicating success or failure
+ *
+ * @example
+ * ```typescript
+ * // Eager API
+ * enforce(['hello', 42]).tuple(enforce.isString(), enforce.isNumber());
+ *
+ * // Lazy API
+ * const coordSchema = enforce.tuple(enforce.isNumber(), enforce.isNumber());
+ * coordSchema.test([40.7, -74.0]); // true
+ * coordSchema.test([40.7]);        // false — too few
+ * coordSchema.test([40.7, -74, 0]);// false — too many
+ * ```
+ */
+export function tuple(value: unknown, ...rules: any[]): RuleRunReturn<any> {
+  if (!Array.isArray(value)) return RuleRunReturn.Failing(value);
+
+  const requiredCount = countRequired(rules);
+
+  if (value.length < requiredCount || value.length > rules.length) {
+    return RuleRunReturn.Failing(value);
+  }
+
+  return validateElements(value, rules);
+}
+
+function countRequired(rules: any[]): number {
+  let count = rules.length;
+  for (let i = rules.length - 1; i >= 0; i--) {
+    if (isOptionalRule(rules[i])) count = i;
+    else break;
+  }
+  return count;
+}
+
+function validateElements(value: any[], rules: any[]): RuleRunReturn<any> {
+  const parsedTuple: any[] = [];
+
+  for (let i = 0; i < rules.length; i++) {
+    if (isBeyondArrayEnd(value, i, rules[i])) continue;
+
+    const res = runElementRule(value[i], rules[i], i);
+
+    if (!res.pass) return elementFailure(value, res, i);
+
+    parsedTuple.push(res.type ?? value[i]);
+  }
+
+  return RuleRunReturn.Passing(parsedTuple);
+}
+
+function isBeyondArrayEnd(value: any[], index: number, rule: any): boolean {
+  return index >= value.length && isOptionalRule(rule);
+}
+
+function runElementRule(
+  item: any,
+  rule: any,
+  index: number,
+): RuleRunReturn<any> {
+  return ctx.run({ value: item, set: true, meta: { index } }, () =>
+    rule.run(item),
+  );
+}
+
+function elementFailure(
+  value: any[],
+  res: RuleRunReturn<any>,
+  index: number,
+): RuleRunReturn<any> {
+  const failure = RuleRunReturn.Failing(value, res.message);
+  failure.path = [index.toString(), ...(res.path || [])];
+  return failure;
+}
+
+/**
+ * Checks whether a rule is an optional rule by testing if it passes
+ * with undefined (the same way shape detects optional fields).
+ */
+function isOptionalRule(rule: RuleInstance<any, any>): boolean {
+  if (!rule || typeof rule.test !== 'function') return false;
+  return rule.test(undefined);
+}
+
+/**
+ * Maps a tuple of RuleInstances to their inferred output types.
+ * [RuleInstance<string>, RuleInstance<number>] → [string, number]
+ */
+type InferTuple<T extends RuleInstance<any, any>[]> = {
+  [K in keyof T]: T[K] extends RuleInstance<infer R, any> ? R : never;
+};
+
+/**
+ * Maps a tuple of RuleInstances to their inferred input types.
+ * Used for the Args parameter of the returned RuleInstance.
+ */
+type InferTupleInput<T extends RuleInstance<any, any>[]> = {
+  [K in keyof T]: T[K] extends RuleInstance<any, [infer A, ...any[]]>
+    ? A
+    : never;
+};
+
+export type TupleRuleInstance<T extends RuleInstance<any, any>[]> =
+  RuleInstance<InferTuple<T>, [InferTupleInput<T>]>;

--- a/packages/n4s/src/rules/schemaRules/tuple.ts
+++ b/packages/n4s/src/rules/schemaRules/tuple.ts
@@ -1,4 +1,4 @@
-import { isFunction } from 'vest-utils';
+import { isFunction, longerThan, greaterThan } from 'vest-utils';
 
 import { ctx } from '../../enforceContext';
 import type { RuleInstance } from '../../utils/RuleInstance';
@@ -36,7 +36,10 @@ export function tuple(value: unknown, ...rules: any[]): RuleRunReturn<any> {
   const requiredCount = countRequired(rules);
 
   // Reject arrays that are too short or too long
-  if (value.length < requiredCount || value.length > rules.length) {
+  if (
+    greaterThan(requiredCount, value.length) ||
+    longerThan(value, rules.length)
+  ) {
     return RuleRunReturn.Failing(value);
   }
 

--- a/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
+++ b/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
@@ -304,7 +304,7 @@ enforce.tuple(enforce.isString(), enforce.isNumber());
 // ✗ ['hello', 42, true]    — too many elements
 ```
 
-Trailing elements can be made optional:
+Only trailing elements can be made optional (elements in the middle must remain required):
 
 ```js
 enforce.tuple(enforce.isString(), enforce.optional(enforce.isNumber()));

--- a/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
+++ b/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
@@ -13,6 +13,7 @@ keywords:
     partial,
     loose,
     isArrayOf,
+    list,
     lazy,
     recursive,
     tuple,
@@ -33,7 +34,7 @@ These rules are available in `enforce`:
   - [enforce.loose() - loose shape matching](#enforceloose---loose-shape-matching)
   - [enforce.pick() - pick a subset of fields](#enforcepick---pick-a-subset-of-fields)
   - [enforce.omit() - omit a subset of fields](#enforceomit---omit-a-subset-of-fields)
-  - [enforce.isArrayOf() - array shape matching](#enforceisarrayof---array-shape-matching)
+  - [enforce.isArrayOf() / enforce.list() - array shape matching](#enforceisarrayof--enforcelist---array-shape-matching)
   - [enforce.record() - dynamic object matching](#enforcerecord---dynamic-object-matching)
   - [enforce.lazy() - recursive schemas](#enforcelazy---recursive-schemas)
   - [enforce.tuple() - fixed-length array validation](#enforcetuple---fixed-length-array-validation)
@@ -171,9 +172,11 @@ enforce({ name: 'Laura', code: 'x23', internal: true }).omit(
 // ✅ This will pass, validating only `name` and skipping `code` and `internal`
 ```
 
-## enforce.isArrayOf() - array shape matching
+## enforce.isArrayOf() / enforce.list() - array shape matching
 
-enforce.isArrayOf can be used to determine the allowed types and values within an array. It will run against each element in the array, and will only pass if all items meet at least one of the validation rules.
+`enforce.list()` is an alias for `enforce.isArrayOf()` — they are identical. Use whichever reads better alongside your other schema rules (`shape`, `tuple`, `record`, `loose`, etc.).
+
+enforce.isArrayOf (or enforce.list) can be used to determine the allowed types and values within an array. It will run against each element in the array, and will only pass if all items meet at least one of the validation rules.
 
 ```js
 enforce([1, 2, 'hello!']).isArrayOf(enforce.isString(), enforce.isNumber());

--- a/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
+++ b/website/docs/enforce/builtin-enforce-plugins/schema_rules.md
@@ -15,6 +15,7 @@ keywords:
     isArrayOf,
     lazy,
     recursive,
+    tuple,
   ]
 ---
 
@@ -35,6 +36,7 @@ These rules are available in `enforce`:
   - [enforce.isArrayOf() - array shape matching](#enforceisarrayof---array-shape-matching)
   - [enforce.record() - dynamic object matching](#enforcerecord---dynamic-object-matching)
   - [enforce.lazy() - recursive schemas](#enforcelazy---recursive-schemas)
+  - [enforce.tuple() - fixed-length array validation](#enforcetuple---fixed-length-array-validation)
 
 ## enforce.shape() - Lean schema validation.
 
@@ -288,6 +290,56 @@ const schema = enforce.shape({
 
 type Data = typeof schema.infer;
 // { name: string; metadata: { key: string; value: number } }
+```
+
+## enforce.tuple() - fixed-length array validation
+
+Use `enforce.tuple()` to validate arrays where each position has a distinct type. Unlike `isArrayOf` which applies the same rule to all elements, `tuple` maps each rule to its corresponding index and enforces exact length.
+
+```js
+enforce.tuple(enforce.isString(), enforce.isNumber());
+// ✓ ['hello', 42]
+// ✗ ['hello', 'world']    — wrong type at index 1
+// ✗ ['hello']              — too few elements
+// ✗ ['hello', 42, true]    — too many elements
+```
+
+Trailing elements can be made optional:
+
+```js
+enforce.tuple(enforce.isString(), enforce.optional(enforce.isNumber()));
+// ✓ ['hello']
+// ✓ ['hello', 42]
+```
+
+Tuple elements can be any schema rule, including nested shapes and other tuples:
+
+```js
+enforce.tuple(
+  enforce.isString(),
+  enforce.shape({ lat: enforce.isNumber(), lng: enforce.isNumber() }),
+);
+// ✓ ['location', { lat: 40.7, lng: -74.0 }]
+```
+
+### TypeScript
+
+Tuple types are inferred automatically from the rules:
+
+```ts
+const schema = enforce.tuple(enforce.isString(), enforce.isNumber());
+type T = enforce.infer<typeof schema>; // [string, number]
+```
+
+Tuples compose naturally inside shapes:
+
+```ts
+const pointSchema = enforce.shape({
+  label: enforce.isString(),
+  coords: enforce.tuple(enforce.isNumber(), enforce.isNumber()),
+});
+type Point = enforce.infer<typeof pointSchema>;
+// { label: string; coords: [number, number] }
 ```
 
 ## Schema Parsing


### PR DESCRIPTION
## Summary

- Add `enforce.tuple()` schema rule for validating fixed-length arrays where each position has a distinct type
- Support optional trailing elements via `enforce.optional()`, nested schemas (shape, tuple, isArrayOf), and error path propagation with index-based paths
- Add `enforce.infer<typeof schema>` type utility as an alias for `typeof schema.infer`
- Add `enforce.list()` as a semantic alias for `enforce.isArrayOf()` — identical runtime and types, shorter name that reads better alongside `shape`, `tuple`, `record`, `loose`
- Full eager/lazy API integration with correct TypeScript type inference for `.infer`, `.parse()`, and `.test()`
- Parse propagation: tuple correctly transforms values through parsers (custom coercions, built-in chains) both standalone and nested inside shape

## Test plan

- [x] 26 unit tests for tuple: basic validation, optional trailing, nested schemas, eager API, error reporting, RuleInstance methods, .message() override, and type inference
- [x] 4 parse integration tests proving custom coercions, built-in parser chains, nested shape parsing, and tuple-inside-shape transformations
- [x] 2 type inference tests for `.parse()` return types (standalone and nested in shape)
- [x] 5 tests for `enforce.list()`: validation, multiple rules, chaining, type inference, eager API
- [x] `enforce.infer<>` alias test added to integration type test suite
- [x] Pre-commit hooks pass (tsc, eslint, prettier)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `enforce.tuple()` for validating fixed-length tuples with specific type requirements for each element.
  * Added `enforce.list()` as an alternative name for array validation.
  * Added `enforce.infer<>` type utility to extract inferred types from validation rules.

* **Documentation**
  * Updated schema validation documentation with tuple examples, including optional elements and nested schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->