### PR TITLE
Fix docs dark mode and humanize the copy

### DIFF
--- a/AI_USAGE_GUIDE.md
+++ b/AI_USAGE_GUIDE.md
@@ -1,6 +1,6 @@
 # Vest 6 — Consumer Usage Guide
 
-Vest is a framework-independent, stateful validation runtime for complex forms and progressive workflows.
+Vest is a validation library that keeps test results between runs and does not depend on a UI framework.
 
 Use Vest when validation unfolds over time: only some fields should run, earlier results must remain available, fields depend on one another, or async checks can overlap.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vest — form validation that remembers
+# Vest — form validation written like unit tests
 
 ![Vest](https://cdn.jsdelivr.net/gh/ealush/vest@assets/logo_250.png 'Vest')
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vest — TypeScript validation-state framework
+# Vest — form validation that remembers
 
 ![Vest](https://cdn.jsdelivr.net/gh/ealush/vest@assets/logo_250.png 'Vest')
 
@@ -6,7 +6,7 @@
 
 [![Join Discord](https://badgen.net/discord/online-members/WmADZpJnSe?icon=discord&label=Discord)](https://discord.gg/WmADZpJnSe) [![GitHub Stars](https://badgen.net/github/stars/ealush/vest?color=yellow&label=GitHub%20Stars)](https://github.com/ealush/vest) [![Version](https://badgen.net/npm/v/vest?icon=npm)](https://www.npmjs.com/package/vest) [![Downloads](https://badgen.net/npm/dt/vest?label=Downloads)](https://www.npmjs.com/package/vest) [![Bundle size](https://badgen.net/bundlephobia/minzip/vest)](https://bundlephobia.com/package/vest) [![Status](https://badgen.net/github/status/ealush/vest)](https://github.com/ealush/vest/actions)
 
-Vest manages validation as values change over time. It runs only the relevant field or step, retains trustworthy results from earlier interactions, and prevents stale asynchronous work from replacing the current result.
+Vest runs the tests for the field or step that changed and keeps the results for everything else. When async checks overlap, only the latest result can update the suite.
 
 > **Vest validates what changed, remembers what already passed, and prevents stale async validation results.**
 
@@ -43,7 +43,7 @@ await result;
 ## Why Vest?
 
 - **Incremental execution:** Validate a field, group, or step without rerunning everything.
-- **Retained validation state:** Focused runs merge into one complete living result.
+- **Retained validation state:** A focused run updates part of the existing result instead of replacing it.
 - **Race-safe async:** Track pending work, cancel obsolete requests, and ignore stale completions.
 - **Real workflow primitives:** Model dependent fields, conditional sections, warnings, optional values, groups, and dynamic lists.
 - **Client and server continuity:** Run statelessly on the server and resume full validation state in the browser.
@@ -62,9 +62,9 @@ await result;
 
 These layers are complementary. A common architecture uses a form manager for input mechanics, Vest for progressive interaction, and a schema validator for the final submitted boundary.
 
-## Strong use cases
+## Where Vest works well
 
-Vest is particularly useful for:
+Vest works well for:
 
 - async username, email, inventory, coupon, or eligibility checks;
 - onboarding and multi-step workflows;
@@ -86,10 +86,10 @@ npm i vest
 ## Start here
 
 - [Getting started](https://vestjs.dev/docs/get_started)
-- [Ten Vest 6 tutorials](https://vestjs.dev/docs/tutorials)
-- [How Vest thinks about validation](https://vestjs.dev/docs/concepts)
+- [Vest tutorials](https://vestjs.dev/docs/tutorials)
+- [How Vest handles validation](https://vestjs.dev/docs/concepts)
 - [Async validation without race conditions](https://vestjs.dev/docs/guides/async-validation-race-conditions)
-- [Canonical React Hook Form + Standard Schema architecture](https://vestjs.dev/docs/guides/production-architecture)
+- [Complete registration example](https://vestjs.dev/docs/guides/production-architecture)
 - [When not to use Vest](https://vestjs.dev/docs/guides/when-not-to-use-vest)
 - [Vest, schema validators, and form libraries](https://vestjs.dev/docs/vest_vs_the_rest)
 - [Consumer AI usage guide](https://vestjs.dev/llms-consumer.txt)

--- a/packages/vest/README.md
+++ b/packages/vest/README.md
@@ -1,4 +1,4 @@
-# Vest — form validation that remembers
+# Vest — form validation written like unit tests
 
 ![Vest](https://cdn.jsdelivr.net/gh/ealush/vest@assets/logo_250.png 'Vest')
 

--- a/packages/vest/README.md
+++ b/packages/vest/README.md
@@ -1,4 +1,4 @@
-# Vest — TypeScript validation-state framework
+# Vest — form validation that remembers
 
 ![Vest](https://cdn.jsdelivr.net/gh/ealush/vest@assets/logo_250.png 'Vest')
 
@@ -6,7 +6,7 @@
 
 [![Join Discord](https://badgen.net/discord/online-members/WmADZpJnSe?icon=discord&label=Discord)](https://discord.gg/WmADZpJnSe) [![GitHub Stars](https://badgen.net/github/stars/ealush/vest?color=yellow&label=GitHub%20Stars)](https://github.com/ealush/vest) [![Version](https://badgen.net/npm/v/vest?icon=npm)](https://www.npmjs.com/package/vest) [![Downloads](https://badgen.net/npm/dt/vest?label=Downloads)](https://www.npmjs.com/package/vest) [![Bundle size](https://badgen.net/bundlephobia/minzip/vest)](https://bundlephobia.com/package/vest) [![Status](https://badgen.net/github/status/ealush/vest)](https://github.com/ealush/vest/actions)
 
-Vest manages validation as values change over time. It runs only the relevant field or step, retains trustworthy results from earlier interactions, and prevents stale asynchronous work from replacing the current result.
+Vest runs the tests for the field or step that changed and keeps the results for everything else. When async checks overlap, only the latest result can update the suite.
 
 > **Vest validates what changed, remembers what already passed, and prevents stale async validation results.**
 
@@ -43,7 +43,7 @@ await result;
 ## Why Vest?
 
 - **Incremental execution:** Validate a field, group, or step without rerunning everything.
-- **Retained validation state:** Focused runs merge into one complete living result.
+- **Retained validation state:** A focused run updates part of the existing result instead of replacing it.
 - **Race-safe async:** Track pending work, cancel obsolete requests, and ignore stale completions.
 - **Real workflow primitives:** Model dependent fields, conditional sections, warnings, optional values, groups, and dynamic lists.
 - **Client and server continuity:** Run statelessly on the server and resume full validation state in the browser.
@@ -62,9 +62,9 @@ await result;
 
 These layers are complementary. A common architecture uses a form manager for input mechanics, Vest for progressive interaction, and a schema validator for the final submitted boundary.
 
-## Strong use cases
+## Where Vest works well
 
-Vest is particularly useful for:
+Vest works well for:
 
 - async username, email, inventory, coupon, or eligibility checks;
 - onboarding and multi-step workflows;
@@ -86,10 +86,10 @@ npm i vest
 ## Start here
 
 - [Getting started](https://vestjs.dev/docs/get_started)
-- [Ten Vest 6 tutorials](https://vestjs.dev/docs/tutorials)
-- [How Vest thinks about validation](https://vestjs.dev/docs/concepts)
+- [Vest tutorials](https://vestjs.dev/docs/tutorials)
+- [How Vest handles validation](https://vestjs.dev/docs/concepts)
 - [Async validation without race conditions](https://vestjs.dev/docs/guides/async-validation-race-conditions)
-- [Canonical React Hook Form + Standard Schema architecture](https://vestjs.dev/docs/guides/production-architecture)
+- [Complete registration example](https://vestjs.dev/docs/guides/production-architecture)
 - [When not to use Vest](https://vestjs.dev/docs/guides/when-not-to-use-vest)
 - [Vest, schema validators, and form libraries](https://vestjs.dev/docs/vest_vs_the_rest)
 - [Consumer AI usage guide](https://vestjs.dev/llms-consumer.txt)

--- a/scripts/build-llms.js
+++ b/scripts/build-llms.js
@@ -187,7 +187,7 @@ const sectionOrder = [
 ];
 
 let llmsTxt = `# Vest 6
-> Form validation that remembers previous runs. Vest validates what changed, keeps the other results, and ignores stale async responses.
+> Form validation written like unit tests. Vest validates what changed, keeps the other results, and ignores stale async responses.
 
 - [Full Vest 6 documentation](https://vestjs.dev/llms-full.txt)
 - [Consumer usage guide](https://vestjs.dev/llms-consumer.txt)

--- a/scripts/build-llms.js
+++ b/scripts/build-llms.js
@@ -187,7 +187,7 @@ const sectionOrder = [
 ];
 
 let llmsTxt = `# Vest 6
-> TypeScript validation-state framework for complex interactive forms. Vest validates what changed, retains trustworthy previous results, and prevents stale async work from corrupting current state.
+> Form validation that remembers previous runs. Vest validates what changed, keeps the other results, and ignores stale async responses.
 
 - [Full Vest 6 documentation](https://vestjs.dev/llms-full.txt)
 - [Consumer usage guide](https://vestjs.dev/llms-consumer.txt)
@@ -208,7 +208,7 @@ let llmsTxt = `# Vest 6
 Vest composes with schema validators and form managers; these categories are not mutually exclusive.
 
 ## Start with a problem
-- [Ten Vest 6 tutorials](https://vestjs.dev/docs/tutorials)
+- [Vest tutorials](https://vestjs.dev/docs/tutorials)
 - [Async validation without race conditions](https://vestjs.dev/docs/guides/async-validation-race-conditions)
 - [Validate one field or step](https://vestjs.dev/docs/guides/focused-validation)
 - [Dependent and cross-field validation](https://vestjs.dev/docs/guides/dependent-fields)
@@ -219,14 +219,14 @@ Vest composes with schema validators and form managers; these categories are not
 - [Typed schemas and parsed results](https://vestjs.dev/docs/guides/typed-schemas)
 - [React Hook Form and schema integration](https://vestjs.dev/docs/guides/form-and-schema-integration)
 - [Next.js Server Actions and resumable state](https://vestjs.dev/docs/guides/nextjs-server-actions)
-- [Production registration architecture](https://vestjs.dev/docs/guides/production-architecture)
+- [Complete registration example](https://vestjs.dev/docs/guides/production-architecture)
 - [When not to use Vest](https://vestjs.dev/docs/guides/when-not-to-use-vest)
 
 ## Key Concepts
-- **Living Result**: A suite stores validation truth and reconciles new runs with previous field results.
+- **Retained Results**: A suite updates the fields that ran and keeps the results for the others.
 - **Focused Updates**: Validate a field, step, or group with \`suite.only()\` or \`suite.focus()\` while retaining everything else.
 - **Race-safe Async**: Pending work is tracked, obsolete runs are canceled, and stale async results are ignored.
-- **Progressive Workflows**: Model dependent fields, conditional sections, optional values, warnings, groups, and dynamic lists.
+- **Form Workflows**: Model dependent fields, conditional sections, optional values, warnings, groups, and dynamic lists.
 
 ## Advanced Features
 - **Server and SSR**: Use \`runStatic()\`, then serialize and resume full validation state in the browser.

--- a/website/docs/community_resources/standard_schema.md
+++ b/website/docs/community_resources/standard_schema.md
@@ -43,7 +43,7 @@ function EmailForm() {
 }
 ```
 
-The resolver is the simplest path when the form manager should invoke complete validation. To use Vest's progressive runtime during interaction, also run the changed field through the same suite:
+The resolver is the simplest option when the form manager should validate the whole form. To validate one field during interaction, run that field through the same suite:
 
 ```ts
 suite.only('email').run(form.getValues());

--- a/website/docs/concepts.md
+++ b/website/docs/concepts.md
@@ -1,26 +1,26 @@
 ---
 sidebar_position: 2
-title: How Vest Thinks About Validation
-description: Understand Vest as a stateful runtime for validation that unfolds over time.
+title: How Vest Handles Validation
+description: See what a Vest suite remembers between runs and why that matters for interactive forms.
 keywords:
   [Vest, Stateful Validation, Progressive Validation, Validation Suite, Async]
 ---
 
-# How Vest Thinks About Validation
+# How Vest Handles Validation
 
-Vest models validation as an evolving process, not just a function that parses an object once.
+Most validators inspect a value and return an answer. Vest can do that too, but a suite can also keep its result between runs.
 
 A schema validator usually answers:
 
 > Does this value match the required structure right now?
 
-Vest answers a different set of questions:
+An interactive form has a few more questions:
 
-> What changed? Which rules need to run? Which previous results are still trustworthy? Which async result is still current? Is the complete workflow ready to proceed?
+> What changed? Which rules need to run again? Can the other results stay as they are? Is this async response still current? Can the user continue?
 
-This is why Vest is particularly useful for complex forms, onboarding flows, wizards, configuration interfaces, and other progressive workflows.
+Those questions come up in forms, onboarding, checkout flows, settings screens, and anywhere validation happens a little at a time.
 
-## The three layers
+## What a suite gives you
 
 ### 1. Executable business rules
 
@@ -42,9 +42,9 @@ const suite = create(data => {
 
 The familiar syntax is valuable because it gives validation logic a consistent structure. Rules live outside UI components, support multiple tests per field, and can be unit-tested without simulating DOM events.
 
-### 2. A living validation result
+### 2. One result that updates over time
 
-A suite is more than a validation function. It stores the current truth about the workflow.
+A suite keeps the latest result for every test it has seen.
 
 When `suite.run()` executes, Vest:
 
@@ -65,13 +65,13 @@ Username changes
   → ignore an older username request if it finishes late
 ```
 
-This is Vest's central capability: **do the minimum new work without losing the conclusions already earned**.
+The result is still complete even when the latest run only checked one field.
 
 ### 3. Assertions, schemas, and integration
 
 `enforce` provides assertions, schemas, parsing, and custom rules. Vest suites and Enforce rules also implement Standard Schema for interoperability with compatible tools.
 
-Schema validation answers structural questions before behavioral tests run. Stateful suite execution then manages how validation evolves during interaction.
+The schema checks and parses the input. The suite then keeps track of test results as the user interacts with the form.
 
 ## Validation state, not form state
 
@@ -150,7 +150,7 @@ Real workflows are rarely independent field maps. Vest includes primitives for r
 - `each()` tracks dynamic list items with stable keys;
 - warnings provide guidance without blocking completion.
 
-These are workflow concepts, not merely value matchers.
+These tools describe relationships between tests, not just the shape of a value.
 
 ## Errors are not the same as incompleteness
 
@@ -166,12 +166,12 @@ That is different from an active validation error. Vest exposes `isTested`, `isP
 
 Because suites do not depend on UI components, the same validation contract can be used with React, Vue, Svelte, Angular, vanilla JavaScript, or Node.js.
 
-The framework decides when to invoke the suite and how to render it. Vest decides what validation work is relevant and maintains the resulting truth.
+Your framework decides when to run the suite and how to show its result. Vest keeps track of the validation itself.
 
-## The core idea
+## In short
 
-The test-like syntax makes Vest easy to learn. The stateful runtime is why it exists.
+Vest's test-like syntax is familiar, but the state kept by the suite is the important part.
 
-> **Vest validates what changed, remembers what already passed, and prevents stale asynchronous validation results.**
+It lets you validate what changed without forgetting what already passed, and it prevents an old async response from overwriting a newer result.
 
 Continue with [Understanding Vest's State](./understanding_state.md) or see [Vest alongside schema and form libraries](./vest_vs_the_rest.md).

--- a/website/docs/enforce/enforce.md
+++ b/website/docs/enforce/enforce.md
@@ -21,7 +21,7 @@ keywords:
 
 # Enforce: The Assertion Library for Vest
 
-Enforce is a powerful assertion library that powers Vest's validations. It's designed to be:
+Enforce is the assertion library used inside Vest tests. Its rules are:
 
 - **Fluent** - Chain multiple assertions together naturally
 - **Composable** - Build reusable validators from smaller pieces

--- a/website/docs/get_started.md
+++ b/website/docs/get_started.md
@@ -7,9 +7,9 @@ keywords: [Vest, Tutorial, Stateful Validation, JavaScript, React, Vue, Svelte]
 
 # Getting Started
 
-Vest is a **stateful validation runtime for complex forms and progressive workflows**.
+Vest is a validation library for forms and other flows that change over time.
 
-It validates the field or step changing now, retains trustworthy results from earlier runs, and prevents obsolete asynchronous work from corrupting current validation state.
+It can validate only the field or step that changed, keep the results from earlier runs, and ignore an old async response when a newer one has already finished.
 
 If you know Jest or Mocha, the authoring model will feel familiar: define a suite of named tests and use assertions to express the rules. The test-like syntax makes Vest approachable; its persistent validation runtime is what makes it different.
 
@@ -17,7 +17,7 @@ import GetStartedSandpack from '@site/src/components/Sandpack/GetStarted';
 
 ## The problem Vest solves
 
-Interactive validation is not a one-time parse. A real form unfolds over time:
+Forms are rarely validated just once. While someone fills one out:
 
 1. The user changes one field.
 2. Only the related rules should run.
@@ -26,7 +26,7 @@ Interactive validation is not a one-time parse. A real form unfolds over time:
 5. Async responses may arrive in the wrong order.
 6. The complete workflow still needs one reliable validation result.
 
-Vest owns that process without owning your form values, DOM, or UI components.
+Vest handles the validation state without taking over your values, DOM, or components.
 
 ## Installation
 
@@ -104,7 +104,7 @@ expect(invalid.hasErrors('password')).toBe(true);
 
 The test exercises the same rules as the UI without rendering a component. Interactive application code should still use stateful `run()` so focused results can accumulate over time.
 
-## When Vest is a strong fit
+## When Vest is useful
 
 Use Vest when validation behavior includes:
 
@@ -116,12 +116,12 @@ Use Vest when validation behavior includes:
 - errors, warnings, pending states, and progressive completion;
 - validation shared between browser and server.
 
-For a one-shot API boundary parse, an Enforce schema's `.parse()` API may be all you need. For progressive workflows, the same Enforce schema can be attached to a Vest suite so Vest owns both parsed output and the interactive journey. Zod or another schema library can also be composed at the boundary.
+If you only need to parse an API payload once, an Enforce schema's `.parse()` method may be enough. Attach the same schema to a Vest suite when you also need validation while the user works through a form. You can use Zod or another schema library at the boundary instead if that is already part of your stack.
 
 ## Next steps
 
-- **[Follow the ten-tutorial learning path](./tutorials.md)**: Build from a basic suite through async state, schemas, server validation, and custom rules.
-- **[Understand Vest's living result](./concepts.md)**: Learn the stateful runtime mental model.
+- **[Browse the tutorials](./tutorials.md)**: Start with a basic suite or jump to async checks, schemas, server validation, or custom rules.
+- **[See how Vest handles validation](./concepts.md)**: Understand what the suite remembers between runs.
 - **[Async validation without stale results](./writing_tests/async_tests.md)**: Coordinate overlapping server checks safely.
 - **[Focused updates](./writing_your_suite/focused_updates.md)**: Validate one field, step, or group.
 - **[Dependent fields](./writing_your_suite/including_and_excluding/include.md)**: Rerun related rules together.

--- a/website/docs/guides/client-server-validation.md
+++ b/website/docs/guides/client-server-validation.md
@@ -22,12 +22,20 @@ const result = await registrationSuite.runStatic(requestBody);
 An API handler should await all async work before accepting data:
 
 ```ts
+import { SuiteSerializer } from 'vest/exports/SuiteSerializer';
+
 export async function register(request) {
   const data = await request.json();
   const result = await registrationSuite.runStatic(data);
 
   if (!result.isValid()) {
-    return Response.json({ errors: result.getErrors() }, { status: 422 });
+    return Response.json(
+      {
+        errors: result.getErrors(),
+        vestState: SuiteSerializer.serialize(result),
+      },
+      { status: 422 },
+    );
   }
 
   return createAccount(data);

--- a/website/docs/guides/client-server-validation.md
+++ b/website/docs/guides/client-server-validation.md
@@ -1,6 +1,6 @@
 ---
 title: Client and Server Validation
-description: Use one Vest suite for progressive browser interaction and independent server validation.
+description: Use one Vest suite for field-by-field browser validation and independent server requests.
 keywords: [server validation, client validation, SSR validation, runStatic]
 ---
 
@@ -55,11 +55,11 @@ The suite now knows which tests passed, failed, or were skipped on the server an
 
 ## Why serialize more than errors?
 
-An error map does not describe successful tests, warnings, group status, skipped work, or omitted branches. Serialized Vest state retains that context, so the next browser interaction can continue from the authoritative server result instead of reconstructing an incomplete approximation.
+An error map leaves out successful tests, warnings, group status, skipped work, and omitted branches. Serialized Vest state keeps all of that, so the browser can continue from the server result instead of rebuilding part of it by hand.
 
 An error map also creates a second UI integration path. The application must store the server errors, route each message to the correct field component, decide how those messages interact with client errors and warnings, and clear or merge them when the user edits again.
 
-Resuming Vest state avoids that parallel wiring. If the form already renders from the suite, the same selectors immediately expose the server result after `SuiteSerializer.resume()`:
+Resuming Vest state avoids a second set of wiring. If the form already renders from the suite, the same selectors expose the server result after `SuiteSerializer.resume()`:
 
 ```ts
 registrationSuite.getMessage('email');
@@ -71,4 +71,4 @@ The UI does not need a special `serverErrors` branch. Its existing bindings keep
 
 Resume only when new server state arrives. Do not resume the same payload on every render.
 
-Use a separate boundary schema when you also need structural parsing or transformation. See the [production architecture](./production-architecture.md) and [SSR serialization reference](../suite_serialization.md).
+Add a schema when you also need to parse or transform the submitted data. See the [complete registration example](./production-architecture.md) and [SSR serialization reference](../suite_serialization.md).

--- a/website/docs/guides/conditional-sections.md
+++ b/website/docs/guides/conditional-sections.md
@@ -6,7 +6,7 @@ keywords: [conditional validation, optional form section, omitWhen, skipWhen]
 
 # Conditional Form Sections
 
-Conditional interfaces create two different states that should not be conflated:
+Two conditional-field states can look similar but need different handling:
 
 - **Not ready to run:** the rule is still required, but a prerequisite currently fails.
 - **Not applicable:** the field should not count toward validity at all.
@@ -60,9 +60,9 @@ skipWhen(true, () => {
 
 `omitWhen`, by contrast, does not enter its callback when the condition is true because those tests do not belong to the current workflow at all.
 
-## Decision rule
+## Which one should you use?
 
-- Ask “will this rule matter later for the current workflow?” If yes, use `skipWhen`.
+- Ask “will this rule matter later in this form?” If yes, use `skipWhen`.
 - Ask “does this field or section currently exist conceptually?” If no, use `omitWhen`.
 - Use `optional(field)` when one value may be blank but must satisfy its tests when provided.
 

--- a/website/docs/guides/focused-validation.md
+++ b/website/docs/guides/focused-validation.md
@@ -1,12 +1,12 @@
 ---
 title: Validate One Field or Step
-description: Run only the validation affected by the current interaction while retaining trustworthy earlier results.
+description: Validate the field or step that changed without losing earlier results.
 keywords: [focused validation, field validation, progressive form, Vest only]
 ---
 
 # Validate One Field or Step
 
-Rerunning an entire form on every interaction wastes work and often exposes errors for untouched fields. Vest lets the UI describe the current validation scope while the suite retains results established by earlier runs.
+Running every rule after each keystroke wastes work and can show errors for fields the user has not touched. With Vest, the UI says what changed and the suite keeps the other results.
 
 ```ts
 const result = signupSuite.only('email').run(formData);
@@ -14,7 +14,7 @@ const result = signupSuite.only('email').run(formData);
 
 Only tests named `email` execute. Passing or failing results for fields such as `username` and `password` remain available.
 
-## Watch the result accumulate
+## The result still contains the other fields
 
 ```ts
 const data = {

--- a/website/docs/guides/form-and-schema-integration.md
+++ b/website/docs/guides/form-and-schema-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Use Vest with Form and Schema Libraries
-description: Let form managers own inputs while Vest can manage progressive validation state and parse submitted data with Enforce schemas.
+description: Use Vest with a form manager, an Enforce schema, or a schema library you already have.
 keywords: [React Hook Form Vest, Zod Vest, Standard Schema, form integration]
 ---
 
@@ -31,7 +31,7 @@ const form = useForm({
 });
 ```
 
-That resolver is useful for full form-library validation. For Vest's progressive runtime behavior, call focused runs from the relevant field interaction and render the Vest result:
+The resolver covers full-form validation. To validate as the user types or leaves a field, run the relevant field through the same suite and render the Vest result:
 
 ```ts
 async function validateUsername() {
@@ -43,9 +43,9 @@ async function validateUsername() {
 }
 ```
 
-## Boundary option 1: Vest and Enforce
+## Parse with Enforce
 
-Use `enforce.shape` when Vest should own the complete path from untrusted input to progressive business validation:
+Use `enforce.shape` when you want Vest to parse the input as well as run the form's business rules:
 
 ```ts
 const registrationSchema = enforce.shape({
@@ -63,9 +63,9 @@ const result = await registrationSuite.runStatic(values);
 if (result.isValid()) await api.register(result.value);
 ```
 
-The schema parses and transforms the payload. The suite applies the authoritative business rules, and `result.value` contains the parsed output.
+The schema parses and transforms the payload. The suite runs the remaining rules, and `result.value` contains the parsed output.
 
-## Boundary option 2: Compose with another schema library
+## Keep another schema library
 
 An application that already uses Zod or another schema library can keep it at the boundary:
 
@@ -78,7 +78,7 @@ if (result.isValid()) {
 }
 ```
 
-This is deliberate overlap: Zod parses this particular application's data contract while Vest manages the validation lifecycle and business rules. Enforce could replace Zod here when a single Vest-native schema and runtime are preferred.
+Here Zod parses the application's data contract and Vest handles validation during interaction. You can replace Zod with Enforce if you would rather keep both jobs in Vest.
 
 See the complete [production architecture](./production-architecture.md), [Standard Schema reference](../community_resources/standard_schema.md), and [tool comparison](../vest_vs_the_rest.md).
 

--- a/website/docs/guides/form-and-schema-integration.md
+++ b/website/docs/guides/form-and-schema-integration.md
@@ -48,6 +48,8 @@ async function validateUsername() {
 Use `enforce.shape` when you want Vest to parse the input as well as run the form's business rules:
 
 ```ts
+import { create, enforce, test } from 'vest';
+
 const registrationSchema = enforce.shape({
   age: enforce.isNumeric().toNumber(),
   email: enforce.isString().trim(),

--- a/website/docs/guides/memo-and-debounce.md
+++ b/website/docs/guides/memo-and-debounce.md
@@ -86,7 +86,7 @@ Debounced tests are asynchronous even when their inner callback is synchronous. 
 - Use only `debounce` when values rarely repeat but interactions arrive in bursts.
 - Use only `memo` when the application revisits a small number of dependency combinations.
 - Combine them when both behaviors occur and the cached answer is safe to reuse.
-- Skip caching when the answer is authoritative, volatile, or unsafe to retain. A short `ttl` can bound reuse when limited caching is acceptable.
+- Skip caching when the answer must always be fresh or is unsafe to retain. Use a short `ttl` when limited reuse is acceptable.
 
 ## Common mistakes
 

--- a/website/docs/guides/multi-step-workflows.md
+++ b/website/docs/guides/multi-step-workflows.md
@@ -1,13 +1,13 @@
 ---
 title: Validation for Multi-Step Forms
-description: Validate one step at a time while preserving the validation state of the complete workflow.
+description: Validate one step at a time and check the complete form before submission.
 keywords:
   [multi-step form validation, wizard validation, onboarding, Vest groups]
 ---
 
 # Validation for Multi-Step Forms
 
-Multi-step forms need local progress and global truth. A user should validate the current step without losing the results from completed steps, while final submission must still require the complete workflow.
+A multi-step form should validate the current step without forgetting the steps already completed. Submission still needs to check the whole form.
 
 Model steps with groups:
 
@@ -58,7 +58,7 @@ async function canContinue(step: Step, data: OnboardingData) {
 }
 ```
 
-The result from earlier steps remains in the suite, so a review screen can display the status of the full workflow without rerunning every remote check.
+Earlier step results remain in the suite, so a review screen can show the whole form without repeating every remote check.
 
 Cross-field rules remain ordinary TypeScript. Put password and confirmation tests in the same group, then run that group when either value changes. If a field outside the active group must also rerun, use the dependent-field patterns described in [dependent and cross-field validation](./dependent-fields.md).
 

--- a/website/docs/guides/nextjs-server-actions.md
+++ b/website/docs/guides/nextjs-server-actions.md
@@ -54,10 +54,10 @@ export function RegistrationForm({ actionState }) {
 }
 ```
 
-Resuming preserves more than an error map: the suite knows which rules passed, failed, or were skipped. The next browser interaction can therefore run one field while retaining trustworthy server conclusions.
+Resuming restores more than an error map: the suite knows which rules passed, failed, or were skipped. The next browser interaction can run one field while keeping the other server results.
 
 ## Add a parsing boundary
 
-Parse untrusted action input before persistence. An Enforce schema can own that contract directly through `.parse()` or as the Vest suite's schema, while the suite applies authoritative business rules with `runStatic()`. Zod, Valibot, or another schema tool can be used instead when the application already standardizes on it.
+Parse action input before saving it. You can use an Enforce schema directly through `.parse()` or attach it to the Vest suite and call `runStatic()`. If the application already uses Zod, Valibot, or another schema tool, it can stay in that role.
 
 The reference implementation is in the [production registration example](./production-architecture.md). See [suite serialization](../suite_serialization.md) for the lower-level API.

--- a/website/docs/guides/nextjs-server-actions.md
+++ b/website/docs/guides/nextjs-server-actions.md
@@ -10,6 +10,8 @@ A Server Action must validate every request independently. When it returns error
 
 ## Server Action
 
+This example uses a `registrationSuite` created with an Enforce schema, so a successful result contains the parsed input in `result.value`.
+
 ```ts
 'use server';
 
@@ -27,7 +29,7 @@ export async function register(data) {
     };
   }
 
-  await saveAccount(data);
+  await saveAccount(result.value);
   return { ok: true };
 }
 ```

--- a/website/docs/guides/production-architecture.md
+++ b/website/docs/guides/production-architecture.md
@@ -1,6 +1,6 @@
 ---
-title: Production Registration Architecture
-description: A tested reference architecture combining progressive Vest validation with a final schema boundary and server validation.
+title: Complete Registration Example
+description: A tested registration form with focused validation, async checks, schema parsing, and server validation.
 keywords:
   [
     production form validation,
@@ -11,15 +11,15 @@ keywords:
 
 import ProductionRegistrationSandpack from '@site/src/components/Sandpack/ProductionRegistration';
 
-# Production Registration Architecture
+# Complete Registration Example
 
-The canonical example keeps three responsibilities explicit:
+This example splits the work between three pieces:
 
 > **The form layer owns the inputs, the schema owns the boundary, and Vest owns how validation evolves.**
 
 The executable source lives in [`examples/production-registration`](https://github.com/ealush/vest/tree/latest/examples/production-registration).
 
-## What it demonstrates
+## What is in the example
 
 - React Hook Form owns values, registration, and submission mechanics.
 - The official Standard Schema resolver connects full-form submission to Vest.
@@ -33,9 +33,9 @@ The executable source lives in [`examples/production-registration`](https://gith
 - A runnable Vite page demonstrates the architecture with deterministic local services.
 - Vitest proves focused retention, async race behavior, conditionals, warnings, and server isolation.
 
-## Try the browser workflow
+## Try it
 
-This playground loads the browser files directly from the canonical example—there is no second copy to drift. Try `taken` as the username, correct it before the delayed response returns, switch to a business account, and submit a weak password to see errors, pending state, conditional validation, and warnings interact.
+The playground loads its files from the example project, so the code shown here and the tested example stay in sync. Try `taken` as the username and change it before the delayed response returns. You can also switch to a business account or submit a weak password to see the conditional fields and warning state.
 
 <ProductionRegistrationSandpack />
 
@@ -62,11 +62,11 @@ Submission
   → persist parsed payload
 ```
 
-## Why does this example use both Vest and Zod?
+## Why the example also uses Zod
 
-Zod is used here to demonstrate composition with an existing schema stack. It parses this example's complete data boundary, while Vest coordinates focused validation, retained results, async races, warnings, conditionals, and stateless server business rules.
+Many applications already use Zod, so this example shows how to keep it. Zod parses the submitted payload; Vest handles focused runs, async checks, warnings, conditional fields, and server-side business rules.
 
-Zod is not required for this architecture. An Enforce schema created with `enforce.shape` can parse and transform the boundary directly with `.parse()`, or be passed to `create` so `run()` and `runStatic()` validate the schema and expose parsed output as `result.value`. In that version, Vest owns both the boundary and the validation lifecycle.
+Zod is optional here. An Enforce schema created with `enforce.shape` can parse and transform the payload with `.parse()`. You can also pass it to `create`; then `run()` and `runStatic()` expose the parsed value as `result.value`.
 
 ## Run the example
 

--- a/website/docs/guides/typed-schemas.md
+++ b/website/docs/guides/typed-schemas.md
@@ -1,13 +1,13 @@
 ---
 title: Typed Schemas and Parsed Results
-description: Parse serialized input into typed output while keeping Vest's stateful suite runtime and Standard Schema interoperability.
+description: Parse form input, use the typed value in your suite, and read it from the result.
 keywords:
   [Vest TypeScript schema, parsed validation, Enforce schema, Standard Schema]
 ---
 
 # Typed Schemas and Parsed Results
 
-Interactive validation and structural parsing solve different parts of the same workflow. A Vest suite can accept an Enforce schema as the second argument to `create`, giving the run a typed input, a parsed output, and behavioral tests.
+An Enforce schema can parse the input before the suite's tests run. Pass it as the second argument to `create`; the suite callback receives the parsed type and a successful result exposes the parsed value.
 
 ## Define input and output together
 
@@ -73,8 +73,8 @@ const output = await registrationSuite['~standard'].validate({
 
 Successful Standard Schema output contains the parsed values, so `output.value.age` is a number.
 
-## Assign clear responsibilities
+## Using another schema library
 
-An Enforce schema can be the application's boundary schema. It is also reasonable to use Zod, Valibot, or another schema at an external API boundary while Vest manages progressive interaction. What matters is that the form manager, boundary parser, and validation-state runtime each have an explicit job.
+Enforce can parse your API boundary, but it does not have to. If your application already uses Zod, Valibot, or another schema library there, keep it and use Vest for validation during interaction.
 
 Read [form and schema library integration](./form-and-schema-integration.md), the [Standard Schema reference](../community_resources/standard_schema.md), and the [production registration architecture](./production-architecture.md) for complete compositions.

--- a/website/docs/guides/validation-status.md
+++ b/website/docs/guides/validation-status.md
@@ -1,6 +1,6 @@
 ---
 title: Errors, Warnings, Pending, and Untested State
-description: Model validation status precisely instead of reducing every incomplete workflow to valid or invalid.
+description: Show untested, pending, error, warning, and passing states correctly.
 keywords: [validation errors, warnings, pending validation, untested fields]
 ---
 
@@ -10,7 +10,7 @@ Interactive validation has more than two states. A field may be untested, pendin
 
 | State    | What it means                                      | Typical UI                |
 | -------- | -------------------------------------------------- | ------------------------- |
-| Untested | No authoritative test result exists yet            | Neutral guidance          |
+| Untested | The field has not been checked yet                 | Neutral guidance          |
 | Pending  | Asynchronous work for the current value is running | Progress indicator        |
 | Error    | A blocking rule failed                             | Error message             |
 | Warning  | Advisory guidance failed                           | Non-blocking message      |
@@ -67,6 +67,6 @@ Render status in this order:
 
 On submission, await the complete suite and require `isValid()`. Warnings do not make the suite invalid; errors, pending work, and incomplete required tests do.
 
-Do not merge warning messages into the error array. Their separate severity is what lets the same suite support nuanced feedback in the browser and on the server.
+Keep warnings separate from errors. That is what lets the UI show advice without blocking submission.
 
 Read the [result selector reference](../writing_your_suite/accessing_the_result.md) and [warning guide](../writing_tests/warn_only_tests.md).

--- a/website/docs/guides/when-not-to-use-vest.md
+++ b/website/docs/guides/when-not-to-use-vest.md
@@ -1,12 +1,12 @@
 ---
 title: When Not to Use Vest
-description: Choose the smallest validation tool that matches the actual lifecycle and integration needs of your application.
+description: Know when HTML validation, a schema, or a form library is enough on its own.
 keywords: [Vest alternatives, form validation choice, Zod vs Vest]
 ---
 
 # When Not to Use Vest
 
-Vest is designed for validation that has a lifecycle. It is not automatically the best choice every time an application checks a value.
+Vest is most useful when validation changes during user interaction. It is more machinery than you need for every value check.
 
 ## Use native HTML validation when
 
@@ -42,6 +42,6 @@ Vest earns its place when several of these are true:
 
 ## Combine tools when responsibilities differ
 
-A production architecture can use React Hook Form for input mechanics and Vest for both progressive validation and an Enforce-powered API boundary. If a project already standardizes on Zod, it can keep Zod at the boundary and use Vest for the validation lifecycle. Both are valid compositions.
+You might use React Hook Form for input handling and Vest with Enforce for both interactive validation and the API boundary. If the project already uses Zod, keep Zod at the boundary and use Vest for the form. Either approach works.
 
 See the [production architecture](./production-architecture.md) and [comparison guide](../vest_vs_the_rest.md).

--- a/website/docs/suite_serialization.md
+++ b/website/docs/suite_serialization.md
@@ -83,5 +83,5 @@ export function RegistrationForm({ actionData }) {
 
 :::caution Why not just pass the errors?
 You might wonder, "Why not just pass the error object?"
-If you only pass errors, your suite doesn't know _which_ tests passed, which are pending, or which groups were skipped. By resuming the full state, Vest can continue validation seamlessly (e.g., when the user edits a field) without losing the context of the server-side run.
+If you only pass errors, your suite doesn't know _which_ tests passed, which are pending, or which groups were skipped. Resuming the full state lets the next field edit continue from the server result without rebuilding that context in the client.
 :::

--- a/website/docs/tutorials.md
+++ b/website/docs/tutorials.md
@@ -1,43 +1,40 @@
 ---
-title: Ten Vest 6 Tutorials
-description: Follow a practical learning path through stateful runs, async races, warnings, conditions, schemas, server validation, and custom rules.
-keywords:
-  [Vest tutorials, TypeScript validation, form validation tutorial, Vest 6]
+title: Vest Tutorials
+description: Learn Vest through examples covering focused runs, async checks, warnings, schemas, and server validation.
+keywords: [Vest tutorials, TypeScript validation, form validation tutorial]
 ---
 
-# Ten Vest 6 Tutorials
+# Vest Tutorials
 
-Vest becomes most useful when validation stops being a one-time check and starts behaving like a process. These tutorials progress from a small test-like suite to focused state, asynchronous work, conditional workflows, server continuity, and application-specific rules.
+Start with a small suite, or jump straight to the problem you are trying to solve. The examples cover focused validation, async checks, conditional fields, schemas, and sharing validation between the browser and server.
 
-Every example follows the Vest 6 API hierarchy:
+One API detail is worth knowing before you begin:
 
 1. Use `suite.run(data)` for stateful application validation.
 2. Use `suite.runStatic(data)` for an independent server request or isolated execution.
-3. Pass the suite to Standard Schema consumers. The `~standard.validate` hook is an interoperability contract, not Vest's general execution API.
+3. Pass the suite itself to a library that supports Standard Schema. The `~standard.validate` hook is for those integrations, not for calling directly in application code.
 
-## The learning path
+## Pick a tutorial
 
-|   # | Tutorial                                                                           | What you will build                         | Core capability                                      |
-| --: | ---------------------------------------------------------------------------------- | ------------------------------------------- | ---------------------------------------------------- |
-|   1 | [Validation that reads like unit tests](./get_started.md)                          | A signup suite outside the UI               | `create`, `test`, `enforce`, and result selectors    |
-|   2 | [Validate one field without forgetting the rest](./guides/focused-validation.md)   | Progressive profile validation              | Focused execution and retained results               |
-|   3 | [Async checks without stale results](./guides/async-validation-race-conditions.md) | Username availability validation            | Pending state, cancellation, and race safety         |
-|   4 | [Reduce repeated async validation](./guides/memo-and-debounce.md)                  | A coupon check with bounded reuse           | `memo`, `debounce`, and `AbortSignal`                |
-|   5 | [Warnings that do not block submission](./guides/validation-status.md)             | Password-strength guidance                  | Errors, warnings, pending, and untested state        |
-|   6 | [Choose between skipping and omitting](./guides/conditional-sections.md)           | Pickup and delivery sections                | Relevant-later versus not-applicable rules           |
-|   7 | [Validate a multi-step workflow](./guides/multi-step-workflows.md)                 | A typed onboarding wizard                   | Groups, step validity, and cross-field rules         |
-|   8 | [Parse typed input without losing Vest's runtime](./guides/typed-schemas.md)       | A schema-backed registration suite          | Input/output inference, parsing, and Standard Schema |
-|   9 | [Share validation between server and client](./guides/client-server-validation.md) | Stateless request validation with hydration | `runStatic`, serialization, and resumption           |
-|  10 | [Teach validation your domain language](./enforce/creating_custom_rules.md)        | Typed, context-aware Enforce rules          | `condition`, `enforce.extend`, and sibling context   |
+| Tutorial                                                                           | Example                              | What it covers                                     |
+| ---------------------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------------- |
+| [Write your first suite](./get_started.md)                                         | Signup                               | `create`, `test`, `enforce`, and result selectors  |
+| [Validate one field without forgetting the rest](./guides/focused-validation.md)   | Profile form                         | Focused runs and retained results                  |
+| [Handle async checks safely](./guides/async-validation-race-conditions.md)         | Username availability                | Pending state, cancellation, and race safety       |
+| [Avoid repeated async work](./guides/memo-and-debounce.md)                         | Coupon check                         | `memo`, `debounce`, and `AbortSignal`              |
+| [Show warnings without blocking submission](./guides/validation-status.md)         | Password strength                    | Errors, warnings, pending, and untested state      |
+| [Skip or remove conditional rules](./guides/conditional-sections.md)               | Pickup and delivery                  | `skipWhen`, `omitWhen`, and `optional`             |
+| [Validate a multi-step form](./guides/multi-step-workflows.md)                     | Onboarding                           | Groups, step validity, and cross-field rules       |
+| [Parse input and keep the typed result](./guides/typed-schemas.md)                 | Registration                         | Parsing, type inference, and Standard Schema       |
+| [Share validation between server and client](./guides/client-server-validation.md) | Server validation and browser resume | `runStatic`, serialization, and resumption         |
+| [Write rules for your own domain](./enforce/creating_custom_rules.md)              | Custom Enforce rules                 | `condition`, `enforce.extend`, and sibling context |
 
-## What the sequence demonstrates
+## A good order for learning Vest
 
-The first tutorial makes rules readable and independently testable. The next six show why Vest is a validation-state runtime: each interaction can run a deliberate subset of work while the suite retains trustworthy history and coordinates pending results. The final three connect that runtime to typed parsing, server authority, ecosystem tools, and domain-specific vocabulary.
+If Vest is new to you, read the first three in order. They introduce suites, focused runs, and async validation—the ideas most of the other guides build on. After that, choose the examples that match your application.
 
-You do not need every capability. Start with the tutorial closest to the failure mode in your application, then return to the sequence when the workflow grows.
+## See everything working together
 
-## After the tutorials
-
-- Use the [production registration architecture](./guides/production-architecture.md) to see the capabilities composed in one runnable React application.
-- Read [Vest, schema validators, and form libraries](./vest_vs_the_rest.md) before choosing responsibility boundaries.
-- Check [when not to use Vest](./guides/when-not-to-use-vest.md) for smaller or purely structural validation tasks.
+- Open the [complete registration example](./guides/production-architecture.md) for a runnable React application.
+- Read [Vest, schema validators, and form libraries](./vest_vs_the_rest.md) to decide which tool should handle each part of your form.
+- Check [when not to use Vest](./guides/when-not-to-use-vest.md) if your validation is simple or only runs once.

--- a/website/docs/understanding_state.md
+++ b/website/docs/understanding_state.md
@@ -7,7 +7,7 @@ keywords: [Vest, Stateful Validations, Field merge, Resetting, Removing fields]
 
 # Understanding Vest's State
 
-One of Vest's most powerful features is its **stateful validation**. Unlike schema-based validators that start fresh every time, Vest remembers previous results and merges them intelligently.
+Vest suites keep validation state between runs. A focused run updates the fields it checked and leaves the other field results in place.
 
 ## Why Stateful Validation?
 
@@ -16,7 +16,7 @@ Imagine a form with 10 fields. When a user updates just the "username" field, yo
 1. **Re-validate everything** - Slow, and might flash errors on untouched fields
 2. **Validate only "username"** - Fast, but you lose the state of other fields
 
-Vest gives you the best of both worlds: **validate one field, keep the full picture**.
+With Vest, you can validate one field and keep the rest of the result.
 
 ### How It Works
 

--- a/website/docs/usage_with_frameworks/react.md
+++ b/website/docs/usage_with_frameworks/react.md
@@ -5,7 +5,7 @@ title: React
 
 # Using Vest with React
 
-Vest integrates seamlessly with React applications, providing powerful validation capabilities for forms and user input. This guide covers common patterns and best practices.
+Vest suites do not depend on React. A component runs the suite when a value changes and renders the result from state. This guide shows the usual patterns.
 
 ## Quick Start
 

--- a/website/docs/vest_vs_the_rest.md
+++ b/website/docs/vest_vs_the_rest.md
@@ -7,7 +7,7 @@ keywords: [Vest, Zod, React Hook Form, Schema Validation, Stateful Validation]
 
 # Vest, Schema Validators, and Form Libraries
 
-Vest does not need every validation problem to be a Vest problem.
+Vest can work alongside the form and schema tools you already use.
 
 These capabilities can be composed, but they are not mutually exclusive:
 
@@ -18,17 +18,17 @@ These capabilities can be composed, but they are not mutually exclusive:
 | **Vest suites**                  | Stateful and stateless validation workflows        |
 | **Vest suite + Enforce schema**  | Both parsed boundaries and validation over time    |
 
-## The distinction
+## Where Vest differs
 
 A schema validator is excellent at answering:
 
 > Does this submitted payload have the expected structure and values?
 
-Vest is designed to answer:
+A Vest suite also needs to answer:
 
 > The user changed one part of a workflow. What needs to run now, what previous state remains valid, and which async result should be trusted?
 
-Vest can answer both questions. Enforce schemas provide structural validation, transformation, and parsing; a Vest suite adds the stateful runtime model for validation that unfolds over time.
+Vest can handle both jobs. Enforce schemas validate, transform, and parse data. A Vest suite keeps test results up to date while the user moves through a form.
 
 ## Vest and Zod
 
@@ -74,7 +74,7 @@ Vest is a strong choice for:
 - multi-step workflows;
 - warnings, pending state, and progressive completion.
 
-### Use Vest end to end, or compose it with Zod
+### Use Vest on its own or with Zod
 
 Vest can own both the interactive workflow and the submitted boundary:
 
@@ -85,20 +85,18 @@ User interaction
 
 Final submission
   → Enforce schema parses and transforms the complete payload
-  → Vest runStatic applies authoritative business rules
+  → Vest runStatic applies the business rules
 ```
 
-If an application already uses Zod, it can parse the boundary before a stateless Vest run. That is an interoperability choice, not a limitation of Vest:
+If your application already uses Zod, parse the payload before a stateless Vest run:
 
 ```text
 Final submission
   → Zod parses the complete boundary payload
-  → Vest runStatic applies authoritative business rules
+  → Vest runStatic applies the business rules
 ```
 
-The concise explanation is:
-
-> **Zod can be the boundary schema. Enforce can be too. Vest's differentiator is carrying validation through the whole workflow.**
+Zod and Enforce can both parse the boundary. The Vest suite is what carries the validation result from one interaction to the next.
 
 ## Vest and form state managers
 
@@ -157,4 +155,4 @@ Prefer a simpler solution when:
 - validation happens only once at an API boundary;
 - your primary problem is storing form values rather than validation behavior.
 
-The goal is not to replace every schema or form library. It is to make progressive validation a first-class part of the application architecture.
+You do not have to replace your schema or form library to use Vest. Add it when keeping validation correct between interactions is the hard part.

--- a/website/docs/vest_vs_the_rest.md
+++ b/website/docs/vest_vs_the_rest.md
@@ -90,10 +90,9 @@ Final submission
 
 If your application already uses Zod, parse the payload before a stateless Vest run:
 
-```text
-Final submission
-  → Zod parses the complete boundary payload
-  → Vest runStatic applies the business rules
+```ts
+const parsed = schema.parse(payload);
+const result = await suite.runStatic(parsed);
 ```
 
 Zod and Enforce can both parse the boundary. The Vest suite is what carries the validation result from one interaction to the next.

--- a/website/docs/writing_your_suite/dirty_checking.md
+++ b/website/docs/writing_your_suite/dirty_checking.md
@@ -11,7 +11,7 @@ A common challenge in form validation is "noise control." You don't want to scre
 
 Traditionally, libraries use an `isDirty` flag to track if a user has modified a field. Since Vest is **UI-agnostic** (it doesn't touch your DOM or listen to events), it doesn't track "dirty" state for you.
 
-Instead, Vest provides two powerful tools to handle user interaction: **`isTested()`** and **`suite.only()`**.
+Vest provides two tools for this: **`isTested()`** and **`suite.only()`**.
 
 ## 1. `isTested()`: The Vest Alternative to `isDirty`
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -41,8 +41,7 @@ const config = {
   baseUrl: '/',
   favicon: 'favicon.ico',
   title: 'Vest',
-  tagline:
-    'TypeScript validation-state framework for complex forms and progressive workflows.',
+  tagline: 'Form validation that remembers previous runs.',
   url: 'https://vestjs.dev',
   onBrokenLinks: 'throw',
   markdown: {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -41,7 +41,7 @@ const config = {
   baseUrl: '/',
   favicon: 'favicon.ico',
   title: 'Vest',
-  tagline: 'Form validation that remembers previous runs.',
+  tagline: 'Form validation written like unit tests.',
   url: 'https://vestjs.dev',
   onBrokenLinks: 'throw',
   markdown: {

--- a/website/src/components/HomepageFeatures.js
+++ b/website/src/components/HomepageFeatures.js
@@ -10,21 +10,21 @@ const FeatureList = [
     emoji: '◎',
     category: 'Focused',
     description:
-      'Validate the active field, step, or group without rerunning unrelated rules or exposing errors for untouched inputs.',
+      'Validate the active field, step, or group without rerunning unrelated rules or showing errors on untouched inputs.',
   },
   {
     title: 'Keep what already passed',
     emoji: '↺',
     category: 'Stateful',
     description:
-      'Vest merges each focused run into a living result, preserving trustworthy validation state from earlier interactions.',
+      'Each focused run updates the same result, so fields you did not run keep their previous status.',
   },
   {
     title: 'Trust the latest response',
     emoji: '⇄',
     category: 'Race-safe',
     description:
-      'Track pending work, cancel obsolete requests, and prevent slow stale responses from replacing the current result.',
+      'Track pending work, cancel old requests, and stop a slow response from replacing the result for the current value.',
   },
   {
     title: 'Model real workflows',
@@ -38,14 +38,14 @@ const FeatureList = [
     emoji: '↗',
     category: 'Full stack',
     description:
-      'Run statelessly on the server, resume validation state in the browser, or share one suite across UI frameworks.',
+      'Run each server request in isolation, restore its result in the browser, and share the same suite across frameworks.',
   },
   {
     title: 'Write rules like tests',
     emoji: '✓',
     category: 'Maintainable',
     description:
-      'Keep business rules outside feature code in readable suites that are straightforward to unit-test and reuse.',
+      'Keep rules in readable suites outside your components, then unit-test and reuse them like any other code.',
   },
 ];
 
@@ -75,14 +75,14 @@ export default function HomepageFeatures() {
       <div className="container">
         <div className={styles.sectionHeader}>
           <p className={styles.sectionEyebrow}>
-            A runtime for validation over time
+            Built for validation over time
           </p>
           <h2 className={styles.sectionTitle}>
-            The complete picture, without repeating all the work
+            Run less. Keep the full result.
           </h2>
           <p className={styles.sectionDescription}>
-            A suite is a living validation result. It knows what ran, what can
-            be retained, what is pending, and which result is still relevant.
+            A suite remembers what ran, what passed, what is pending, and which
+            async response belongs to the current value.
           </p>
         </div>
         <div className={styles.featuresGrid}>
@@ -107,11 +107,11 @@ export default function HomepageFeatures() {
         </div>
         <div className={styles.nextStep}>
           <div>
-            <span className={styles.positioningLabel}>Learn by solving</span>
-            <h3>Start with the validation problem you already have.</h3>
+            <span className={styles.positioningLabel}>Learn Vest</span>
+            <h3>Start with the problem you are trying to solve.</h3>
             <p>
-              Ten practical tutorials move from a first suite to async state,
-              typed schemas, and browser/server continuity.
+              Write a first suite, handle async checks, parse typed input, or
+              share validation between the browser and server.
             </p>
           </div>
           <Link

--- a/website/src/components/HomepageFeatures.module.css
+++ b/website/src/components/HomepageFeatures.module.css
@@ -134,6 +134,11 @@ html[data-theme='dark'] .features {
   color: var(--feature-paper);
 }
 
+html[data-theme='dark'] .positioningBand {
+  background: #181818;
+  color: var(--feature-ink);
+}
+
 .positioningBand > div {
   display: flex;
   min-height: 210px;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -63,18 +63,22 @@
 }
 
 html[data-theme='dark'] {
+  --ifm-color-primary: #a7b3ff;
+  --ifm-color-primary-dark: #98a5ff;
+  --ifm-color-primary-darker: #8d9aff;
+  --ifm-color-primary-darkest: #7180f0;
+  --ifm-color-primary-light: #bbc4ff;
+  --ifm-color-primary-lighter: #ccd3ff;
+  --ifm-color-primary-lightest: #e6e9ff;
   --ifm-background-color: var(--vest-slate);
+  --ifm-background-surface-color: #151d2e;
   --ifm-font-color-base: #e6e9f4;
   --ifm-heading-color: #f8fafc;
   --ifm-navbar-background-color: rgba(15, 23, 42, 0.78);
   --ifm-card-background-color: rgba(22, 30, 46, 0.7);
   --docusaurus-highlighted-code-line-bg: rgba(99, 102, 241, 0.15);
   --vest-body-bg-gradient: none;
-  --vest-footer-bg: linear-gradient(
-    180deg,
-    rgba(79, 70, 229, 0.12),
-    rgba(15, 23, 42, 0.92)
-  );
+  --vest-footer-bg: linear-gradient(180deg, #1b2135, #0f172a);
   --vest-footer-color: #e2e8f0;
   --vest-surface: rgba(22, 30, 46, 0.72);
   --vest-surface-strong: #151d2e;
@@ -331,6 +335,7 @@ html[data-theme='dark'] .token.class-name {
 html[data-theme='dark'] :not(pre) > code {
   background: rgba(99, 102, 241, 0.18);
   border: 1px solid rgba(129, 140, 248, 0.35);
+  color: #e6e9ff;
 }
 
 html[data-theme='light'] pre[class*='language-'] {
@@ -445,6 +450,11 @@ html[data-theme='dark'] .menu__link--active:not(.menu__link--sublist) {
   color: var(--ifm-color-primary-dark);
 }
 
+html[data-theme='dark'] .breadcrumbs__item--active .breadcrumbs__link {
+  background: rgba(129, 140, 248, 0.14);
+  color: var(--ifm-color-primary-lighter);
+}
+
 .theme-doc-version-badge {
   margin-bottom: 1rem;
   border: 1px solid rgba(99, 102, 241, 0.18);
@@ -454,6 +464,12 @@ html[data-theme='dark'] .menu__link--active:not(.menu__link--sublist) {
   font-size: 0.67rem;
   font-weight: 750;
   letter-spacing: 0.05em;
+}
+
+html[data-theme='dark'] .theme-doc-version-badge {
+  background: rgba(129, 140, 248, 0.14);
+  border-color: rgba(167, 179, 255, 0.35);
+  color: var(--ifm-color-primary-lighter);
 }
 
 .theme-doc-markdown {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -44,8 +44,8 @@ function HomepageHeader() {
             <span className={styles.heroEdition}>06 / validation runtime</span>
           </div>
           <h1 className={clsx('hero__title', styles.heroTitle)}>
-            Validation that
-            <span className={styles.heroHighlight}> remembers.</span>
+            Validation
+            <span className={styles.heroHighlight}> like unit tests.</span>
           </h1>
           <p className={styles.heroStatement}>
             Your form changes one field at a time. Its validation should too.
@@ -187,7 +187,7 @@ export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`${siteConfig.title}: Form validation that remembers`}
+      title={`${siteConfig.title}: Form validation written like unit tests`}
       description="Validate what changed, keep previous results, and ignore stale async responses with Vest."
     >
       <HomepageHeader />

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -51,8 +51,8 @@ function HomepageHeader() {
             Your form changes one field at a time. Its validation should too.
           </p>
           <p className={clsx('hero__subtitle', styles.heroTagline)}>
-            Vest runs the rules that matter now, retains the truth established
-            before, and makes stale async answers irrelevant.
+            Run the rules for the field that changed. Keep the other results.
+            Ignore async responses that arrived too late.
           </p>
           <div className={styles.ctaGroup}>
             <button
@@ -187,8 +187,8 @@ export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`${siteConfig.title}: TypeScript validation-state framework`}
-      description="Validate what changed, retain previous results, and prevent stale async responses with Vest."
+      title={`${siteConfig.title}: Form validation that remembers`}
+      description="Validate what changed, keep previous results, and ignore stale async responses with Vest."
     >
       <HomepageHeader />
       <main>

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -172,6 +172,7 @@ html[data-theme='dark'] .heroTagline {
 
 .secondaryCta {
   --ifm-button-color: var(--vest-black);
+
   border: 1px solid var(--vest-black);
   border-left: 0;
   background: transparent;

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -108,7 +108,7 @@ html[data-theme='dark'] .heroEdition {
   display: block;
   color: var(--vest-red);
   font-family: var(--ifm-font-family-monospace);
-  font-size: 0.76em;
+  font-size: 0.56em;
   font-weight: 500;
   letter-spacing: -0.07em;
 }

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -171,9 +171,14 @@ html[data-theme='dark'] .heroTagline {
 }
 
 .secondaryCta {
+  --ifm-button-color: var(--vest-black);
   border: 1px solid var(--vest-black);
   border-left: 0;
   background: transparent;
+  color: var(--vest-black);
+}
+
+html[data-theme='dark'] .secondaryCta {
   color: var(--vest-black);
 }
 

--- a/website/static/llms-consumer.txt
+++ b/website/static/llms-consumer.txt
@@ -1,6 +1,6 @@
 # Vest 6 — Consumer Usage Guide
 
-Vest is a framework-independent, stateful validation runtime for complex forms and progressive workflows.
+Vest is a validation library that keeps test results between runs and does not depend on a UI framework.
 
 Use Vest when validation unfolds over time: only some fields should run, earlier results must remain available, fields depend on one another, or async checks can overlap.
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -3651,12 +3651,20 @@ const result = await registrationSuite.runStatic(requestBody);
 An API handler should await all async work before accepting data:
 
 ```ts
+import { SuiteSerializer } from 'vest/exports/SuiteSerializer';
+
 export async function register(request) {
   const data = await request.json();
   const result = await registrationSuite.runStatic(data);
 
   if (!result.isValid()) {
-    return Response.json({ errors: result.getErrors() }, { status: 422 });
+    return Response.json(
+      {
+        errors: result.getErrors(),
+        vestState: SuiteSerializer.serialize(result),
+      },
+      { status: 422 },
+    );
   }
 
   return createAccount(data);
@@ -3993,6 +4001,8 @@ async function validateUsername() {
 Use `enforce.shape` when you want Vest to parse the input as well as run the form's business rules:
 
 ```ts
+import { create, enforce, test } from 'vest';
+
 const registrationSchema = enforce.shape({
   age: enforce.isNumeric().toNumber(),
   email: enforce.isString().trim(),
@@ -4207,6 +4217,8 @@ A Server Action must validate every request independently. When it returns error
 
 ## Server Action
 
+This example uses a `registrationSuite` created with an Enforce schema, so a successful result contains the parsed input in `result.value`.
+
 ```ts
 'use server';
 
@@ -4224,7 +4236,7 @@ export async function register(data) {
     };
   }
 
-  await saveAccount(data);
+  await saveAccount(result.value);
   return { ok: true };
 }
 ```
@@ -6408,10 +6420,9 @@ Final submission
 
 If your application already uses Zod, parse the payload before a stateless Vest run:
 
-```text
-Final submission
-  → Zod parses the complete boundary payload
-  → Vest runStatic applies the business rules
+```ts
+const parsed = schema.parse(payload);
+const result = await suite.runStatic(parsed);
 ```
 
 Zod and Enforce can both parse the boundary. The Vest suite is what carries the validation result from one interaction to the next.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -224,8 +224,11 @@ After running your suite, the results object is returned. It has the following f
 
 - `hasErrors(fieldName?)`: Returns true if the suite or the provided field has errors.
 - `hasWarnings(fieldName?)`: Returns true if the suite or the provided field has warnings.
-- `getErrors(fieldName?)`: Returns an object with errors in the suite, or an array of objects for a specific field.
-- `getWarnings(fieldName?)`: Returns an object with warnings in the suite, or an array of objects for a specific field.
+- `getError(fieldName?)`: Without a field, returns the first summary object (`{ fieldName, message, groupName }`). With a field, returns that field's first error message string. Returns `undefined` when none exists.
+- `getWarning(fieldName?)`: Without a field, returns the first summary object. With a field, returns that field's first warning message string. Returns `undefined` when none exists.
+- `getMessage(fieldName)`: Returns the field's first error or warning message string, preferring an error when both exist.
+- `getErrors(fieldName?)`: Without a field, returns an object whose keys are field names and values are arrays of message strings. With a field, returns that field's array of error message strings.
+- `getWarnings(fieldName?)`: Without a field, returns an object whose keys are field names and values are arrays of message strings. With a field, returns that field's array of warning message strings.
 - `hasErrorsByGroup(groupName)`: Returns true if the provided group has errors.
 - `hasWarningByGroup(groupName)`: Returns true if the provided group has warnings.
 - `getErrorsByGroup(groupName)`: Returns an object with errors in the provided group.
@@ -305,13 +308,13 @@ function EmailForm() {
 }
 ```
 
-The resolver is the simplest path when the form manager should invoke complete validation. To use Vest's progressive runtime during interaction, also run the changed field through the same suite:
+The resolver is the simplest option when the form manager should validate the whole form. To validate one field during interaction, run that field through the same suite:
 
 ```ts
 suite.only('email').run(form.getValues());
 ```
 
-See the tested [production architecture](https://vestjs.dev/docs/guides/production-architecture) for focused async validation, warnings, conditionals, Zod at the server boundary, and a stateless server run.
+See the tested [production architecture](https://vestjs.dev/docs/guides/production-architecture) for focused async validation, warnings, conditionals, a replaceable Zod boundary, and a stateless server run. An Enforce schema can own the boundary instead.
 
 ## Direct Standard Schema validation
 
@@ -351,21 +354,21 @@ Read [Vest, schema validators, and form libraries](https://vestjs.dev/docs/vest_
 - [Up your form validation game with Vest (video)](http://www.youtube.com/watch?v=X2PuiawaGV4) - A session from the Svelte Summit on how to use Vest with Svelte.
 
 
-# How Vest Thinks About Validation
+# How Vest Handles Validation
 
-Vest models validation as an evolving process, not just a function that parses an object once.
+Most validators inspect a value and return an answer. Vest can do that too, but a suite can also keep its result between runs.
 
 A schema validator usually answers:
 
 > Does this value match the required structure right now?
 
-Vest answers a different set of questions:
+An interactive form has a few more questions:
 
-> What changed? Which rules need to run? Which previous results are still trustworthy? Which async result is still current? Is the complete workflow ready to proceed?
+> What changed? Which rules need to run again? Can the other results stay as they are? Is this async response still current? Can the user continue?
 
-This is why Vest is particularly useful for complex forms, onboarding flows, wizards, configuration interfaces, and other progressive workflows.
+Those questions come up in forms, onboarding, checkout flows, settings screens, and anywhere validation happens a little at a time.
 
-## The three layers
+## What a suite gives you
 
 ### 1. Executable business rules
 
@@ -387,9 +390,9 @@ const suite = create(data => {
 
 The familiar syntax is valuable because it gives validation logic a consistent structure. Rules live outside UI components, support multiple tests per field, and can be unit-tested without simulating DOM events.
 
-### 2. A living validation result
+### 2. One result that updates over time
 
-A suite is more than a validation function. It stores the current truth about the workflow.
+A suite keeps the latest result for every test it has seen.
 
 When `suite.run()` executes, Vest:
 
@@ -410,13 +413,13 @@ Username changes
   → ignore an older username request if it finishes late
 ```
 
-This is Vest's central capability: **do the minimum new work without losing the conclusions already earned**.
+The result is still complete even when the latest run only checked one field.
 
 ### 3. Assertions, schemas, and integration
 
 `enforce` provides assertions, schemas, parsing, and custom rules. Vest suites and Enforce rules also implement Standard Schema for interoperability with compatible tools.
 
-Schema validation answers structural questions before behavioral tests run. Stateful suite execution then manages how validation evolves during interaction.
+The schema checks and parses the input. The suite then keeps track of test results as the user interacts with the form.
 
 ## Validation state, not form state
 
@@ -495,7 +498,7 @@ Real workflows are rarely independent field maps. Vest includes primitives for r
 - `each()` tracks dynamic list items with stable keys;
 - warnings provide guidance without blocking completion.
 
-These are workflow concepts, not merely value matchers.
+These tools describe relationships between tests, not just the shape of a value.
 
 ## Errors are not the same as incompleteness
 
@@ -511,13 +514,13 @@ That is different from an active validation error. Vest exposes `isTested`, `isP
 
 Because suites do not depend on UI components, the same validation contract can be used with React, Vue, Svelte, Angular, vanilla JavaScript, or Node.js.
 
-The framework decides when to invoke the suite and how to render it. Vest decides what validation work is relevant and maintains the resulting truth.
+Your framework decides when to run the suite and how to show its result. Vest keeps track of the validation itself.
 
-## The core idea
+## In short
 
-The test-like syntax makes Vest easy to learn. The stateful runtime is why it exists.
+Vest's test-like syntax is familiar, but the state kept by the suite is the important part.
 
-> **Vest validates what changed, remembers what already passed, and prevents stale asynchronous validation results.**
+It lets you validate what changed without forgetting what already passed, and it prevents an old async response from overwriting a newer result.
 
 Continue with [Understanding Vest's State](https://vestjs.dev/docs/understanding_state) or see [Vest alongside schema and form libraries](https://vestjs.dev/docs/vest_vs_the_rest).
 
@@ -1860,7 +1863,7 @@ _Note: In the interface definition, include the `value` as the first argument._
 
 # Enforce: The Assertion Library for Vest
 
-Enforce is a powerful assertion library that powers Vest's validations. It's designed to be:
+Enforce is the assertion library used inside Vest tests. Its rules are:
 
 - **Fluent** - Chain multiple assertions together naturally
 - **Composable** - Build reusable validators from smaller pieces
@@ -3425,9 +3428,9 @@ enforce(value)
 
 # Getting Started
 
-Vest is a **stateful validation runtime for complex forms and progressive workflows**.
+Vest is a validation library for forms and other flows that change over time.
 
-It validates the field or step changing now, retains trustworthy results from earlier runs, and prevents obsolete asynchronous work from corrupting current validation state.
+It can validate only the field or step that changed, keep the results from earlier runs, and ignore an old async response when a newer one has already finished.
 
 If you know Jest or Mocha, the authoring model will feel familiar: define a suite of named tests and use assertions to express the rules. The test-like syntax makes Vest approachable; its persistent validation runtime is what makes it different.
 
@@ -3435,7 +3438,7 @@ import GetStartedSandpack from '@site/src/components/Sandpack/GetStarted';
 
 ## The problem Vest solves
 
-Interactive validation is not a one-time parse. A real form unfolds over time:
+Forms are rarely validated just once. While someone fills one out:
 
 1. The user changes one field.
 2. Only the related rules should run.
@@ -3444,7 +3447,7 @@ Interactive validation is not a one-time parse. A real form unfolds over time:
 5. Async responses may arrive in the wrong order.
 6. The complete workflow still needs one reliable validation result.
 
-Vest owns that process without owning your form values, DOM, or UI components.
+Vest handles the validation state without taking over your values, DOM, or components.
 
 ## Installation
 
@@ -3522,7 +3525,7 @@ expect(invalid.hasErrors('password')).toBe(true);
 
 The test exercises the same rules as the UI without rendering a component. Interactive application code should still use stateful `run()` so focused results can accumulate over time.
 
-## When Vest is a strong fit
+## When Vest is useful
 
 Use Vest when validation behavior includes:
 
@@ -3534,12 +3537,12 @@ Use Vest when validation behavior includes:
 - errors, warnings, pending states, and progressive completion;
 - validation shared between browser and server.
 
-For a one-shot API boundary parse, a schema validator may be all you need. A common architecture is to use a schema validator for the submitted payload and Vest for the interactive journey that produces it.
+If you only need to parse an API payload once, an Enforce schema's `.parse()` method may be enough. Attach the same schema to a Vest suite when you also need validation while the user works through a form. You can use Zod or another schema library at the boundary instead if that is already part of your stack.
 
 ## Next steps
 
-- **[Follow the ten-tutorial learning path](https://vestjs.dev/docs/tutorials)**: Build from a basic suite through async state, schemas, server validation, and custom rules.
-- **[Understand Vest's living result](https://vestjs.dev/docs/concepts)**: Learn the stateful runtime mental model.
+- **[Browse the tutorials](https://vestjs.dev/docs/tutorials)**: Start with a basic suite or jump to async checks, schemas, server validation, or custom rules.
+- **[See how Vest handles validation](https://vestjs.dev/docs/concepts)**: Understand what the suite remembers between runs.
 - **[Async validation without stale results](https://vestjs.dev/docs/writing_tests/async_tests)**: Coordinate overlapping server checks safely.
 - **[Focused updates](https://vestjs.dev/docs/writing_your_suite/focused_updates)**: Validate one field, step, or group.
 - **[Dependent fields](https://vestjs.dev/docs/writing_your_suite/including_and_excluding/include)**: Rerun related rules together.
@@ -3681,11 +3684,11 @@ The suite now knows which tests passed, failed, or were skipped on the server an
 
 ## Why serialize more than errors?
 
-An error map does not describe successful tests, warnings, group status, skipped work, or omitted branches. Serialized Vest state retains that context, so the next browser interaction can continue from the authoritative server result instead of reconstructing an incomplete approximation.
+An error map leaves out successful tests, warnings, group status, skipped work, and omitted branches. Serialized Vest state keeps all of that, so the browser can continue from the server result instead of rebuilding part of it by hand.
 
 An error map also creates a second UI integration path. The application must store the server errors, route each message to the correct field component, decide how those messages interact with client errors and warnings, and clear or merge them when the user edits again.
 
-Resuming Vest state avoids that parallel wiring. If the form already renders from the suite, the same selectors immediately expose the server result after `SuiteSerializer.resume()`:
+Resuming Vest state avoids a second set of wiring. If the form already renders from the suite, the same selectors expose the server result after `SuiteSerializer.resume()`:
 
 ```ts
 registrationSuite.getMessage('email');
@@ -3697,12 +3700,12 @@ The UI does not need a special `serverErrors` branch. Its existing bindings keep
 
 Resume only when new server state arrives. Do not resume the same payload on every render.
 
-Use a separate boundary schema when you also need structural parsing or transformation. See the [production architecture](https://vestjs.dev/docs/guides/production-architecture) and [SSR serialization reference](https://vestjs.dev/docs/suite_serialization).
+Add a schema when you also need to parse or transform the submitted data. See the [complete registration example](https://vestjs.dev/docs/guides/production-architecture) and [SSR serialization reference](https://vestjs.dev/docs/suite_serialization).
 
 
 # Conditional Form Sections
 
-Conditional interfaces create two different states that should not be conflated:
+Two conditional-field states can look similar but need different handling:
 
 - **Not ready to run:** the rule is still required, but a prerequisite currently fails.
 - **Not applicable:** the field should not count toward validity at all.
@@ -3756,9 +3759,9 @@ skipWhen(true, () => {
 
 `omitWhen`, by contrast, does not enter its callback when the condition is true because those tests do not belong to the current workflow at all.
 
-## Decision rule
+## Which one should you use?
 
-- Ask “will this rule matter later for the current workflow?” If yes, use `skipWhen`.
+- Ask “will this rule matter later in this form?” If yes, use `skipWhen`.
 - Ask “does this field or section currently exist conceptually?” If no, use `omitWhen`.
 - Use `optional(field)` when one value may be blank but must satisfy its tests when provided.
 
@@ -3861,7 +3864,7 @@ Read the complete [dynamic tests reference](https://vestjs.dev/docs/writing_test
 
 # Validate One Field or Step
 
-Rerunning an entire form on every interaction wastes work and often exposes errors for untouched fields. Vest lets the UI describe the current validation scope while the suite retains results established by earlier runs.
+Running every rule after each keystroke wastes work and can show errors for fields the user has not touched. With Vest, the UI says what changed and the suite keeps the other results.
 
 ```ts
 const result = signupSuite.only('email').run(formData);
@@ -3869,7 +3872,7 @@ const result = signupSuite.only('email').run(formData);
 
 Only tests named `email` execute. Passing or failing results for fields such as `username` and `password` remain available.
 
-## Watch the result accumulate
+## The result still contains the other fields
 
 ```ts
 const data = {
@@ -3950,11 +3953,13 @@ Read the [focus modifier reference](https://vestjs.dev/docs/writing_your_suite/f
 
 Vest does not need to replace the other validation-related tools in an application.
 
-| Layer           | Owns                                                                             |
-| --------------- | -------------------------------------------------------------------------------- |
-| Form manager    | Values, registration, events, and submission mechanics                           |
-| Vest            | Focused execution, retained results, dependencies, pending work, and async races |
-| Boundary schema | Parsing and protecting the final submitted payload                               |
+| Layer                                 | Owns                                                                             |
+| ------------------------------------- | -------------------------------------------------------------------------------- |
+| Form manager                          | Values, registration, events, and submission mechanics                           |
+| Vest suite                            | Focused execution, retained results, dependencies, pending work, and async races |
+| Enforce schema or another schema tool | Parsing, transforming, and protecting the final submitted payload                |
+
+An Enforce schema is part of Vest, so Vest can own both validation over time and the parsed boundary. A separate schema library is optional.
 
 ## React Hook Form through Standard Schema
 
@@ -3971,7 +3976,7 @@ const form = useForm({
 });
 ```
 
-That resolver is useful for full form-library validation. For Vest's progressive runtime behavior, call focused runs from the relevant field interaction and render the Vest result:
+The resolver covers full-form validation. To validate as the user types or leaves a field, run the relevant field through the same suite and render the Vest result:
 
 ```ts
 async function validateUsername() {
@@ -3983,9 +3988,31 @@ async function validateUsername() {
 }
 ```
 
-## Schema boundary
+## Parse with Enforce
 
-At submission, first await the full Vest workflow and then parse the payload with the application's boundary schema:
+Use `enforce.shape` when you want Vest to parse the input as well as run the form's business rules:
+
+```ts
+const registrationSchema = enforce.shape({
+  age: enforce.isNumeric().toNumber(),
+  email: enforce.isString().trim(),
+});
+
+const registrationSuite = create(data => {
+  test('age', 'Must be 18 or older', () => {
+    enforce(data.age).greaterThanOrEquals(18);
+  });
+}, registrationSchema);
+
+const result = await registrationSuite.runStatic(values);
+if (result.isValid()) await api.register(result.value);
+```
+
+The schema parses and transforms the payload. The suite runs the remaining rules, and `result.value` contains the parsed output.
+
+## Keep another schema library
+
+An application that already uses Zod or another schema library can keep it at the boundary:
 
 ```ts
 const result = await registrationSuite.run(values);
@@ -3996,7 +4023,7 @@ if (result.isValid()) {
 }
 ```
 
-This is deliberate overlap: both layers may express required fields, but they answer different questions. Vest manages the interaction lifecycle; the boundary schema guarantees the data contract.
+Here Zod parses the application's data contract and Vest handles validation during interaction. You can replace Zod with Enforce if you would rather keep both jobs in Vest.
 
 See the complete [production architecture](https://vestjs.dev/docs/guides/production-architecture), [Standard Schema reference](https://vestjs.dev/docs/community_resources/standard_schema), and [tool comparison](https://vestjs.dev/docs/vest_vs_the_rest).
 
@@ -4084,7 +4111,7 @@ Debounced tests are asynchronous even when their inner callback is synchronous. 
 - Use only `debounce` when values rarely repeat but interactions arrive in bursts.
 - Use only `memo` when the application revisits a small number of dependency combinations.
 - Combine them when both behaviors occur and the cached answer is safe to reuse.
-- Skip caching when the answer is authoritative, volatile, or unsafe to retain. A short `ttl` can bound reuse when limited caching is acceptable.
+- Skip caching when the answer must always be fresh or is unsafe to retain. Use a short `ttl` when limited reuse is acceptable.
 
 ## Common mistakes
 
@@ -4101,7 +4128,7 @@ Next, read [async validation without race conditions](https://vestjs.dev/docs/gu
 
 # Validation for Multi-Step Forms
 
-Multi-step forms need local progress and global truth. A user should validate the current step without losing the results from completed steps, while final submission must still require the complete workflow.
+A multi-step form should validate the current step without forgetting the steps already completed. Submission still needs to check the whole form.
 
 Model steps with groups:
 
@@ -4152,7 +4179,7 @@ async function canContinue(step: Step, data: OnboardingData) {
 }
 ```
 
-The result from earlier steps remains in the suite, so a review screen can display the status of the full workflow without rerunning every remote check.
+Earlier step results remain in the suite, so a review screen can show the whole form without repeating every remote check.
 
 Cross-field rules remain ordinary TypeScript. Put password and confirmation tests in the same group, then run that group when either value changes. If a field outside the active group must also rerun, use the dependent-field patterns described in [dependent and cross-field validation](https://vestjs.dev/docs/guides/dependent-fields).
 
@@ -4224,26 +4251,26 @@ export function RegistrationForm({ actionState }) {
 }
 ```
 
-Resuming preserves more than an error map: the suite knows which rules passed, failed, or were skipped. The next browser interaction can therefore run one field while retaining trustworthy server conclusions.
+Resuming restores more than an error map: the suite knows which rules passed, failed, or were skipped. The next browser interaction can run one field while keeping the other server results.
 
 ## Add a parsing boundary
 
-Parse untrusted action input with Zod, Valibot, Enforce, or another schema tool before persistence. Use Vest for business validation lifecycle and the schema for the submitted data contract.
+Parse action input before saving it. You can use an Enforce schema directly through `.parse()` or attach it to the Vest suite and call `runStatic()`. If the application already uses Zod, Valibot, or another schema tool, it can stay in that role.
 
 The reference implementation is in the [production registration example](https://vestjs.dev/docs/guides/production-architecture). See [suite serialization](https://vestjs.dev/docs/suite_serialization) for the lower-level API.
 
 
 import ProductionRegistrationSandpack from '@site/src/components/Sandpack/ProductionRegistration';
 
-# Production Registration Architecture
+# Complete Registration Example
 
-The canonical example keeps three responsibilities explicit:
+This example splits the work between three pieces:
 
 > **The form layer owns the inputs, the schema owns the boundary, and Vest owns how validation evolves.**
 
 The executable source lives in [`examples/production-registration`](https://github.com/ealush/vest/tree/latest/examples/production-registration).
 
-## What it demonstrates
+## What is in the example
 
 - React Hook Form owns values, registration, and submission mechanics.
 - The official Standard Schema resolver connects full-form submission to Vest.
@@ -4253,13 +4280,13 @@ The executable source lives in [`examples/production-registration`](https://gith
 - Business accounts reveal a conditional company section.
 - Password strength is a non-blocking warning.
 - The server uses a stateless Vest run.
-- Zod parses the final API boundary.
+- This implementation uses Zod for the final API boundary; an Enforce schema can own the same boundary through `.parse()` or as the suite schema.
 - A runnable Vite page demonstrates the architecture with deterministic local services.
 - Vitest proves focused retention, async race behavior, conditionals, warnings, and server isolation.
 
-## Try the browser workflow
+## Try it
 
-This playground loads the browser files directly from the canonical example—there is no second copy to drift. Try `taken` as the username, correct it before the delayed response returns, switch to a business account, and submit a weak password to see errors, pending state, conditional validation, and warnings interact.
+The playground loads its files from the example project, so the code shown here and the tested example stay in sync. Try `taken` as the username and change it before the delayed response returns. You can also switch to a business account or submit a weak password to see the conditional fields and warning state.
 
 <ProductionRegistrationSandpack />
 
@@ -4286,9 +4313,11 @@ Submission
   → persist parsed payload
 ```
 
-## Why both Vest and a boundary schema?
+## Why the example also uses Zod
 
-The schema protects a complete data boundary. It does not remember what happened during the previous interaction or decide which remote response is still relevant. Vest supplies that runtime behavior and then gets out of the way of parsing and persistence.
+Many applications already use Zod, so this example shows how to keep it. Zod parses the submitted payload; Vest handles focused runs, async checks, warnings, conditional fields, and server-side business rules.
+
+Zod is optional here. An Enforce schema created with `enforce.shape` can parse and transform the payload with `.parse()`. You can also pass it to `create`; then `run()` and `runStatic()` expose the parsed value as `result.value`.
 
 ## Run the example
 
@@ -4304,7 +4333,7 @@ Start with the [suite source](https://github.com/ealush/vest/blob/latest/example
 
 # Typed Schemas and Parsed Results
 
-Interactive validation and structural parsing solve different parts of the same workflow. A Vest suite can accept an Enforce schema as the second argument to `create`, giving the run a typed input, a parsed output, and behavioral tests.
+An Enforce schema can parse the input before the suite's tests run. Pass it as the second argument to `create`; the suite callback receives the parsed type and a successful result exposes the parsed value.
 
 ## Define input and output together
 
@@ -4370,9 +4399,9 @@ const output = await registrationSuite['~standard'].validate({
 
 Successful Standard Schema output contains the parsed values, so `output.value.age` is a number.
 
-## Assign clear responsibilities
+## Using another schema library
 
-An Enforce schema can be the application's boundary schema. It is also reasonable to use Zod, Valibot, or another schema at an external API boundary while Vest manages progressive interaction. What matters is that the form manager, boundary parser, and validation-state runtime each have an explicit job.
+Enforce can parse your API boundary, but it does not have to. If your application already uses Zod, Valibot, or another schema library there, keep it and use Vest for validation during interaction.
 
 Read [form and schema library integration](https://vestjs.dev/docs/guides/form-and-schema-integration), the [Standard Schema reference](https://vestjs.dev/docs/community_resources/standard_schema), and the [production registration architecture](https://vestjs.dev/docs/guides/production-architecture) for complete compositions.
 
@@ -4383,7 +4412,7 @@ Interactive validation has more than two states. A field may be untested, pendin
 
 | State    | What it means                                      | Typical UI                |
 | -------- | -------------------------------------------------- | ------------------------- |
-| Untested | No authoritative test result exists yet            | Neutral guidance          |
+| Untested | The field has not been checked yet                 | Neutral guidance          |
 | Pending  | Asynchronous work for the current value is running | Progress indicator        |
 | Error    | A blocking rule failed                             | Error message             |
 | Warning  | Advisory guidance failed                           | Non-blocking message      |
@@ -4440,14 +4469,14 @@ Render status in this order:
 
 On submission, await the complete suite and require `isValid()`. Warnings do not make the suite invalid; errors, pending work, and incomplete required tests do.
 
-Do not merge warning messages into the error array. Their separate severity is what lets the same suite support nuanced feedback in the browser and on the server.
+Keep warnings separate from errors. That is what lets the UI show advice without blocking submission.
 
 Read the [result selector reference](https://vestjs.dev/docs/writing_your_suite/accessing_the_result) and [warning guide](https://vestjs.dev/docs/writing_tests/warn_only_tests).
 
 
 # When Not to Use Vest
 
-Vest is designed for validation that has a lifecycle. It is not automatically the best choice every time an application checks a value.
+Vest is most useful when validation changes during user interaction. It is more machinery than you need for every value check.
 
 ## Use native HTML validation when
 
@@ -4455,13 +4484,13 @@ Vest is designed for validation that has a lifecycle. It is not automatically th
 - `required`, `min`, `max`, `pattern`, and input types express the rules;
 - custom error timing and server rule sharing are unnecessary.
 
-## Use a schema validator alone when
+## Use only a schema API when
 
 - the primary job is parsing an API request, configuration file, or environment variables;
 - validation happens once at a clear boundary;
 - transformations, codecs, JSON Schema, or ecosystem-specific type integrations are more important than interaction state.
 
-Zod, Valibot, ArkType, Joi, and Ajv each have strengths in this category.
+An Enforce schema's `.parse()` API can be enough for this job without creating a Vest suite. Zod, Valibot, ArkType, Joi, and Ajv also have strengths in this category.
 
 ## Use a form manager's built-in validation when
 
@@ -4483,7 +4512,7 @@ Vest earns its place when several of these are true:
 
 ## Combine tools when responsibilities differ
 
-A common production architecture is React Hook Form for input mechanics, Vest for progressive validation state, and Zod for the final API boundary. This is not redundant when each layer owns a distinct failure mode.
+You might use React Hook Form for input handling and Vest with Enforce for both interactive validation and the API boundary. If the project already uses Zod, keep Zod at the boundary and use Vest for the form. Either approach works.
 
 See the [production architecture](https://vestjs.dev/docs/guides/production-architecture) and [comparison guide](https://vestjs.dev/docs/vest_vs_the_rest).
 
@@ -4819,46 +4848,44 @@ export function RegistrationForm({ actionData }) {
 
 :::caution Why not just pass the errors?
 You might wonder, "Why not just pass the error object?"
-If you only pass errors, your suite doesn't know _which_ tests passed, which are pending, or which groups were skipped. By resuming the full state, Vest can continue validation seamlessly (e.g., when the user edits a field) without losing the context of the server-side run.
+If you only pass errors, your suite doesn't know _which_ tests passed, which are pending, or which groups were skipped. Resuming the full state lets the next field edit continue from the server result without rebuilding that context in the client.
 :::
 
 
-# Ten Vest 6 Tutorials
+# Vest Tutorials
 
-Vest becomes most useful when validation stops being a one-time check and starts behaving like a process. These tutorials progress from a small test-like suite to focused state, asynchronous work, conditional workflows, server continuity, and application-specific rules.
+Start with a small suite, or jump straight to the problem you are trying to solve. The examples cover focused validation, async checks, conditional fields, schemas, and sharing validation between the browser and server.
 
-Every example follows the Vest 6 API hierarchy:
+One API detail is worth knowing before you begin:
 
 1. Use `suite.run(data)` for stateful application validation.
 2. Use `suite.runStatic(data)` for an independent server request or isolated execution.
-3. Pass the suite to Standard Schema consumers. The `~standard.validate` hook is an interoperability contract, not Vest's general execution API.
+3. Pass the suite itself to a library that supports Standard Schema. The `~standard.validate` hook is for those integrations, not for calling directly in application code.
 
-## The learning path
+## Pick a tutorial
 
-|   # | Tutorial                                                                           | What you will build                         | Core capability                                      |
-| --: | ---------------------------------------------------------------------------------- | ------------------------------------------- | ---------------------------------------------------- |
-|   1 | [Validation that reads like unit tests](https://vestjs.dev/docs/get_started)                          | A signup suite outside the UI               | `create`, `test`, `enforce`, and result selectors    |
-|   2 | [Validate one field without forgetting the rest](https://vestjs.dev/docs/guides/focused-validation)   | Progressive profile validation              | Focused execution and retained results               |
-|   3 | [Async checks without stale results](https://vestjs.dev/docs/guides/async-validation-race-conditions) | Username availability validation            | Pending state, cancellation, and race safety         |
-|   4 | [Reduce repeated async validation](https://vestjs.dev/docs/guides/memo-and-debounce)                  | A coupon check with bounded reuse           | `memo`, `debounce`, and `AbortSignal`                |
-|   5 | [Warnings that do not block submission](https://vestjs.dev/docs/guides/validation-status)             | Password-strength guidance                  | Errors, warnings, pending, and untested state        |
-|   6 | [Choose between skipping and omitting](https://vestjs.dev/docs/guides/conditional-sections)           | Pickup and delivery sections                | Relevant-later versus not-applicable rules           |
-|   7 | [Validate a multi-step workflow](https://vestjs.dev/docs/guides/multi-step-workflows)                 | A typed onboarding wizard                   | Groups, step validity, and cross-field rules         |
-|   8 | [Parse typed input without losing Vest's runtime](https://vestjs.dev/docs/guides/typed-schemas)       | A schema-backed registration suite          | Input/output inference, parsing, and Standard Schema |
-|   9 | [Share validation between server and client](https://vestjs.dev/docs/guides/client-server-validation) | Stateless request validation with hydration | `runStatic`, serialization, and resumption           |
-|  10 | [Teach validation your domain language](https://vestjs.dev/docs/enforce/creating_custom_rules)        | Typed, context-aware Enforce rules          | `condition`, `enforce.extend`, and sibling context   |
+| Tutorial                                                                           | Example                              | What it covers                                     |
+| ---------------------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------------- |
+| [Write your first suite](https://vestjs.dev/docs/get_started)                                         | Signup                               | `create`, `test`, `enforce`, and result selectors  |
+| [Validate one field without forgetting the rest](https://vestjs.dev/docs/guides/focused-validation)   | Profile form                         | Focused runs and retained results                  |
+| [Handle async checks safely](https://vestjs.dev/docs/guides/async-validation-race-conditions)         | Username availability                | Pending state, cancellation, and race safety       |
+| [Avoid repeated async work](https://vestjs.dev/docs/guides/memo-and-debounce)                         | Coupon check                         | `memo`, `debounce`, and `AbortSignal`              |
+| [Show warnings without blocking submission](https://vestjs.dev/docs/guides/validation-status)         | Password strength                    | Errors, warnings, pending, and untested state      |
+| [Skip or remove conditional rules](https://vestjs.dev/docs/guides/conditional-sections)               | Pickup and delivery                  | `skipWhen`, `omitWhen`, and `optional`             |
+| [Validate a multi-step form](https://vestjs.dev/docs/guides/multi-step-workflows)                     | Onboarding                           | Groups, step validity, and cross-field rules       |
+| [Parse input and keep the typed result](https://vestjs.dev/docs/guides/typed-schemas)                 | Registration                         | Parsing, type inference, and Standard Schema       |
+| [Share validation between server and client](https://vestjs.dev/docs/guides/client-server-validation) | Server validation and browser resume | `runStatic`, serialization, and resumption         |
+| [Write rules for your own domain](https://vestjs.dev/docs/enforce/creating_custom_rules)              | Custom Enforce rules                 | `condition`, `enforce.extend`, and sibling context |
 
-## What the sequence demonstrates
+## A good order for learning Vest
 
-The first tutorial makes rules readable and independently testable. The next six show why Vest is a validation-state runtime: each interaction can run a deliberate subset of work while the suite retains trustworthy history and coordinates pending results. The final three connect that runtime to typed parsing, server authority, ecosystem tools, and domain-specific vocabulary.
+If Vest is new to you, read the first three in order. They introduce suites, focused runs, and async validation—the ideas most of the other guides build on. After that, choose the examples that match your application.
 
-You do not need every capability. Start with the tutorial closest to the failure mode in your application, then return to the sequence when the workflow grows.
+## See everything working together
 
-## After the tutorials
-
-- Use the [production registration architecture](https://vestjs.dev/docs/guides/production-architecture) to see the capabilities composed in one runnable React application.
-- Read [Vest, schema validators, and form libraries](https://vestjs.dev/docs/vest_vs_the_rest) before choosing responsibility boundaries.
-- Check [when not to use Vest](https://vestjs.dev/docs/guides/when-not-to-use-vest) for smaller or purely structural validation tasks.
+- Open the [complete registration example](https://vestjs.dev/docs/guides/production-architecture) for a runnable React application.
+- Read [Vest, schema validators, and form libraries](https://vestjs.dev/docs/vest_vs_the_rest) to decide which tool should handle each part of your form.
+- Check [when not to use Vest](https://vestjs.dev/docs/guides/when-not-to-use-vest) if your validation is simple or only runs once.
 
 
 import { SchemaTypedSandpack, ConfigTypedSandpack } from '@site/src/components/Sandpack/TypedSuites';
@@ -5088,7 +5115,7 @@ enforce(10).isWithinRange(5, 15);
 
 # Understanding Vest's State
 
-One of Vest's most powerful features is its **stateful validation**. Unlike schema-based validators that start fresh every time, Vest remembers previous results and merges them intelligently.
+Vest suites keep validation state between runs. A focused run updates the fields it checked and leaves the other field results in place.
 
 ## Why Stateful Validation?
 
@@ -5097,7 +5124,7 @@ Imagine a form with 10 fields. When a user updates just the "username" field, yo
 1. **Re-validate everything** - Slow, and might flash errors on untouched fields
 2. **Validate only "username"** - Fast, but you lose the state of other fields
 
-Vest gives you the best of both worlds: **validate one field, keep the full picture**.
+With Vest, you can validate one field and keep the rest of the result.
 
 ### How It Works
 
@@ -5503,7 +5530,7 @@ Vest 5 uses Javascript Proxies, which were introduced in ES2015. Therefore, Vest
 
 # Using Vest with React
 
-Vest integrates seamlessly with React applications, providing powerful validation capabilities for forms and user input. This guide covers common patterns and best practices.
+Vest suites do not depend on React. A component runs the suite when a value changes and renders the result from state. This guide shows the usual patterns.
 
 ## Quick Start
 
@@ -6298,27 +6325,28 @@ const fieldThreeClasses = cn('field_3'); // "some-tested-class my_warning_class"
 
 # Vest, Schema Validators, and Form Libraries
 
-Vest does not need every validation problem to be a Vest problem.
+Vest can work alongside the form and schema tools you already use.
 
-Different tools own different parts of the workflow:
+These capabilities can be composed, but they are not mutually exclusive:
 
-| Tool category                    | Primary responsibility                              |
-| -------------------------------- | --------------------------------------------------- |
-| Schema validators such as Zod    | Define and parse a valid data boundary              |
-| Form managers such as RHF/Formik | Manage values, registration, events, and submission |
-| **Vest**                         | Manage how validation evolves during interaction    |
+| Tool or layer                    | What it can own                                    |
+| -------------------------------- | -------------------------------------------------- |
+| Form managers such as RHF/Formik | Values, registration, events, and submission       |
+| Enforce schemas, Zod, or Valibot | Structural validation, transformation, and parsing |
+| **Vest suites**                  | Stateful and stateless validation workflows        |
+| **Vest suite + Enforce schema**  | Both parsed boundaries and validation over time    |
 
-## The distinction
+## Where Vest differs
 
 A schema validator is excellent at answering:
 
 > Does this submitted payload have the expected structure and values?
 
-Vest is designed to answer:
+A Vest suite also needs to answer:
 
 > The user changed one part of a workflow. What needs to run now, what previous state remains valid, and which async result should be trusted?
 
-Vest can also perform structural validation with Enforce schemas. The distinction is about the runtime model, not a claim that schema validation is unimportant.
+Vest can handle both jobs. Enforce schemas validate, transform, and parse data. A Vest suite keeps test results up to date while the user moves through a form.
 
 ## Vest and Zod
 
@@ -6330,6 +6358,31 @@ Zod is a strong choice for:
 - deriving TypeScript types;
 - one-shot validation.
 
+Enforce supports those same core boundary jobs. A schema created with `enforce.shape`, `enforce.loose`, or `enforce.partial` exposes `.parse()` and returns transformed output:
+
+```ts
+const accountSchema = enforce.shape({
+  age: enforce.isNumeric().toNumber(),
+  email: enforce.isString().trim(),
+});
+
+const account = accountSchema.parse(input);
+// account.age is a number
+```
+
+Attach the schema to a suite when the same boundary and parsed values should participate in Vest's runtime:
+
+```ts
+const accountSuite = create(parsedAccount => {
+  test('age', 'Must be an adult', () => {
+    enforce(parsedAccount.age).greaterThanOrEquals(18);
+  });
+}, accountSchema);
+
+const result = accountSuite.runStatic(input);
+if (result.isValid()) persist(result.value);
+```
+
 Vest is a strong choice for:
 
 - validating one field or step at a time;
@@ -6339,9 +6392,9 @@ Vest is a strong choice for:
 - multi-step workflows;
 - warnings, pending state, and progressive completion.
 
-### Use both
+### Use Vest on its own or with Zod
 
-A production application can use Zod for the submitted boundary and Vest for interaction:
+Vest can own both the interactive workflow and the submitted boundary:
 
 ```text
 User interaction
@@ -6349,13 +6402,19 @@ User interaction
   → UI shows errors, warnings, and pending work
 
 Final submission
-  → Zod parses the complete boundary payload
-  → server applies authoritative business rules
+  → Enforce schema parses and transforms the complete payload
+  → Vest runStatic applies the business rules
 ```
 
-The concise explanation is:
+If your application already uses Zod, parse the payload before a stateless Vest run:
 
-> **Zod defines what a valid submitted account looks like. Vest manages how the user gets there.**
+```text
+Final submission
+  → Zod parses the complete boundary payload
+  → Vest runStatic applies the business rules
+```
+
+Zod and Enforce can both parse the boundary. The Vest suite is what carries the validation result from one interaction to the next.
 
 ## Vest and form state managers
 
@@ -6373,19 +6432,19 @@ Vest implements Standard Schema so compatible tools can consume suites and Enfor
 
 ## Capability comparison
 
-| Capability                          | Schema validator   | Form state manager | Vest                               |
-| ----------------------------------- | ------------------ | ------------------ | ---------------------------------- |
-| Parse a complete object boundary    | Primary            | Varies             | Yes, with schemas                  |
-| Own field values and registration   | No                 | Primary            | No                                 |
-| Run selected fields or groups       | Varies             | Often              | Primary                            |
-| Retain validation between runs      | No                 | Often              | Primary                            |
-| Prevent stale async results         | Usually manual     | Varies             | Built in                           |
-| Model dependent fields              | Cross-object rule  | Varies             | `include` and ordinary JS          |
-| Model conditional sections          | Unions/refinements | Varies             | `skipWhen`, `omitWhen`, `optional` |
-| Warnings that do not block submit   | Usually custom     | Varies             | Built in                           |
-| Share rules across UI frameworks    | Yes                | Usually no         | Yes                                |
-| Stateless server execution          | Yes                | Not primary        | `runStatic()`                      |
-| Resume full server validation state | No                 | Framework-specific | `SuiteSerializer`                  |
+| Capability                          | Standalone schema tool | Form state manager | Vest                               |
+| ----------------------------------- | ---------------------- | ------------------ | ---------------------------------- |
+| Parse a complete object boundary    | Primary                | Varies             | `enforce.shape(...).parse()`       |
+| Own field values and registration   | No                     | Primary            | No                                 |
+| Run selected fields or groups       | Varies                 | Often              | Primary                            |
+| Retain validation between runs      | No                     | Often              | Primary                            |
+| Prevent stale async results         | Usually manual         | Varies             | Built in                           |
+| Model dependent fields              | Cross-object rule      | Varies             | `include` and ordinary JS          |
+| Model conditional sections          | Unions/refinements     | Varies             | `skipWhen`, `omitWhen`, `optional` |
+| Warnings that do not block submit   | Usually custom         | Varies             | Built in                           |
+| Share rules across UI frameworks    | Yes                    | Usually no         | Yes                                |
+| Stateless server execution          | Yes                    | Not primary        | `runStatic()`                      |
+| Resume full server validation state | No                     | Framework-specific | `SuiteSerializer`                  |
 
 ## Why use Vest instead of writing validation state manually?
 
@@ -6414,7 +6473,7 @@ Prefer a simpler solution when:
 - validation happens only once at an API boundary;
 - your primary problem is storing form values rather than validation behavior.
 
-The goal is not to replace every schema or form library. It is to make progressive validation a first-class part of the application architecture.
+You do not have to replace your schema or form library to use Vest. Add it when keeping validation correct between interactions is the hard part.
 
 
 # Debouncing Tests
@@ -7628,7 +7687,7 @@ A common challenge in form validation is "noise control." You don't want to scre
 
 Traditionally, libraries use an `isDirty` flag to track if a user has modified a field. Since Vest is **UI-agnostic** (it doesn't touch your DOM or listen to events), it doesn't track "dirty" state for you.
 
-Instead, Vest provides two powerful tools to handle user interaction: **`isTested()`** and **`suite.only()`**.
+Vest provides two tools for this: **`isTested()`** and **`suite.only()`**.
 
 ## 1. `isTested()`: The Vest Alternative to `isDirty`
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -1,5 +1,5 @@
 # Vest 6
-> Form validation that remembers previous runs. Vest validates what changed, keeps the other results, and ignores stale async responses.
+> Form validation written like unit tests. Vest validates what changed, keeps the other results, and ignores stale async responses.
 
 - [Full Vest 6 documentation](https://vestjs.dev/llms-full.txt)
 - [Consumer usage guide](https://vestjs.dev/llms-consumer.txt)

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -1,5 +1,5 @@
 # Vest 6
-> TypeScript validation-state framework for complex interactive forms. Vest validates what changed, retains trustworthy previous results, and prevents stale async work from corrupting current state.
+> Form validation that remembers previous runs. Vest validates what changed, keeps the other results, and ignores stale async responses.
 
 - [Full Vest 6 documentation](https://vestjs.dev/llms-full.txt)
 - [Consumer usage guide](https://vestjs.dev/llms-consumer.txt)
@@ -20,7 +20,7 @@
 Vest composes with schema validators and form managers; these categories are not mutually exclusive.
 
 ## Start with a problem
-- [Ten Vest 6 tutorials](https://vestjs.dev/docs/tutorials)
+- [Vest tutorials](https://vestjs.dev/docs/tutorials)
 - [Async validation without race conditions](https://vestjs.dev/docs/guides/async-validation-race-conditions)
 - [Validate one field or step](https://vestjs.dev/docs/guides/focused-validation)
 - [Dependent and cross-field validation](https://vestjs.dev/docs/guides/dependent-fields)
@@ -31,14 +31,14 @@ Vest composes with schema validators and form managers; these categories are not
 - [Typed schemas and parsed results](https://vestjs.dev/docs/guides/typed-schemas)
 - [React Hook Form and schema integration](https://vestjs.dev/docs/guides/form-and-schema-integration)
 - [Next.js Server Actions and resumable state](https://vestjs.dev/docs/guides/nextjs-server-actions)
-- [Production registration architecture](https://vestjs.dev/docs/guides/production-architecture)
+- [Complete registration example](https://vestjs.dev/docs/guides/production-architecture)
 - [When not to use Vest](https://vestjs.dev/docs/guides/when-not-to-use-vest)
 
 ## Key Concepts
-- **Living Result**: A suite stores validation truth and reconciles new runs with previous field results.
+- **Retained Results**: A suite updates the fields that ran and keeps the results for the others.
 - **Focused Updates**: Validate a field, step, or group with `suite.only()` or `suite.focus()` while retaining everything else.
 - **Race-safe Async**: Pending work is tracked, obsolete runs are canceled, and stale async results are ignored.
-- **Progressive Workflows**: Model dependent fields, conditional sections, optional values, warnings, groups, and dynamic lists.
+- **Form Workflows**: Model dependent fields, conditional sections, optional values, warnings, groups, and dynamic lists.
 
 ## Advanced Features
 - **Server and SSR**: Use `runStatic()`, then serialize and resume full validation state in the browser.
@@ -48,7 +48,7 @@ Vest composes with schema validators and form managers; these categories are not
 
 ## Core Documentation
 - [Getting Started with Vest](https://vestjs.dev/docs/get_started)
-- [How Vest Thinks About Validation](https://vestjs.dev/docs/concepts)
+- [How Vest Handles Validation](https://vestjs.dev/docs/concepts)
 - [Vest, Schema Validators, and Form Libraries](https://vestjs.dev/docs/vest_vs_the_rest)
 - [Api reference](https://vestjs.dev/docs/api_reference)
 - [Server-Side Rendering (SSR)](https://vestjs.dev/docs/suite_serialization)
@@ -56,7 +56,7 @@ Vest composes with schema validators and form managers; these categories are not
 - [Server-Side & SSR](https://vestjs.dev/docs/server_side_validations)
 - [Typescript Support](https://vestjs.dev/docs/typescript_support)
 - [Upgrade guides](https://vestjs.dev/docs/upgrade_guide)
-- [Ten Vest 6 Tutorials](https://vestjs.dev/docs/tutorials)
+- [Vest Tutorials](https://vestjs.dev/docs/tutorials)
 
 ## Problem-first Guides
 - [Async Validation Without Race Conditions](https://vestjs.dev/docs/guides/async-validation-race-conditions)
@@ -69,7 +69,7 @@ Vest composes with schema validators and form managers; these categories are not
 - [Reduce Repeated Async Validation](https://vestjs.dev/docs/guides/memo-and-debounce)
 - [Validation for Multi-Step Forms](https://vestjs.dev/docs/guides/multi-step-workflows)
 - [Next.js Server Actions Without Double Validation](https://vestjs.dev/docs/guides/nextjs-server-actions)
-- [Production Registration Architecture](https://vestjs.dev/docs/guides/production-architecture)
+- [Complete Registration Example](https://vestjs.dev/docs/guides/production-architecture)
 - [Typed Schemas and Parsed Results](https://vestjs.dev/docs/guides/typed-schemas)
 - [Errors, Warnings, Pending, and Untested State](https://vestjs.dev/docs/guides/validation-status)
 - [When Not to Use Vest](https://vestjs.dev/docs/guides/when-not-to-use-vest)


### PR DESCRIPTION
## What changed

- fixes dark-mode contrast for inline code, links, badges, breadcrumbs, CTAs, the homepage comparison section, and footer
- renames the tutorial index to Vest Tutorials and rewrites it around tasks instead of a numbered marketing sequence
- removes generated-sounding language across the new guides, homepage, READMEs, and supporting docs
- regenerates the public llms indexes so their titles and wording stay in sync

## Verification

- 19 website tests pass
- optimized website production build passes
- visually checked the homepage and representative docs pages in light and dark modes
- no browser console errors during the page audit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed product messaging across the README and website to describe “form validation written like unit tests,” emphasizing retained results and ignoring stale async responses.
  * Clarified suite behavior and guidance across focused validation, multi-step workflows, conditional sections, warnings vs errors, memo/debounce freshness, and async race safety.
  * Updated integration guidance (schemas/form managers, React), plus client/server validation, server actions, serialization/resume, and SSR examples; refreshed tutorial navigation and terminology.
* **Style**
  * Improved dark-theme appearance (homepage layout, inline code, breadcrumbs, version badges, theme bands, and code highlighting/footer theming).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->