### PR TITLE
Improve search discovery and Vest learning resources

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -76,6 +76,10 @@ const config = {
             },
           },
         },
+        sitemap: {
+          // Legacy docs remain available for direct links but are not promoted to crawlers.
+          ignorePatterns: ['/docs/4.x/**', '/docs/5.x/**'],
+        },
         pages: {
           path: 'src/pages',
           include: ['**/*.{js,jsx,ts,tsx,md,mdx}'],

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://vestjs.dev/sitemap.xml


### PR DESCRIPTION
## Summary
- add a crawler-facing robots.txt and omit legacy v4/v5 docs from the generated sitemap
- add a curated talks and articles page that connects Vest’s interaction-first model to the runnable docs
- correct the getting-started async example to pass Vest’s AbortSignal directly

## Verification
- yarn workspace website build
- git diff --check