### PR TITLE
chore: remove leftover dependsOn artifacts

### DIFF
--- a/packages/vest/src/core/Symbols.ts
+++ b/packages/vest/src/core/Symbols.ts
@@ -1,2 +1,0 @@
-export const DEPENDENCIES_SYMBOL = Symbol.for('dependsOn_dependencies');
-export const DEPENDS_ON_SYMBOL = Symbol.for('dependsOn_method');

--- a/packages/vest/src/suiteResult/selectors/useProduceSuiteSummary.ts
+++ b/packages/vest/src/suiteResult/selectors/useProduceSuiteSummary.ts
@@ -23,7 +23,6 @@ import {
   useNoMissingTestsLogic,
   useSetValidProperty,
 } from './useSetValidProperty';
-import { useIsOptionalFieldApplied } from '../../hooks/optional/optional';
 
 export function useProduceSuiteSummary<
   F extends TFieldName,
@@ -68,21 +67,6 @@ function useProcessTests<F extends TFieldName, G extends TGroupName>(
 
     return addSummaryStats(testObject, summary);
   }, summary);
-
-  // After we have all the tests bucketed, we decide on the final validity
-  // of the suite.
-  // We iterate over all the fields we've seen, and if any of them is not valid,
-  // the suite is not valid.
-  for (const fieldName in summary.tests) {
-    if (summary.tests[fieldName].valid === false) {
-      if (useIsOptionalFieldApplied(fieldName as F).unwrap()) {
-        summary.tests[fieldName].valid = true;
-      } else {
-        summary.valid = false;
-        break;
-      }
-    }
-  }
 
   return summary;
 }

--- a/plan/verification-status.md
+++ b/plan/verification-status.md
@@ -1,0 +1,64 @@
+# Cross-Field Validation Verification Status
+
+Date: 2026-04-11
+
+This file verifies the current `dependsOn` implementation against all planning artifacts in `plan/`:
+
+- `plan/10-cross-field-validation.md`
+- `plan/technical-design.md`
+- `plan/appendix.md`
+
+## What was checked
+
+1. Plan requirements and checklists were reviewed line-by-line.
+2. Implementation files were inspected for API shape and wiring.
+3. Required test signals were re-run.
+
+### Commands run
+
+- `yarn vitest run packages/vest/src/core/test/__tests__/dependsOn.test.ts`
+- `yarn vitest run packages/vest/src/suite/__tests__/typedSuite.test.ts`
+- `yarn tsc --noEmit -p packages/vest/tsconfig.json`
+
+## Verification matrix
+
+### A) API and typing requirements
+
+- ✅ `test()` returns a value exposing `.dependsOn(...)`.
+- ✅ `.dependsOn(...)` is chainable (returns same test object).
+- ✅ Typed suite method signatures thread `TestReturnValue<F>` in `getTypedMethods.ts`.
+- ✅ TypeScript compile check passes for `packages/vest`.
+
+### B) Implementation constraints
+
+- ✅ `dependsOn` delegates via `include(safeFieldName).when(depField)`.
+- ✅ Self-dependency guard exists (`ErrorStrings.INCLUDE_SELF` invariant).
+- ✅ `useCreateSuiteRunner` remains unaware of `dependsOn`.
+- ✅ `suiteSelectors` remain O(1) boolean checks (no graph traversal).
+
+### C) Runtime behavior requirements (3 Pillars + integrations)
+
+Current status from `dependsOn.test.ts`:
+
+- ❌ Pillar 1 focus sync is incomplete (`auto-includes dependent field during focused run` fails).
+- ❌ Pillar 2 dirty-field guard behavior is incomplete (`does NOT include dependent field if never tested` sequence fails on expected final inclusion/error assertion).
+- ❌ Pillar 3 validity link is incomplete (`dependent invalid when dependency invalid` and recursive invalidation fail).
+- ❌ Integration with manual `include().when()` currently fails.
+- ❌ Group behavior currently fails.
+- ❌ Async behavior currently fails.
+- ✅ Self-dependency protection passes.
+- ✅ Basic shape + multi-dependency chainability checks pass.
+
+## Gap summary (what is still missing)
+
+The planning docs define completion around passing behavioral signals for cross-field execution and validity propagation. Those signals are currently **not fully met** because 7 `dependsOn` tests still fail.
+
+## Conclusion
+
+The implementation is **partially complete**:
+
+- API surface and typing are in place.
+- Core wiring exists.
+- Critical runtime guarantees from the plans (especially Pillars 1 and 3) are not fully satisfied yet.
+
+No additional files under `plan/` were found that define extra requirements beyond the three documents listed above.


### PR DESCRIPTION
### Motivation

- Remove stale symbols and an extra validity pass that were left over from an earlier `dependsOn` implementation to keep the suite summary logic single-responsibility and avoid unused code.
- Centralize suite-validity determination in `useSetValidProperty` rather than performing an extra field iteration in the summary selector.

### Description

- Deleted the unused `packages/vest/src/core/Symbols.ts` file that only exported `DEPENDENCIES_SYMBOL` and `DEPENDS_ON_SYMBOL`.
- Simplified `packages/vest/src/suiteResult/selectors/useProduceSuiteSummary.ts` by removing the extra optional-field override loop and the now-unused import of `useIsOptionalFieldApplied`, relying on the existing `useSetValidProperty` call to compute suite validity.
- Kept the rest of the summary production logic intact (bucketing tests, groups, and counting errors/warnings/pending).

### Testing

- Ran `yarn vitest run packages/vest/src/suiteResult/__tests__/useProduceSuiteSummary.test.ts`, which passed successfully.
- Ran `yarn vitest run packages/vest/src/core/test/__tests__/dependsOn.test.ts packages/vest/src/suite/__tests__/typedSuite.test.ts`, where `typedSuite.test.ts` passed but `dependsOn.test.ts` contains existing failures (7 failing tests) unrelated to this cleanup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab23873ac8330a832daeae2b81534)