### PR TITLE
Show the homepage suite and fix long docs backgrounds

### DIFF
--- a/website/src/components/codePlaygrounds.test.js
+++ b/website/src/components/codePlaygrounds.test.js
@@ -39,6 +39,14 @@ const rawExampleSuiteCode = readTemplateLiteral(rawExampleSource, 'SuiteCode');
 const heroSuiteCode = readTemplateLiteral(homepageSource, 'HeroSuiteCode');
 
 function executeDefaultExport(source, modules, scope = {}) {
+  const scopeNames = Object.keys(scope);
+
+  scopeNames.forEach(name => {
+    if (name === 'modules' || !/^[A-Za-z_$][\w$]*$/.test(name)) {
+      throw new Error(`Invalid injected scope name: ${name}`);
+    }
+  });
+
   const executable = source
     .replace(
       /import \{ ([^}]+) \} from '([^']+)';/g,
@@ -52,9 +60,9 @@ function executeDefaultExport(source, modules, scope = {}) {
     )
     .replace(/export default ([A-Za-z_$][\w$]*);/, 'return $1;');
 
-  return new Function('modules', ...Object.keys(scope), executable)(
+  return new Function('modules', ...scopeNames, executable)(
     modules,
-    ...Object.values(scope),
+    ...scopeNames.map(name => scope[name]),
   );
 }
 
