### PR TITLE
Add structured failure types to suite issue handling

### DIFF
--- a/packages/n4s/src/__tests__/issue.test.ts
+++ b/packages/n4s/src/__tests__/issue.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { enforce } from '../n4s';
+
+describe('structured issues', () => {
+  it('decorates the immediately preceding rule', () => {
+    const rule = enforce
+      .isString()
+      .issue({ code: 'not_string', message: 'Must be text' })
+      .longerThanOrEquals(5)
+      .issue({ code: 'too_short', message: 'Use at least 5 characters' });
+
+    // @ts-expect-error - Exercising the runtime type guard.
+    expect(rule.validate(42)).toEqual({
+      issues: [
+        {
+          code: 'not_string',
+          message: 'Must be text',
+          meta: { actual: { type: 'number' }, rule: 'isString' },
+          path: [],
+        },
+      ],
+    });
+
+    expect(rule.validate('abc')).toEqual({
+      issues: [
+        {
+          code: 'too_short',
+          message: 'Use at least 5 characters',
+          meta: {
+            actual: { length: 3, type: 'string' },
+            inclusive: true,
+            minimum: 5,
+            rule: 'longerThanOrEquals',
+          },
+          path: [],
+        },
+      ],
+    });
+  });
+
+  it('derives the path while preserving field rule metadata through shapes', () => {
+    const schema = enforce.shape({
+      account: enforce.shape({
+        password: enforce.isString().longerThanOrEquals(12).issue({
+          code: 'too_short',
+          message: 'Password must contain at least 12 characters',
+        }),
+      }),
+    });
+
+    expect(schema.validate({ account: { password: 'secret' } })).toEqual({
+      issues: [
+        {
+          code: 'too_short',
+          message: 'Password must contain at least 12 characters',
+          meta: {
+            actual: { length: 6, type: 'string' },
+            inclusive: true,
+            minimum: 12,
+            rule: 'longerThanOrEquals',
+          },
+          path: ['account', 'password'],
+        },
+      ],
+    });
+  });
+
+  it('does not expose rejected values or opaque rule arguments', () => {
+    const rejected = 'private@example.com';
+    const rule = enforce
+      .isString()
+      .equals('another-private@example.com')
+      .issue({ code: 'mismatch', message: 'Values do not match' });
+
+    const result = rule.validate(rejected);
+
+    expect(JSON.stringify(result)).not.toContain(rejected);
+    expect(JSON.stringify(result)).not.toContain('another-private@example.com');
+  });
+});

--- a/packages/n4s/src/extendLogic.ts
+++ b/packages/n4s/src/extendLogic.ts
@@ -53,7 +53,10 @@ export function extendEnforce(
     };
 
     enforce[ruleName] = (...args: any[]) =>
