### PR TITLE
fix(n4s): bump validator to ^13.12.0 to fix isDate timezone bug (#1152)

### DIFF
--- a/packages/n4s/package.json
+++ b/packages/n4s/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/validator": "^13.15.10",
-    "validator": "13.9.0"
+    "validator": "^13.12.0"
   },
   "vxAllowResolve": [
     "validator"

--- a/packages/n4s/src/exports/__tests__/date.test.ts
+++ b/packages/n4s/src/exports/__tests__/date.test.ts
@@ -89,6 +89,37 @@ describe('date', () => {
       expect(() => enforce(Date.now()).isDate()).toThrow();
     });
 
+    describe('Regression: timezone-sensitive date validation (#1152)', () => {
+      it('Should pass for YYYY-MM-DD dates at month boundaries', () => {
+        expect(() => enforce('2024-01-31').isDate()).not.toThrow();
+        expect(() => enforce('2024-02-29').isDate()).not.toThrow();
+        expect(() => enforce('2024-03-31').isDate()).not.toThrow();
+        expect(() => enforce('2024-05-31').isDate()).not.toThrow();
+        expect(() => enforce('2024-07-31').isDate()).not.toThrow();
+        expect(() => enforce('2024-08-31').isDate()).not.toThrow();
+        expect(() => enforce('2024-10-31').isDate()).not.toThrow();
+        expect(() => enforce('2024-12-31').isDate()).not.toThrow();
+      });
+
+      it('Should pass for various date formats without options', () => {
+        expect(() => enforce('2024-01-15').isDate()).not.toThrow();
+        expect(() => enforce('2024/01/15').isDate()).not.toThrow();
+      });
+
+      it('Should fail for invalid dates at boundaries', () => {
+        expect(() => enforce('2024-02-30').isDate()).toThrow();
+        expect(() => enforce('2024-04-31').isDate()).toThrow();
+        expect(() => enforce('2024-06-31').isDate()).toThrow();
+        expect(() => enforce('2024-09-31').isDate()).toThrow();
+        expect(() => enforce('2024-11-31').isDate()).toThrow();
+      });
+
+      it('Should pass for Date objects', () => {
+        expect(() => enforce(new Date('2024-01-15')).isDate()).not.toThrow();
+        expect(() => enforce(new Date(2024, 0, 15)).isDate()).not.toThrow();
+      });
+    });
+
     describe('With options', () => {
       describe('format', () => {
         // Valid formats:

--- a/packages/n4s/src/exports/__tests__/date.test.ts
+++ b/packages/n4s/src/exports/__tests__/date.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { enforce } from '../../n4s';
 import '../date';
@@ -90,6 +90,15 @@ describe('date', () => {
     });
 
     describe('Regression: timezone-sensitive date validation (#1152)', () => {
+      const originalTZ = process.env.TZ;
+
+      beforeEach(() => {
+        process.env.TZ = 'America/New_York';
+      });
+
+      afterEach(() => {
+        process.env.TZ = originalTZ;
+      });
       it('Should pass for YYYY-MM-DD dates at month boundaries', () => {
         expect(() => enforce('2024-01-31').isDate()).not.toThrow();
         expect(() => enforce('2024-02-29').isDate()).not.toThrow();

--- a/yarn.lock
+++ b/yarn.lock
@@ -12927,7 +12927,7 @@ __metadata:
   dependencies:
     "@types/validator": ^13.15.10
     context: ^4.0.17
-    validator: 13.9.0
+    validator: ^13.12.0
     vest-utils: ^2.0.17
   languageName: unknown
   linkType: soft
@@ -17326,10 +17326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validator@npm:13.9.0":
-  version: 13.9.0
-  resolution: "validator@npm:13.9.0"
-  checksum: e2c936f041f61faa42bafd17c6faddf939498666cd82e88d733621c286893730b008959f4cb12ab3e236148a4f3805c30b85e3dcf5e0efd8b0cbcd36c02bfc0c
+"validator@npm:^13.12.0":
+  version: 13.15.35
+  resolution: "validator@npm:13.15.35"
+  checksum: c7ff69e12dcee71f0672c5f4b392aec9c2dbef68fb1fc6ec8546a4b2bdb2623bdfe4a9b112188566962be7d422d7d21de2ac731ae596dbd33ab1594c4cec4782
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Bug fix? ✔

## Related issues
Fixes #1152
Refs validatorjs/validator.js#2257

## Summary
- Upgrade `validator` from `13.9.0` to `^13.12.0` in `packages/n4s/package.json` (resolves to 13.15.35)
- Add regression tests for timezone-sensitive date validation at month boundaries

## Root cause
In validator.js v13.10.0+, the `isDate` function was changed to construct dates using `new Date(YYYY-MM-DD...)` (UTC parsing), but then validated using `getDate()` (local timezone). This caused valid dates near timezone boundaries to incorrectly return `false`.

The upstream fix (validator.js PR #2257) switched to `getUTCDate()` in v13.12.0. Vest was pinned to 13.9.0 as a temporary workaround.

## Verification
- `npx vitest run packages/n4s/src/exports/__tests__/date.test.ts` — 26 tests passed
- `yarn vx typecheck` — ✅ passed
- `yarn lint` — 0 errors (23 pre-existing warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for date validation across timezone-sensitive month-end dates, supported separators, invalid calendar dates, and `Date` object inputs.
  * Added checks for consistent behavior when running in the Eastern Time timezone.
  * These regression tests help maintain reliable validation across supported date formats, calendar boundaries, and environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->