### PR TITLE
Fix async test boolean return typing

### DIFF
--- a/packages/vest/src/core/test/TestTypes.ts
+++ b/packages/vest/src/core/test/TestTypes.ts
@@ -5,7 +5,7 @@ import { TFieldName } from '../../suiteResult/SuiteResultTypes';
 export type TestFnPayload = { signal: AbortSignal };
 
 export type TestFn = (payload: TestFnPayload) => TestResult;
-export type AsyncTest = Promise<void>;
+export type AsyncTest = Promise<boolean | void>;
 export type TestResult = Maybe<AsyncTest | boolean> | void;
 
 export type TestMessage = string | undefined;

--- a/packages/vest/src/suite/__tests__/typedSuite.test.ts
+++ b/packages/vest/src/suite/__tests__/typedSuite.test.ts
@@ -107,4 +107,27 @@ describe('typed methods', () => {
     expect(typeof suite.omitWhen).toBe('function');
     expect(typeof suite.optional).toBe('function');
   });
+
+  it('should accept async tests that resolve with booleans inside skipWhen', async () => {
+    const suite = vest.create<{
+      fields: 'username';
+    }>(() => {
+      vest.test('username', 'Username is required', () => {
+        return true;
+      });
+
+      vest.skipWhen(
+        result => result.hasErrors('username'),
+        () => {
+          vest.test('username', 'Username already exists', async () => {
+            return true;
+          });
+        },
+      );
+    });
+
+    await suite.run({});
+
+    expect(suite.get().isValid('username')).toBe(true);
+  });
 });


### PR DESCRIPTION
Summary
- Allow async Vest tests to resolve with boolean values in the public TestResult type.
- Add a typed suite regression covering an async test inside skipWhen.

Why this helps
- Matches the documented skipWhen async validation example and avoids TypeScript errors when async tests return Promise<boolean>.

Changes made
- Updated AsyncTest to allow Promise<boolean | void>.
- Added coverage for an async boolean-returning test inside skipWhen.

Testing
- node .yarn/releases/yarn-3.5.1.cjs build
- node .yarn/releases/yarn-3.5.1.cjs workspace vest vitest run src/suite/__tests__/typedSuite.test.ts
- node .yarn/releases/yarn-3.5.1.cjs vx typecheck
- node .yarn/releases/yarn-3.5.1.cjs vx typecheck-tests
- node .yarn/releases/yarn-3.5.1.cjs test
- node .yarn/releases/yarn-3.5.1.cjs prettier --check packages/vest/src/core/test/TestTypes.ts packages/vest/src/suite/__tests__/typedSuite.test.ts
- node .yarn/releases/yarn-3.5.1.cjs eslint packages/vest/src/core/test/TestTypes.ts packages/vest/src/suite/__tests__/typedSuite.test.ts

Related issue
Closes #1156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Async validation tests can now return a boolean result in addition to completing without a value.
  * Conditional test skipping supports asynchronous checks that return boolean outcomes.

* **Tests**
  * Added coverage confirming asynchronous conditional validation works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->