-      addToChain({}, (value: any) => ruleWrapper(value, ...args));
+      addToChain({}, (value: any) => ruleWrapper(value, ...args), {
+        args,
+        rule: ruleName,
+      });
 
     registerLazyRule(
       ruleName,

--- a/packages/n4s/src/issue.ts
+++ b/packages/n4s/src/issue.ts
@@ -1,0 +1,100 @@
+export type IssueConfig = {
+  code: string;
+  message: string;
+};
+
+export type EnforceIssue = IssueConfig & {
+  meta: Readonly<Record<string, unknown>>;
+  path?: ReadonlyArray<string | number>;
+};
+
+export type RuleDescriptor = {
+  args: readonly unknown[];
+  issue?: IssueConfig;
+  rule: string;
+};
+
+export function deriveIssueMeta(
+  descriptor: RuleDescriptor,
+  value: unknown,
+): Readonly<Record<string, unknown>> {
+  const constraint = deriveConstraint(descriptor.rule, descriptor.args);
+  const actual = describeActual(value);
+
+  return {
+    rule: descriptor.rule,
+    ...constraint,
+    ...(actual === undefined ? {} : { actual }),
+  };
+}
+
+function deriveConstraint(
+  rule: string,
+  args: readonly unknown[],
+): Record<string, unknown> {
+  return constraintDerivers[rule]?.(args) ?? {};
+}
+
+const minimumExclusive = ([minimum]: readonly unknown[]) => ({
+  inclusive: false,
+  minimum,
+});
+const minimumInclusive = ([minimum]: readonly unknown[]) => ({
+  inclusive: true,
+  minimum,
+});
+const maximumExclusive = ([maximum]: readonly unknown[]) => ({
+  inclusive: false,
+  maximum,
+});
+const maximumInclusive = ([maximum]: readonly unknown[]) => ({
+  inclusive: true,
+  maximum,
+});
+
+const constraintDerivers: Record<
+  string,
+  (args: readonly unknown[]) => Record<string, unknown>
+> = {
+  greaterThan: minimumExclusive,
+  greaterThanOrEquals: minimumInclusive,
+  gt: minimumExclusive,
+  gte: minimumInclusive,
+  isBetween: ([minimum, maximum]) => ({
+    inclusive: true,
+    maximum,
+    minimum,
+  }),
+  lengthEquals: ([length]) => ({ length }),
+  lengthNotEquals: ([disallowedLength]) => ({ disallowedLength }),
+  lessThan: maximumExclusive,
+  lessThanOrEquals: maximumInclusive,
+  longerThan: minimumExclusive,
+  longerThanOrEquals: minimumInclusive,
+  lt: maximumExclusive,
+  lte: maximumInclusive,
+  maxLength: maximumInclusive,
+  minLength: minimumInclusive,
+  shorterThan: maximumExclusive,
+  shorterThanOrEquals: maximumInclusive,
+};
+
+function describeActual(value: unknown): Record<string, unknown> | undefined {
+  if (Array.isArray(value)) {
+    return { length: value.length, type: 'array' };
+  }
+
+  if (typeof value === 'string') {
+    return { length: value.length, type: 'string' };
+  }
+
+  if (value === null) {
+    return { type: 'null' };
+  }
+
+  if (value === undefined) {
+    return { type: 'undefined' };
+  }
+
+  return { type: typeof value };
+}

--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -87,30 +87,42 @@ const schemaAttacher =
 const schemaRulesWithArrayChaining = {
   ...schemaModifiers,
   isArrayOf: <T>(...rules: any[]): ArrayRuleInstance<T> =>
-    addToChain<ArrayRuleInstance<T>>(arrayRules, (value: any) => {
-      const result = ctx.run({ value }, () =>
-        schemaRules.isArrayOf(value, ...rules),
-      );
-      return RuleRunReturn.create(result, value);
-    }),
+    addToChain<ArrayRuleInstance<T>>(
+      arrayRules,
+      (value: any) => {
+        const result = ctx.run({ value }, () =>
+          schemaRules.isArrayOf(value, ...rules),
+        );
+        return RuleRunReturn.create(result, value);
+      },
+      { args: rules, rule: 'isArrayOf' },
+    ),
   lazy: lazyRule,
   list: <T>(...rules: any[]): ArrayRuleInstance<T> =>
-    addToChain<ArrayRuleInstance<T>>(arrayRules, (value: any) => {
-      const result = ctx.run({ value }, () =>
-        schemaRules.isArrayOf(value, ...rules),
-      );
-      return RuleRunReturn.create(result, value);
-    }),
+    addToChain<ArrayRuleInstance<T>>(
+      arrayRules,
+      (value: any) => {
+        const result = ctx.run({ value }, () =>
+          schemaRules.isArrayOf(value, ...rules),
+        );
+        return RuleRunReturn.create(result, value);
+      },
+      { args: rules, rule: 'list' },
+    ),
   loose: schemaAttacher(schemaEvaluators.loose),
   record: recordEvaluators.record,
   shape: schemaAttacher(schemaEvaluators.shape),
   tuple: (...rules: any[]) =>
-    addToChain(arrayRules, (value: any) => {
-      const result = ctx.run({ value }, () =>
-        schemaRules.tuple(value, ...rules),
-      );
-      return RuleRunReturn.create(result, value);
-    }),
+    addToChain(
+      arrayRules,
+      (value: any) => {
+        const result = ctx.run({ value }, () =>
+          schemaRules.tuple(value, ...rules),
+        );
+        return RuleRunReturn.create(result, value);
+      },
+      { args: rules, rule: 'tuple' },
+    ),
 };
 
 const baseEnforceLazy = {

--- a/packages/n4s/src/lazy/ruleAdapter.ts
+++ b/packages/n4s/src/lazy/ruleAdapter.ts
@@ -10,13 +10,17 @@ export function adaptDynamicRules<
   return Object.keys(container).reduce(
     (acc, key) => {
       acc[key as keyof O] = (...args: any[]) =>
-        addToChain({}, (value: any) => {
-          // eslint-disable-next-line max-nested-callbacks
-          const result = ctx.run({ value }, () =>
-            container[key as keyof O](value, ...args),
-          );
-          return RuleRunReturn.create(result, value);
-        });
+        addToChain(
+          {},
+          (value: any) => {
+            // eslint-disable-next-line max-nested-callbacks
+            const result = ctx.run({ value }, () =>
+              container[key as keyof O](value, ...args),
+            );
+            return RuleRunReturn.create(result, value);
+          },
+          { args, rule: key },
+        );
       return acc;
     },
     {} as Record<keyof typeof container, (...args: any[]) => T>,

--- a/packages/n4s/src/lazy/typeRules.ts
+++ b/packages/n4s/src/lazy/typeRules.ts
@@ -69,15 +69,31 @@ type LazyStringRuleInstance = BuildRuleInstance<
 
 export const typeRules = {
   isArray: <T = any>(): LazyArrayRuleInstance<T> =>
-    addToChain<LazyArrayRuleInstance<T>>(lazyArrayRules, isArray),
-  isBoolean: (): BooleanRuleInstance => addToChain(booleanRules, isBoolean),
-  isNull: (): NullRuleInstance => addToChain({}, isNull),
-  isNullish: (): NullishRuleInstance => addToChain({}, isNullish),
+    addToChain<LazyArrayRuleInstance<T>>(lazyArrayRules, isArray, {
+      args: [],
+      rule: 'isArray',
+    }),
+  isBoolean: (): BooleanRuleInstance =>
+    addToChain(booleanRules, isBoolean, { args: [], rule: 'isBoolean' }),
+  isNull: (): NullRuleInstance =>
+    addToChain({}, isNull, { args: [], rule: 'isNull' }),
+  isNullish: (): NullishRuleInstance =>
+    addToChain({}, isNullish, { args: [], rule: 'isNullish' }),
   isNumber: (): LazyNumberRuleInstance =>
-    addToChain<LazyNumberRuleInstance>(lazyNumberRules, isNumber),
+    addToChain<LazyNumberRuleInstance>(lazyNumberRules, isNumber, {
+      args: [],
+      rule: 'isNumber',
+    }),
   isNumeric: (): LazyNumericRuleInstance =>
-    addToChain<LazyNumericRuleInstance>(lazyNumberRules, isNumeric),
+    addToChain<LazyNumericRuleInstance>(lazyNumberRules, isNumeric, {
+      args: [],
+      rule: 'isNumeric',
+    }),
   isString: (): LazyStringRuleInstance =>
-    addToChain<LazyStringRuleInstance>(lazyStringRules, isString),
-  isUndefined: (): UndefinedRuleInstance => addToChain({}, isUndefined),
+    addToChain<LazyStringRuleInstance>(lazyStringRules, isString, {
+      args: [],
+      rule: 'isString',
+    }),
+  isUndefined: (): UndefinedRuleInstance =>
+    addToChain({}, isUndefined, { args: [], rule: 'isUndefined' }),
 };

--- a/packages/n4s/src/n4s.ts
+++ b/packages/n4s/src/n4s.ts
@@ -7,6 +7,8 @@ import { extendEnforce } from './extendLogic';
 import { enforceLazy } from './lazy';
 import type { RuleInstance } from './utils/RuleInstance';
 
+export type { EnforceIssue, IssueConfig } from './issue';
+
 /**
  * Context API for accessing validation context.
  * Allows accessing metadata and parent validation context during rule execution.

--- a/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
+++ b/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
@@ -9,8 +9,14 @@ import {
 import { StandardSchemaV1 } from 'vest-utils/standardSchemaSpec';
 
 import { RuleInstance } from '../../utils/RuleInstance';
+import type { RuleRunReturn } from '../../utils/RuleRunReturn';
+import type { IssueConfig, RuleDescriptor } from '../../issue';
 
-import { executeChain, type Predicate } from './chainExecutor';
+import {
+  executeChain,
+  type ChainPredicate,
+  type Predicate,
+} from './chainExecutor';
 import { createChainProxyHandlers } from './proxyHandlers';
 
 export type RuleFunctions<T extends RuleInstance<any, any>> = Record<
@@ -31,17 +37,20 @@ type LazyMessage = DynamicValue<
 export function createChainBuilder<T extends RuleInstance<any, any>>(
   rules: RuleFunctions<T> | Record<string, (...args: any[]) => any>,
 ) {
-  const chain: Predicate[] = [];
+  const chain: ChainPredicate[] = [];
   const target: Partial<T> = {};
   let lazyMessage: Maybe<LazyMessage> = undefined;
+  let lastAdded: ChainPredicate | undefined;
 
-  const add = (p: Predicate): T => {
-    chain.push(p);
+  const add = (p: Predicate, descriptor: RuleDescriptor): T => {
+    lastAdded = { descriptor, predicate: p };
+    chain.push(lastAdded);
     return proxy;
   };
 
-  const prepend = (p: Predicate): T => {
-    chain.unshift(p);
+  const prepend = (p: Predicate, descriptor: RuleDescriptor): T => {
+    lastAdded = { descriptor, predicate: p };
+    chain.unshift(lastAdded);
     return proxy;
   };
 
@@ -62,12 +71,7 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
       return { value: result.type };
     }
     return {
-      issues: [
-        {
-          message: resolveMessage(result, args[0]),
-          path: result.path || [],
-        },
-      ],
+      issues: [toStandardIssue(result, resolveMessage(result, args[0]))],
     };
   }) as T['validate'];
 
@@ -107,6 +111,14 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
     return proxy;
   };
 
+  const issue = (config: IssueConfig): T => {
+    if (!lastAdded) {
+      throw new TypeError('issue() must follow an enforce rule');
+    }
+    lastAdded.descriptor.issue = config;
+    return proxy;
+  };
+
   const proxy: T = new Proxy(
     target as T,
     createChainProxyHandlers(rules, {
@@ -120,6 +132,7 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
         version: 1 as const,
       } as StandardSchemaV1.Props<any, any>,
       add,
+      issue,
       message,
       parse,
       prepend,
@@ -130,4 +143,11 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
   );
 
   return { add, proxy } as const;
+}
+
+function toStandardIssue(result: RuleRunReturn<any>, message: string) {
+  return Object.assign(
+    { message, path: result.path || [] },
+    result.issue ? { code: result.issue.code, meta: result.issue.meta } : {},
+  );
 }

--- a/packages/n4s/src/rules/chainBuilder/chainExecutor.ts
+++ b/packages/n4s/src/rules/chainBuilder/chainExecutor.ts
@@ -1,29 +1,56 @@
 import { isObject } from 'vest-utils';
 
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
+import { deriveIssueMeta, type RuleDescriptor } from '../../issue';
 
 export type Predicate = (value: any) => boolean | RuleRunReturn<any>;
+
+export type ChainPredicate = {
+  descriptor: RuleDescriptor;
+  predicate: Predicate;
+};
 
 function isRuleRunReturn(result: any): result is RuleRunReturn<any> {
   return isObject(result) && 'pass' in result;
 }
 
 export function executeChain(
-  chain: Predicate[],
+  chain: ChainPredicate[],
   value: any,
 ): RuleRunReturn<any> {
   let currentValue = value;
 
-  for (const predicate of chain) {
-    const result = predicate(currentValue);
+  for (const entry of chain) {
+    const result = entry.predicate(currentValue);
 
     if (isRuleRunReturn(result)) {
-      if (!result.pass) return result as RuleRunReturn<any>;
+      if (!result.pass) return withIssue(result, entry, currentValue);
       currentValue = result.type;
     } else if (!result) {
-      return RuleRunReturn.Failing(currentValue);
+      return withIssue(
+        RuleRunReturn.Failing(currentValue),
+        entry,
+        currentValue,
+      );
     }
   }
 
   return RuleRunReturn.Passing(currentValue);
+}
+
+function withIssue(
+  result: RuleRunReturn<any>,
+  entry: ChainPredicate,
+  value: unknown,
+): RuleRunReturn<any> {
+  if (!entry.descriptor.issue || result.issue) {
+    return result;
+  }
+
+  result.message = entry.descriptor.issue.message;
+  result.issue = {
+    ...entry.descriptor.issue,
+    meta: deriveIssueMeta(entry.descriptor, value),
+  };
+  return result;
 }

--- a/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
+++ b/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
@@ -5,12 +5,14 @@ import { RuleInstance } from '../../utils/RuleInstance';
 import { CHAIN_PREPEND } from '../parsers/parserUtils';
 
 import type { Predicate } from './chainExecutor';
+import type { IssueConfig, RuleDescriptor } from '../../issue';
 import { getLazyRule } from './lazyRegistry';
 
 export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
   rules: Record<string, (...args: any[]) => any>,
   {
     add,
+    issue,
     test,
     validate,
     run,
@@ -19,18 +21,20 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
     prepend,
     '~standard': standard,
   }: {
-    add: (p: Predicate) => T;
+    add: (p: Predicate, descriptor: RuleDescriptor) => T;
+    issue: (config: IssueConfig) => T;
     test: T['test'];
     validate: T['validate'];
     run: T['run'];
     parse: T['parse'];
     message: (msg: any) => T;
-    prepend: (p: Predicate) => T;
+    prepend: (p: Predicate, descriptor: RuleDescriptor) => T;
     '~standard': StandardSchemaV1.Props<any, any>;
   },
 ) {
   const methods = {
     '~standard': standard,
+    issue,
     message,
     parse,
     run,
@@ -39,6 +43,7 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
   };
   const methodKeys = new Set([
     'infer',
+    'issue',
     'test',
     'validate',
     'run',
@@ -57,7 +62,10 @@ function createProxyHandlersHelper<T extends RuleInstance<any, any>>(
   rules: Record<string, any>,
   methods: Record<string, any>,
   methodKeys: Set<string>,
-  inserters: { add: (p: Predicate) => T; prepend: (p: Predicate) => T },
+  inserters: {
+    add: (p: Predicate, descriptor: RuleDescriptor) => T;
+    prepend: (p: Predicate, descriptor: RuleDescriptor) => T;
+  },
 ) {
   function getRuleHandler(prop: string | symbol) {
     if (hasOwnProperty(rules, prop)) {
@@ -65,13 +73,17 @@ function createProxyHandlersHelper<T extends RuleInstance<any, any>>(
         ? inserters.prepend
         : inserters.add;
       return (...args: any[]) =>
-        insert((value: any) => rules[prop](value, ...args));
+        insert((value: any) => rules[prop](value, ...args), {
+          args,
+          rule: String(prop),
+        });
     }
 
     if (typeof prop === 'string') {
       const lazyRule = getLazyRule(prop);
       if (lazyRule) {
-        return (...args: any[]) => inserters.add(lazyRule(...args));
+        return (...args: any[]) =>
+          inserters.add(lazyRule(...args), { args, rule: prop });
       }
     }
 

--- a/packages/n4s/src/rules/genRuleChain.ts
+++ b/packages/n4s/src/rules/genRuleChain.ts
@@ -5,6 +5,7 @@ import {
   type RuleFunctions,
 } from './chainBuilder/chainBuilder';
 import { type Predicate } from './chainBuilder/chainExecutor';
+import type { RuleDescriptor } from '../issue';
 import { registerLazyRule } from './chainBuilder/lazyRegistry';
 
 export { registerLazyRule };
@@ -15,8 +16,9 @@ export { registerLazyRule };
 export function addToChain<T extends RuleInstance<any, any>>(
   rules: RuleFunctions<T> | Record<string, (...args: any[]) => any>,
   predicate: Predicate,
+  descriptor: RuleDescriptor = { args: [], rule: 'custom' },
 ): T {
   const { add, proxy } = createChainBuilder<T>(rules);
-  add(predicate);
+  add(predicate, descriptor);
   return proxy as T;
 }

--- a/packages/n4s/src/rules/schemaRules/lazy.ts
+++ b/packages/n4s/src/rules/schemaRules/lazy.ts
@@ -41,8 +41,12 @@ export function lazy<T>(
     return cached;
   };
 
-  return addToChain<LazyRuleInstance<T>>({}, (value: any) => {
-    const result = ctx.run({ value }, () => resolve().run(value));
-    return RuleRunReturn.create(result, value);
-  });
+  return addToChain<LazyRuleInstance<T>>(
+    {},
+    (value: any) => {
+      const result = ctx.run({ value }, () => resolve().run(value));
+      return RuleRunReturn.create(result, value);
+    },
+    { args: [factory], rule: 'lazy' },
+  );
 }

--- a/packages/n4s/src/rules/schemaRules/tuple.ts
+++ b/packages/n4s/src/rules/schemaRules/tuple.ts
@@ -116,6 +116,7 @@ function elementFailure(
   index: number,
 ): RuleRunReturn<any> {
   const failure = RuleRunReturn.Failing(value, res.message);
+  failure.issue = res.issue;
   failure.path = [index.toString(), ...(res.path || [])];
   return failure;
 }

--- a/packages/n4s/src/utils/RuleInstance.ts
+++ b/packages/n4s/src/utils/RuleInstance.ts
@@ -1,6 +1,7 @@
 import { StandardSchemaV1 } from 'vest-utils/standardSchemaSpec';
 
 import { RuleRunReturn } from './RuleRunReturn';
+import type { IssueConfig } from '../issue';
 
 /**
  * Represents a lazy validation rule that can be executed with a value.
@@ -44,6 +45,8 @@ export class RuleInstance<T, Args extends any[] = any[]> {
   // Type-only declaration for parse helper that throws on issues
   parse!: (...args: Args) => T;
 
+  issue!: (config: IssueConfig) => this;
+
   // Type-only declaration for StandardSchema property.
   // The intersection with `{ readonly types: ... }` narrows `types` from optional
   // (as declared in StandardSchemaV1.Props) to required. This is safe because
@@ -77,7 +80,9 @@ export class RuleInstance<T, Args extends any[] = any[]> {
       return {
         issues: [
           {
-            message: result.message || 'Validation failed',
+            ...(result.issue ?? {
+              message: result.message || 'Validation failed',
+            }),
             path: result.path || [],
           },
         ],
@@ -110,8 +115,8 @@ export class RuleInstance<T, Args extends any[] = any[]> {
         version: 1 as const,
       },
       infer: {} as T,
-      run,
       parse,
+      run,
       test: (...args: Args) => {
         const result = validate(...args);
         return !result.issues;

--- a/packages/n4s/src/utils/RuleRunReturn.ts
+++ b/packages/n4s/src/utils/RuleRunReturn.ts
@@ -1,4 +1,5 @@
 import { isBoolean, Stringable, dynamicValue } from 'vest-utils';
+import type { EnforceIssue } from '../issue';
 
 /**
  * Represents the result of a validation rule execution.
@@ -25,6 +26,7 @@ export class RuleRunReturn<T> {
   /** Optional error message if validation failed */
   message?: string;
   path?: string[];
+  issue?: Omit<EnforceIssue, 'path'>;
 
   constructor(pass: boolean, type: T, message?: string) {
     this.pass = pass;
@@ -76,7 +78,7 @@ export class RuleRunReturn<T> {
       dynamicValue(message ?? pass.message, type),
     );
 
-    res.path = pass.path;
+    Object.assign(res, { issue: pass.issue, path: pass.path });
 
     return res;
   }

--- a/packages/vest/src/core/isolate/IsolateTest/IsolateTest.ts
+++ b/packages/vest/src/core/isolate/IsolateTest/IsolateTest.ts
@@ -7,7 +7,7 @@ import {
   IsolateTestStateMachine,
   TestStatus,
 } from '../../StateMachines/IsolateTestStateMachine';
-import { AsyncTest, TestFn } from '../../test/TestTypes';
+import { AsyncTest, TestFn, TestIssue } from '../../test/TestTypes';
 import { VestIsolateType } from '../VestIsolateType';
 
 export type TIsolateTest<F extends TFieldName = TFieldName> = TIsolate<
@@ -27,6 +27,10 @@ export function IsolateTest<F extends TFieldName = TFieldName>(
 
   if (input.message) {
     payload.message = input.message;
+  }
+
+  if (input.issue) {
+    payload.issue = input.issue;
   }
 
   const isolate = Isolate.create<IsolateTestPayload>(
@@ -54,6 +58,7 @@ export type IsolateTestPayload<F extends TFieldName = TFieldName> =
   };
 
 type CommonTestFields<F extends TFieldName = TFieldName> = {
+  issue?: TestIssue;
   message?: Maybe<string>;
   fieldName: F;
   testFn: TestFn;

--- a/packages/vest/src/core/test/TestTypes.ts
+++ b/packages/vest/src/core/test/TestTypes.ts
@@ -8,7 +8,14 @@ export type TestFn = (payload: TestFnPayload) => TestResult;
 export type AsyncTest = Promise<void>;
 export type TestResult = Maybe<AsyncTest | boolean> | void;
 
-export type TestMessage = string | undefined;
+export type TestIssue = {
+  code: string;
+  message: string;
+  meta?: Readonly<Record<string, unknown>>;
+  path?: ReadonlyArray<string | number>;
+};
+
+export type TestMessage = string | TestIssue | undefined;
 
 export type WithFieldName<F extends TFieldName = TFieldName> = {
   fieldName: F;

--- a/packages/vest/src/core/test/test.ts
+++ b/packages/vest/src/core/test/test.ts
@@ -31,12 +31,13 @@ function vestTest(
 ): TIsolateTest {
   const {
     fieldName: safeFieldName,
+    issue,
     message,
     testFn,
     key,
   } = validateTestParams(fieldName, ...args).unwrap();
 
-  const testObjectInput = { fieldName: safeFieldName, message, testFn };
+  const testObjectInput = { fieldName: safeFieldName, issue, message, testFn };
 
   // This invalidates the suite cache.
   useEmit('TEST_RUN_STARTED');

--- a/packages/vest/src/core/test/validateTestParams.ts
+++ b/packages/vest/src/core/test/validateTestParams.ts
@@ -11,12 +11,13 @@ import { IsolateKey } from 'vestjs-runtime';
 import { ErrorStrings } from '../../errors/ErrorStrings';
 import { TFieldName } from '../../suiteResult/SuiteResultTypes';
 
-import { TestFn, TestMessage } from './TestTypes';
+import { TestFn, TestIssue, TestMessage } from './TestTypes';
 
 export type TestParams<F extends TFieldName = TFieldName> = {
   fieldName: F;
   key?: IsolateKey;
-  message?: TestMessage;
+  issue?: TestIssue;
+  message?: string;
   testFn: TestFn;
 };
 
@@ -34,7 +35,7 @@ export function validateTestParams(
     );
   }
 
-  const [message, testFn, key] = (
+  const [messageOrIssue, testFn, key] = (
     isFunction(rest[1]) ? rest : [undefined, ...rest]
   ) as [TestMessage, TestFn, IsolateKey | undefined];
 
@@ -50,8 +51,15 @@ export function validateTestParams(
 
   return makeResult.Ok({
     fieldName: makeBrand<TFieldName>(fieldName),
+    ...normalizeMessage(messageOrIssue),
     key,
-    message,
     testFn,
   });
+}
+
+function normalizeMessage(messageOrIssue: TestMessage) {
+  if (typeof messageOrIssue === 'object' && messageOrIssue !== null) {
+    return { issue: messageOrIssue, message: messageOrIssue.message };
+  }
+  return { message: messageOrIssue };
 }

--- a/packages/vest/src/suite/__tests__/schema.structuredIssues.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.structuredIssues.test.ts
@@ -1,0 +1,47 @@
+import { enforce } from 'n4s';
+import { describe, expect, it } from 'vitest';
+
+import { create } from '../../vest';
+
+describe('schema structured issues', () => {
+  it('transports n4s issue details into Vest results', () => {
+    const suite = create(
+      () => {},
+      enforce.shape({
+        account: enforce.shape({
+          password: enforce.isString().longerThanOrEquals(12).issue({
+            code: 'too_short',
+            message: 'Password must contain at least 12 characters',
+          }),
+        }),
+      }),
+    );
+
+    const result = suite.run({ account: { password: 'secret' } });
+
+    expect(result.errors[0]).toMatchObject({
+      code: 'too_short',
+      fieldName: 'account.password',
+      meta: {
+        actual: { length: 6, type: 'string' },
+        inclusive: true,
+        minimum: 12,
+        rule: 'longerThanOrEquals',
+      },
+      path: ['account', 'password'],
+    });
+    expect(result.issues).toEqual([
+      {
+        code: 'too_short',
+        message: 'Password must contain at least 12 characters',
+        meta: {
+          actual: { length: 6, type: 'string' },
+          inclusive: true,
+          minimum: 12,
+          rule: 'longerThanOrEquals',
+        },
+        path: ['account', 'password'],
+      },
+    ]);
+  });
+});

--- a/packages/vest/src/suite/getStandardSchema.ts
+++ b/packages/vest/src/suite/getStandardSchema.ts
@@ -13,13 +13,24 @@ export function getStandardSchema<S extends TSchema = undefined>(
         return { value: value as InferSchemaData<S> };
       }
       return {
-        issues: result.errors.map((error: any) => ({
-          ...(error.message === undefined ? {} : { message: error.message }),
-          path: error.fieldName ? error.fieldName.split('.') : undefined,
-        })),
+        issues: result.errors.map(toStandardIssue),
       };
     },
     vendor: 'vest',
     version: 1,
   };
+}
+
+function toStandardIssue(error: any) {
+  const issue: any = { path: getIssuePath(error) };
+  if (error.message !== undefined) issue.message = error.message;
+  if (error.code !== undefined) issue.code = error.code;
+  if (error.meta !== undefined) issue.meta = error.meta;
+  return issue;
+}
+
+function getIssuePath(error: any) {
+  if (error.path !== undefined) return error.path;
+  if (error.fieldName === undefined) return undefined;
+  return error.fieldName.split('.');
 }

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -16,6 +16,7 @@ import { SuiteContext } from '../core/context/SuiteContext';
 import { IsolateReorderable } from 'vestjs-runtime';
 import { IsolateSuite } from '../core/isolate/IsolateSuite/IsolateSuite';
 import { test } from '../core/test/test';
+import type { TestIssue } from '../core/test/TestTypes';
 import { only, skip } from '../hooks/focused/focused';
 import {
   SuiteResult,
@@ -30,6 +31,7 @@ import { useCreateSuiteResult } from '../suiteResult/suiteResult';
 import { SuiteModifiers, SuiteCallbackWithSchema } from './SuiteTypes';
 
 type SchemaRunResult = {
+  readonly issue?: Omit<TestIssue, 'path'>;
   readonly message?: string;
   readonly pass: boolean;
   readonly path?: readonly string[];
@@ -282,7 +284,12 @@ function runSchemaValidation<S extends TSchema = undefined>(
 
       const fieldName = error.path?.length ? error.path.join('.') : '__root__';
       const testKey = `${fieldName}_${i}`;
-      test(fieldName, error.message, () => false, testKey);
+      test(
+        fieldName,
+        error.issue ? { ...error.issue, path: error.path } : error.message,
+        () => false,
+        testKey,
+      );
     }
   };
 }
@@ -422,6 +429,7 @@ function normalizeSingleSchemaRunResult(
   }
 
   return {
+    issue: candidate.issue,
     message: candidate.message,
     pass: candidate.pass,
     path: candidate.path,

--- a/packages/vest/src/suiteResult/SummaryFailure.ts
+++ b/packages/vest/src/suiteResult/SummaryFailure.ts
@@ -1,6 +1,7 @@
 import { TIsolateTest } from '../core/isolate/IsolateTest/IsolateTest';
 import { VestTest } from '../core/isolate/IsolateTest/VestTest';
 import { WithFieldName } from '../core/test/TestTypes';
+import type { TestIssue } from '../core/test/TestTypes';
 
 import { TFieldName, TGroupName } from './SuiteResultTypes';
 
@@ -12,14 +13,25 @@ export class SummaryFailure<
     public fieldName: F,
     public message: string | undefined,
     public groupName: G | undefined,
-  ) {}
+    issue?: TestIssue,
+  ) {
+    if (issue) {
+      this.code = issue.code;
+      this.meta = issue.meta;
+      this.path = issue.path;
+    }
+  }
+
+  public code?: string;
+  public meta?: Readonly<Record<string, unknown>>;
+  public path?: ReadonlyArray<string | number>;
 
   static fromTestObject<F extends TFieldName, G extends TGroupName>(
     testObject: TIsolateTest<F>,
   ): SummaryFailure<F, G> {
-    const { fieldName, message } = VestTest.getData(testObject);
+    const { fieldName, issue, message } = VestTest.getData(testObject);
     const groupName = VestTest.getGroupName<G>(testObject);
 
-    return new SummaryFailure<F, G>(fieldName, message, groupName);
+    return new SummaryFailure<F, G>(fieldName, message, groupName, issue);
   }
 }

--- a/packages/vest/src/suiteResult/__tests__/structuredIssues.test.ts
+++ b/packages/vest/src/suiteResult/__tests__/structuredIssues.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { create, test } from '../../vest';
+
+describe('structured issues', () => {
+  const issue = {
+    code: 'too_short',
+    message: 'Password must contain at least 12 characters',
+    meta: { minimum: 12 },
+    path: ['account', 'password'],
+  } as const;
+
+  it('preserves structured failure data while keeping string selectors compatible', () => {
+    const suite = create(() => {
+      test('account.password', issue, () => false);
+    });
+
+    const result = suite.run();
+
+    expect(result.getErrors('account.password')).toEqual([issue.message]);
+    expect(result.errors[0]).toMatchObject({
+      code: issue.code,
+      fieldName: 'account.password',
+      message: issue.message,
+      meta: issue.meta,
+      path: issue.path,
+    });
+    expect(result.issues).toEqual([
+      {
+        code: issue.code,
+        message: issue.message,
+        meta: issue.meta,
+        path: issue.path,
+      },
+    ]);
+  });
+
+  it('exposes structured issues through Standard Schema', () => {
+    const suite = create(() => {
+      test('account.password', issue, () => false);
+    });
+
+    expect(suite['~standard'].validate({})).toEqual({
+      issues: [
+        {
+          code: issue.code,
+          message: issue.message,
+          meta: issue.meta,
+          path: issue.path,
+        },
+      ],
+    });
+  });
+
+  it('keeps the existing issue path for string messages', () => {
+    const suite = create(() => {
+      test('account.password', 'Invalid password', () => false);
+    });
+
+    expect(suite.run().issues).toEqual([
+      { message: 'Invalid password', path: ['account.password'] },
+    ]);
+  });
+});

--- a/packages/vest/src/suiteResult/suiteResult.ts
+++ b/packages/vest/src/suiteResult/suiteResult.ts
@@ -93,7 +93,9 @@ export function constructSuiteResultObject<
       if (failure.message) {
         acc.push({
           message: failure.message,
-          path: [failure.fieldName],
+          path: failure.path ?? [failure.fieldName],
+          ...(failure.code === undefined ? {} : { code: failure.code }),
+          ...(failure.meta === undefined ? {} : { meta: failure.meta }),
         });
       }
       return acc;

--- a/packages/vest/src/vest.ts
+++ b/packages/vest/src/vest.ts
@@ -17,6 +17,7 @@ import type { Suite } from './suite/SuiteTypes';
 import { createSuite } from './suite/createSuite';
 import type { SuiteConfig } from './suite/createSuite';
 import type { SuiteResult, SuiteSummary } from './suiteResult/SuiteResultTypes';
+import type { TestIssue } from './core/test/TestTypes';
 import { suiteSelectors } from './suiteResult/selectors/suiteSelectors';
 
 export {
@@ -39,4 +40,4 @@ export {
   registerReconciler,
 };
 
-export type { SuiteResult, SuiteSummary, Suite, SuiteConfig };
+export type { SuiteResult, SuiteSummary, Suite, SuiteConfig, TestIssue };

--- a/website/docs/api_reference.md
+++ b/website/docs/api_reference.md
@@ -185,9 +185,29 @@ Combines multiple enforce rules.
 
 - [Read more about `compose`](./enforce/composing_enforce_rules.md)
 
-#### `test(fieldName, message, callback)`
+#### `test(fieldName, messageOrIssue, callback)`
 
 A single validation test inside your suite.
+
+`messageOrIssue` can be a message string or a structured issue with a stable
+`code`, human-readable `message`, and optional `meta` and `path`:
+
+```js
+test(
+  'account.password',
+  {
+    code: 'too_short',
+    message: 'Password must contain at least 12 characters',
+    meta: { minimum: 12 },
+    path: ['account', 'password'],
+  },
+  () => enforce(data.account.password).longerThanOrEquals(12),
+);
+```
+
+Structured data is available on `result.errors`, `result.warnings`, and
+`result.issues`, including through Vest's Standard Schema interface. Existing
+string selectors such as `getErrors(fieldName)` continue to return messages.
 
 - [Read more about `test`](./writing_tests/the_test_function.md)
 

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -192,6 +192,53 @@ result.run.data.raw; // { score: 42 }
 result.run.data.parsed; // { score: 42 }
 ```
 
+## Structured schema issues
+
+Use `.issue()` immediately after a schema rule to give that failure a stable
+code and message. `n4s` derives safe metadata from the rule and `shape` derives
+the nested path:
+
+```typescript
+const schema = enforce.shape({
+  account: enforce.shape({
+    password: enforce
+      .isString()
+      .issue({ code: 'not_string', message: 'Password must be text' })
+      .longerThanOrEquals(12)
+      .issue({
+        code: 'too_short',
+        message: 'Password must contain at least 12 characters',
+      }),
+  }),
+});
+```
+
+For the value `{ account: { password: 'secret' } }`, the issue is:
+
+```javascript
+{
+  code: 'too_short',
+  message: 'Password must contain at least 12 characters',
+  path: ['account', 'password'],
+  meta: {
+    rule: 'longerThanOrEquals',
+    minimum: 12,
+    inclusive: true,
+    actual: { type: 'string', length: 6 },
+  },
+}
+```
+
+Metadata derivation intentionally excludes rejected values and opaque rule
+arguments. This prevents passwords, tokens, equality targets, and custom rule
+configuration from leaking into logs or API responses. Rules without a known
+safe metadata mapping still include the rule name.
+
+Structured issues are returned by `schema.validate()`, and when the schema is
+passed to `create()`, Vest preserves them on `result.errors` and
+`result.issues`. Existing `.message()` and string-based result selectors remain
+supported.
+
 ## Schema Parsing
 
 Schema rules support built-in [data parsers](../enforce/builtin-enforce-plugins/data_parsers.md) that transform values as part of validation. When a schema uses parsers, `suite.run()` receives the transformed data in the callback, and `result.value` contains the parsed output.


### PR DESCRIPTION
## Summary
- Introduce typed issue/failure handling across `n4s` and `vest`.
- Update lazy, schema, and chain execution paths to preserve structured error details.
- Align suite result aggregation and test validation with the new failure shape.
- Refresh docs for schema validation and API references.

## Testing
- Added and updated unit coverage for issue formatting and structured issue aggregation.
- Verified the new failure flow through suite result and schema validation tests.
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured validation issues with codes, messages, paths, and rule metadata.
  * Added chainable issue configuration for schema rules.
  * Vest tests now support structured issue objects alongside string messages.
  * Structured issue details are preserved in suite results and Standard Schema validation responses.

* **Bug Fixes**
  * Improved nested and tuple validation paths while retaining issue metadata.
  * Prevented rejected values and opaque rule arguments from appearing in validation results.

* **Documentation**
  * Added guidance and examples for structured schema issues and test messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->