@@ -69,6 +77,19 @@ function executeNamedFunction(source, functionName) {
 describe('interactive code playgrounds', () => {
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('rejects invalid injected scope names', () => {
+    expect(() =>
+      executeDefaultExport('export default true;', {}, { modules: true }),
+    ).toThrow('Invalid injected scope name: modules');
+    expect(() =>
+      executeDefaultExport(
+        'export default true;',
+        {},
+        { 'invalid-name': true },
+      ),
+    ).toThrow('Invalid injected scope name: invalid-name');
   });
 
   it('executes the exact Getting Started Sandpack suite', () => {
@@ -134,9 +155,10 @@ describe('interactive code playgrounds', () => {
     await usernameRun;
 
     expect(suite.isValid()).toBe(true);
-    expect(isUsernameAvailable).toHaveBeenCalledWith('evyatar', {
-      signal: expect.any(AbortSignal),
-    });
+    expect(isUsernameAvailable).toHaveBeenCalledWith(
+      'evyatar',
+      expect.any(AbortSignal),
+    );
   });
 
   it('reads async completion state from the suite', () => {

--- a/website/src/components/codePlaygrounds.test.js
+++ b/website/src/components/codePlaygrounds.test.js
@@ -28,6 +28,7 @@ const anyTestRecipeSource = new URL(
 );
 const asyncTestsSource = new URL('./Sandpack/AsyncTests.js', import.meta.url);
 const rawExampleSource = new URL('./RawExample.js', import.meta.url);
+const homepageSource = new URL('../pages/index.js', import.meta.url);
 const anyTestRecipeSuiteCode = readTemplateLiteral(
   anyTestRecipeSource,
   'SuiteCode',
@@ -35,8 +36,9 @@ const anyTestRecipeSuiteCode = readTemplateLiteral(
 const getStartedSuiteCode = readTemplateLiteral(getStartedSource, 'SuiteCode');
 const rawExampleApiCode = readTemplateLiteral(rawExampleSource, 'ApiCode');
 const rawExampleSuiteCode = readTemplateLiteral(rawExampleSource, 'SuiteCode');
+const heroSuiteCode = readTemplateLiteral(homepageSource, 'HeroSuiteCode');
 
-function executeDefaultExport(source, modules) {
+function executeDefaultExport(source, modules, scope = {}) {
   const executable = source
     .replace(
       /import \{ ([^}]+) \} from '([^']+)';/g,
@@ -50,7 +52,10 @@ function executeDefaultExport(source, modules) {
     )
     .replace(/export default ([A-Za-z_$][\w$]*);/, 'return $1;');
 
-  return new Function('modules', executable)(modules);
+  return new Function('modules', ...Object.keys(scope), executable)(
+    modules,
+    ...Object.values(scope),
+  );
 }
 
 function executeNamedFunction(source, functionName) {
@@ -107,6 +112,30 @@ describe('interactive code playgrounds', () => {
     runnableSources.forEach(source => {
       const dependencyRange = source.match(/vest: '([^']+)'/)?.[1];
       expect(dependencyRange).toBe('latest');
+    });
+  });
+
+  it('executes the exact suite shown in the homepage run ledger', async () => {
+    const isUsernameAvailable = vi.fn().mockResolvedValue(true);
+    const suite = executeDefaultExport(
+      heroSuiteCode,
+      { vest },
+      { isUsernameAvailable },
+    );
+
+    suite.only('email').run({ email: 'dev@vestjs.dev' });
+    suite.only('password').run({ password: 'correct horse battery staple' });
+    const usernameRun = suite.only('username').run({ username: 'evyatar' });
+
+    expect(usernameRun.isPending('username')).toBe(true);
+    expect(usernameRun.isValid('email')).toBe(true);
+    expect(usernameRun.isValid('password')).toBe(true);
+
+    await usernameRun;
+
+    expect(suite.isValid()).toBe(true);
+    expect(isUsernameAvailable).toHaveBeenCalledWith('evyatar', {
+      signal: expect.any(AbortSignal),
     });
   });
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -88,8 +88,12 @@ html[data-theme='dark'] {
   --vest-shadow-md: 0 22px 60px rgba(0, 0, 0, 0.28);
 }
 
+html[data-theme],
 body {
   background: var(--vest-body-bg-gradient), var(--ifm-background-color);
+}
+
+body {
   color: var(--ifm-font-color-base);
 }
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -88,12 +88,12 @@ html[data-theme='dark'] {
   --vest-shadow-md: 0 22px 60px rgba(0, 0, 0, 0.28);
 }
 
-html[data-theme],
-body {
+html[data-theme] {
   background: var(--vest-body-bg-gradient), var(--ifm-background-color);
 }
 
 body {
+  background: transparent;
   color: var(--ifm-font-color-base);
 }
 

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -19,7 +19,7 @@ const signupSuite = create(data => {
   });
 
   test('username', 'Username is taken', async ({ signal }) => {
-    const available = await isUsernameAvailable(data.username, { signal });
+    const available = await isUsernameAvailable(data.username, signal);
     enforce(available).isTruthy();
   });
 
@@ -47,6 +47,22 @@ function HomepageHeader() {
     document
       .getElementById('async-race-demo')
       ?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  const handleLedgerTabKeyDown = event => {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+
+    event.preventDefault();
+    const views = ['run', 'suite'];
+    const direction = event.key === 'ArrowRight' ? 1 : -1;
+    const currentIndex = views.indexOf(ledgerView);
+    const nextView =
+      views[(currentIndex + direction + views.length) % views.length];
+
+    setLedgerView(nextView);
+    event.currentTarget.parentElement
+      ?.querySelector(`#ledger-${nextView}-tab`)
+      ?.focus();
   };
 
   return (
@@ -161,7 +177,9 @@ function HomepageHeader() {
                 className={styles.ledgerTab}
                 id="ledger-run-tab"
                 onClick={() => setLedgerView('run')}
+                onKeyDown={handleLedgerTabKeyDown}
                 role="tab"
+                tabIndex={ledgerView === 'run' ? 0 : -1}
                 type="button"
               >
                 RUN
@@ -172,7 +190,9 @@ function HomepageHeader() {
                 className={styles.ledgerTab}
                 id="ledger-suite-tab"
                 onClick={() => setLedgerView('suite')}
+                onKeyDown={handleLedgerTabKeyDown}
                 role="tab"
+                tabIndex={ledgerView === 'suite' ? 0 : -1}
                 type="button"
               >
                 SUITE
@@ -185,6 +205,7 @@ function HomepageHeader() {
               className={styles.ledgerPanel}
               id="ledger-run-panel"
               role="tabpanel"
+              tabIndex={0}
             >
               <div className={styles.ledgerCommand}>
                 <span aria-hidden="true">›</span>
@@ -241,6 +262,7 @@ function HomepageHeader() {
               className={clsx(styles.ledgerPanel, styles.codePanel)}
               id="ledger-suite-panel"
               role="tabpanel"
+              tabIndex={0}
             >
               <Highlight
                 code={HeroSuiteCode}
@@ -249,25 +271,29 @@ function HomepageHeader() {
               >
                 {({ getLineProps, getTokenProps, tokens }) => (
                   <pre className={styles.suiteCode}>
-                    {tokens.map((line, lineIndex) => (
-                      <div
-                        key={lineIndex}
-                        {...getLineProps({ line })}
-                        className={styles.codeLine}
-                      >
-                        <span className={styles.codeLineNumber}>
-                          {String(lineIndex + 1).padStart(2, '0')}
-                        </span>
-                        <span>
-                          {line.map((token, tokenIndex) => (
-                            <span
-                              key={tokenIndex}
-                              {...getTokenProps({ token })}
-                            />
-                          ))}
-                        </span>
-                      </div>
-                    ))}
+                    {tokens.map((line, lineIndex) => {
+                      const lineProps = getLineProps({ line });
+
+                      return (
+                        <div
+                          key={lineIndex}
+                          {...lineProps}
+                          className={clsx(lineProps.className, styles.codeLine)}
+                        >
+                          <span className={styles.codeLineNumber}>
+                            {String(lineIndex + 1).padStart(2, '0')}
+                          </span>
+                          <span>
+                            {line.map((token, tokenIndex) => (
+                              <span
+                                key={tokenIndex}
+                                {...getTokenProps({ token })}
+                              />
+                            ))}
+                          </span>
+                        </div>
+                      );
+                    })}
                   </pre>
                 )}
               </Highlight>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -2,6 +2,7 @@ import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
+import { Highlight, themes } from 'prism-react-renderer';
 import React, { useState } from 'react';
 
 import AsyncRaceDemo from '../components/AsyncRaceDemo';
@@ -10,8 +11,28 @@ import RawExample from '../components/RawExample';
 
 import styles from './index.module.css';
 
+const HeroSuiteCode = `import { create, enforce, test } from 'vest';
+
+const signupSuite = create(data => {
+  test('email', 'Enter a valid email', () => {
+    enforce(data.email).matches(/^\\S+@\\S+\\.\\S+$/);
+  });
+
+  test('username', 'Username is taken', async ({ signal }) => {
+    const available = await isUsernameAvailable(data.username, { signal });
+    enforce(available).isTruthy();
+  });
+
+  test('password', 'Use at least 8 characters', () => {
+    enforce(data.password).longerThanOrEquals(8);
+  });
+});
+
+export default signupSuite;`;
+
 function HomepageHeader() {
   const [copied, setCopied] = useState(false);
+  const [ledgerView, setLedgerView] = useState('run');
   const installCommand = 'npm i vest';
 
   const handleCopy = () => {
@@ -123,60 +144,139 @@ function HomepageHeader() {
         </div>
         <div className={styles.ledger} aria-label="A live Vest suite run">
           <div className={styles.ledgerHeader}>
-            <div>
+            <div className={styles.ledgerMeta}>
               <span className={styles.ledgerKicker}>LIVE SUITE</span>
-              <strong>signup / run 04</strong>
+              <strong>
+                signup / {ledgerView === 'run' ? 'run 04' : 'suite.js'}
+              </strong>
             </div>
-            <span className={styles.runState}>RUNNING</span>
+            <div
+              className={styles.ledgerTabs}
+              role="tablist"
+              aria-label="Live suite view"
+            >
+              <button
+                aria-controls="ledger-run-panel"
+                aria-selected={ledgerView === 'run'}
+                className={styles.ledgerTab}
+                id="ledger-run-tab"
+                onClick={() => setLedgerView('run')}
+                role="tab"
+                type="button"
+              >
+                RUN
+              </button>
+              <button
+                aria-controls="ledger-suite-panel"
+                aria-selected={ledgerView === 'suite'}
+                className={styles.ledgerTab}
+                id="ledger-suite-tab"
+                onClick={() => setLedgerView('suite')}
+                role="tab"
+                type="button"
+              >
+                SUITE
+              </button>
+            </div>
           </div>
-          <div className={styles.ledgerCommand}>
-            <span aria-hidden="true">›</span>
-            <code>suite.only('username').run(data)</code>
-          </div>
-          <div className={styles.fieldLedger}>
-            <div className={styles.fieldRow}>
-              <span className={styles.fieldNumber}>01</span>
-              <div>
-                <strong>email</strong>
-                <small>from run 03</small>
+          {ledgerView === 'run' ? (
+            <div
+              aria-labelledby="ledger-run-tab"
+              className={styles.ledgerPanel}
+              id="ledger-run-panel"
+              role="tabpanel"
+            >
+              <div className={styles.ledgerCommand}>
+                <span aria-hidden="true">›</span>
+                <code>signupSuite.only('username').run(data)</code>
               </div>
-              <span className={styles.retainedState}>RETAINED · VALID</span>
-            </div>
-            <div className={clsx(styles.fieldRow, styles.activeField)}>
-              <span className={styles.fieldNumber}>02</span>
-              <div>
-                <strong>username</strong>
-                <small>request #18</small>
+              <div className={styles.fieldLedger}>
+                <div className={styles.fieldRow}>
+                  <span className={styles.fieldNumber}>01</span>
+                  <div>
+                    <strong>email</strong>
+                    <small>from run 03</small>
+                  </div>
+                  <span className={styles.retainedState}>RETAINED · VALID</span>
+                </div>
+                <div className={clsx(styles.fieldRow, styles.activeField)}>
+                  <span className={styles.fieldNumber}>02</span>
+                  <div>
+                    <strong>username</strong>
+                    <small>request #18</small>
+                  </div>
+                  <span className={styles.pendingState}>PENDING</span>
+                </div>
+                <div className={styles.fieldRow}>
+                  <span className={styles.fieldNumber}>03</span>
+                  <div>
+                    <strong>password</strong>
+                    <small>from run 02</small>
+                  </div>
+                  <span className={styles.retainedState}>RETAINED · VALID</span>
+                </div>
               </div>
-              <span className={styles.pendingState}>PENDING</span>
-            </div>
-            <div className={styles.fieldRow}>
-              <span className={styles.fieldNumber}>03</span>
-              <div>
-                <strong>password</strong>
-                <small>from run 02</small>
+              <div className={styles.trace}>
+                <div>
+                  <span>12:04:08.214</span>
+                  <p>
+                    request #17 <strong>ignored / stale</strong>
+                  </p>
+                </div>
+                <div>
+                  <span>12:04:08.228</span>
+                  <p>
+                    previous field state <strong>preserved</strong>
+                  </p>
+                </div>
               </div>
-              <span className={styles.retainedState}>RETAINED · VALID</span>
+              <div className={styles.ledgerFooter}>
+                <code>result.isPending('username')</code>
+                <strong>true</strong>
+              </div>
             </div>
-          </div>
-          <div className={styles.trace}>
-            <div>
-              <span>12:04:08.214</span>
-              <p>
-                request #17 <strong>ignored / stale</strong>
-              </p>
+          ) : (
+            <div
+              aria-labelledby="ledger-suite-tab"
+              className={clsx(styles.ledgerPanel, styles.codePanel)}
+              id="ledger-suite-panel"
+              role="tabpanel"
+            >
+              <Highlight
+                code={HeroSuiteCode}
+                language="javascript"
+                theme={themes.vsDark}
+              >
+                {({ getLineProps, getTokenProps, tokens }) => (
+                  <pre className={styles.suiteCode}>
+                    {tokens.map((line, lineIndex) => (
+                      <div
+                        key={lineIndex}
+                        {...getLineProps({ line })}
+                        className={styles.codeLine}
+                      >
+                        <span className={styles.codeLineNumber}>
+                          {String(lineIndex + 1).padStart(2, '0')}
+                        </span>
+                        <span>
+                          {line.map((token, tokenIndex) => (
+                            <span
+                              key={tokenIndex}
+                              {...getTokenProps({ token })}
+                            />
+                          ))}
+                        </span>
+                      </div>
+                    ))}
+                  </pre>
+                )}
+              </Highlight>
+              <div className={styles.codeNote}>
+                <span>FOCUSED RUN</span>
+                <code>signupSuite.only('username').run(data)</code>
+              </div>
             </div>
-            <div>
-              <span>12:04:08.228</span>
-              <p>
-                previous field state <strong>preserved</strong>
-              </p>
-            </div>
-          </div>
-          <div className={styles.ledgerFooter}>
-            <code>result.isPending('username')</code>
-            <strong>true</strong>
-          </div>
+          )}
         </div>
       </div>
     </header>

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -642,7 +642,7 @@ html[data-theme='dark'] .capabilityRow {
     min-height: 349px;
   }
 
-  .suiteCode {
+  .ledger .suiteCode {
     font-size: 0.54rem;
   }
 

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -268,6 +268,9 @@ html[data-theme='dark'] .capabilityRow {
 
 .ledger {
   position: relative;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
   border: 1px solid #232323;
   background: #151515;
   color: #efede7;
@@ -294,7 +297,7 @@ html[data-theme='dark'] .capabilityRow {
   border-bottom: 1px solid #333;
 }
 
-.ledgerHeader > div {
+.ledgerMeta {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
@@ -311,29 +314,54 @@ html[data-theme='dark'] .capabilityRow {
   letter-spacing: 0.14em;
 }
 
-.runState {
-  color: #ff6868;
-  font-size: 0.65rem;
+.ledgerTabs {
+  display: flex;
+  border: 1px solid #444;
+}
+
+.ledgerTab {
+  min-width: 58px;
+  padding: 0.42rem 0.55rem;
+  border: 0;
+  background: transparent;
+  color: #777;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.58rem;
   font-weight: 800;
   letter-spacing: 0.08em;
 }
 
-.runState::before {
-  display: inline-block;
-  width: 0.45rem;
-  height: 0.45rem;
-  margin-right: 0.45rem;
-  border-radius: 50%;
-  background: #ff5454;
-  box-shadow: 0 0 0 4px rgba(255, 84, 84, 0.12);
-  content: '';
-  animation: blink 1.5s ease-in-out infinite;
+.ledgerTab + .ledgerTab {
+  border-left: 1px solid #444;
 }
 
-@keyframes blink {
-  50% {
-    opacity: 0.4;
-  }
+.ledgerTab:hover {
+  color: #efede7;
+}
+
+.ledgerTab[aria-selected='true'] {
+  background: #efede7;
+  color: #151515;
+}
+
+.ledgerTab:first-child[aria-selected='true']::before {
+  display: inline-block;
+  width: 0.38rem;
+  height: 0.38rem;
+  margin-right: 0.4rem;
+  border-radius: 50%;
+  background: #f04444;
+  content: '';
+}
+
+.ledgerTab:focus-visible {
+  outline: 2px solid #ff6868;
+  outline-offset: 2px;
+}
+
+.ledgerPanel {
+  min-height: 446px;
 }
 
 .ledgerCommand {
@@ -450,6 +478,75 @@ html[data-theme='dark'] .capabilityRow {
   color: #ff6868;
 }
 
+.codePanel {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  background: #151515;
+}
+
+.ledger .suiteCode {
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  margin: 0;
+  padding: 1rem 0;
+  overflow-x: auto;
+  border-radius: 0;
+  background: #151515 !important;
+  color: #d4d4d4 !important;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.61rem;
+  line-height: 1.62;
+  text-align: left;
+}
+
+.codeLine {
+  display: grid;
+  grid-template-columns: 56px auto;
+  width: max-content;
+  min-width: 100%;
+  min-height: 1rem;
+  padding-right: 1rem;
+}
+
+.codeLineNumber {
+  margin-right: 0.8rem;
+  padding-right: 0.8rem;
+  border-right: 1px solid #333;
+  color: #555;
+  text-align: right;
+  user-select: none;
+}
+
+.codeNote {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 53px;
+  padding: 0.75rem 1.2rem 0.75rem 4.6rem;
+  border-top: 1px solid #333;
+  color: #777;
+  font-size: 0.58rem;
+}
+
+.codeNote > span {
+  color: #ff6868;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+}
+
+.codeNote code {
+  overflow: hidden;
+  background: transparent;
+  color: #b9b9b9;
+  font-size: inherit;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 @media screen and (max-width: 1024px) {
   .heroBanner {
     padding-top: 4.75rem;
@@ -530,10 +627,28 @@ html[data-theme='dark'] .capabilityRow {
   .trace {
     display: none;
   }
-}
 
-@media (prefers-reduced-motion: reduce) {
-  .runState::before {
-    animation: none;
+  .ledgerHeader {
+    align-items: center;
+    padding-left: 4rem;
+  }
+
+  .ledgerTab {
+    min-width: 50px;
+    padding-inline: 0.4rem;
+  }
+
+  .ledgerPanel {
+    min-height: 349px;
+  }
+
+  .suiteCode {
+    font-size: 0.54rem;
+  }
+
+  .codeNote {
+    align-items: flex-start;
+    flex-direction: column;
+    padding-left: 4rem;
   }
 }


### PR DESCRIPTION
## Summary

- add an accessible Run/Suite switch to the homepage ledger
- show and syntax-highlight the exact Vest suite behind the displayed run
- test the displayed suite source for focused state retention and async pending behavior
- keep theme backgrounds continuous across long documentation pages

## Verification

- `yarn workspace website test` (21 tests)
- `yarn workspace website build`
- browser-verified desktop and mobile layouts in light and dark themes
- browser-verified ledger tab selection and focus with Left/Right arrow keys
- browser-verified the Tutorials page at the top, midpoint, and footer in light and dark themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tabbed homepage ledger with separate **RUN** and **SUITE** views, including a focused signup run.
  * Added syntax-highlighted signup suite code with line numbers and a focused-run walkthrough.
* **Accessibility**
  * Improved the ledger UI with ARIA-wired tabs and keyboard left/right navigation.
* **Style**
  * Refreshed theme background behavior and improved ledger/code panel layout with responsive adjustments.
* **Tests**
  * Expanded homepage suite coverage, including validation behavior, async username checks, and cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->