### PR TITLE
Fix grammar in custom rule docs

### DIFF
--- a/website/docs/enforce/creating_custom_rules.md
+++ b/website/docs/enforce/creating_custom_rules.md
@@ -1,4 +1,3 @@
-
 ---
 sidebar_position: 4
 title: Creating custom enforce rules

--- a/website/docs/enforce/creating_custom_rules.md
+++ b/website/docs/enforce/creating_custom_rules.md
@@ -1,3 +1,4 @@
+
 ---
 sidebar_position: 4
 title: Creating custom enforce rules
@@ -64,7 +65,7 @@ enforce(user.email).isValidEmail();
 
 ## Custom rules return value
 
-Rules can either return boolean indicating success or failure, or an object with two keys. `pass` indicates whether the validation is successful or not, and message provides a function with no arguments that return an error message in case of failure. Thus, when pass is false, message should return the error message for when enforce(x).yourRule() fails.
+Rules can either return boolean indicating success or failure, or an object with two keys. `pass` indicates whether the validation is successful or not, and message provides a function with no arguments that returns an error message in case of failure. Thus, when pass is false, message should return the error message for when enforce(x).yourRule() fails.
 
 ```js
 enforce.extend({


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Please fill the following form (leave what's relevant)
-->

| Q                | A   |
| ---------------- | --- |
| Bug fix?         | ✖ |
| New feature?     | ✖ |
| Breaking change? | ✖ |
| Deprecations?    | ✖ |
| Documentation?   | ✔ |
| Tests added?     | ✖ |
| Types added?     | ✖ |
| Related issues   |     |

<!-- Describe your changes below in detail. -->

Fixes a small grammar issue in the custom rule documentation:

- `function ... return` -> `function ... returns`

This is a documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for custom rules to clarify return value options (boolean or object with `pass` and `message` function) and error message generation behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ealush/vest/pull/1295)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->