### PR TITLE
fix(nightly): skip publish when no package changes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -30,8 +30,13 @@ jobs:
       - name: Verify changes require nightly publish
         id: verify
         run: |
+          set -o pipefail
           echo "Checking for package changes since stable..."
-          HAS_CHANGES=$(STABLE_BRANCH=stable CURRENT_BRANCH=latest node --loader ./vx/ts-loader.js ./vx/scripts/release/checkNightlyChanges.ts 2>&1 | grep -E "^(true|false)$" | tail -n 1)
+          HAS_CHANGES="$(STABLE_BRANCH=stable CURRENT_BRANCH=latest node --loader ./vx/ts-loader.js ./vx/scripts/release/checkNightlyChanges.ts 2>&1 | grep -xE 'true|false' | tail -n 1)"
+          if [ "$HAS_CHANGES" != "true" ] && [ "$HAS_CHANGES" != "false" ]; then
+            echo "Failed to detect changes (HAS_CHANGES='$HAS_CHANGES')" >&2
+            exit 1
+          fi
           echo "Has package changes: $HAS_CHANGES"
 
           # Also skip if latest and nightly point to the same commit (already published)
@@ -41,15 +46,15 @@ jobs:
           echo "nightly: $NIGHTLY_SHA"
           if [ -n "$LATEST_SHA" ] && [ "$LATEST_SHA" = "$NIGHTLY_SHA" ]; then
             echo "Latest and nightly are at the same commit. No new changes to publish."
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ "$HAS_CHANGES" = "true" ]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "No package changes detected since stable. Skipping nightly publish."
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Push To Nightly Branch
         if: steps.verify.outputs.has_changes == 'true'
@@ -57,6 +62,7 @@ jobs:
           echo "Pushing to nightly branch"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
+          git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}.git
           git branch -D nightly || echo "No nightly branch"
           git push origin --delete nightly || echo "No nightly branch"
           git checkout -b nightly || git checkout nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,12 +16,43 @@ jobs:
         node-version: [22.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          ref: latest
-          fetch-depth: 1
+          fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install
+        run: yarn install --immutable
+      - name: Verify changes require nightly publish
+        id: verify
+        run: |
+          echo "Checking for package changes since stable..."
+          HAS_CHANGES=$(STABLE_BRANCH=stable CURRENT_BRANCH=latest node --loader ./vx/ts-loader.js ./vx/scripts/release/checkNightlyChanges.ts 2>&1 | grep -E "^(true|false)$" | tail -n 1)
+          echo "Has package changes: $HAS_CHANGES"
+
+          # Also skip if latest and nightly point to the same commit (already published)
+          LATEST_SHA=$(git rev-parse origin/latest 2>/dev/null || echo "")
+          NIGHTLY_SHA=$(git rev-parse origin/nightly 2>/dev/null || echo "")
+          echo "latest: $LATEST_SHA"
+          echo "nightly: $NIGHTLY_SHA"
+          if [ -n "$LATEST_SHA" ] && [ "$LATEST_SHA" = "$NIGHTLY_SHA" ]; then
+            echo "Latest and nightly are at the same commit. No new changes to publish."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if [ "$HAS_CHANGES" = "true" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "No package changes detected since stable. Skipping nightly publish."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
       - name: Push To Nightly Branch
+        if: steps.verify.outputs.has_changes == 'true'
         run: |
           echo "Pushing to nightly branch"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/vx/commands/release/release.ts
+++ b/vx/commands/release/release.ts
@@ -34,6 +34,11 @@ async function releaseAll(): Promise<void> {
 
   const { packageListToRelease, isTopLevelChange } = packagesToRelease();
 
+  if (packageListToRelease.length === 0) {
+    logger.info('📭 No packages to release. Skipping.');
+    return;
+  }
+
   for (const name of packageListToRelease) {
     await withPackage(name, () => release({ isTopLevelChange }));
   }

--- a/vx/scripts/release/checkNightlyChanges.ts
+++ b/vx/scripts/release/checkNightlyChanges.ts
@@ -1,0 +1,5 @@
+import listAllChangedPackages from './github/listAllChangedPackages.js';
+
+const changed = listAllChangedPackages();
+// eslint-disable-next-line no-console
+console.log(changed.size > 0 ? 'true' : 'false');

--- a/vx/scripts/release/packagesToRelease.ts
+++ b/vx/scripts/release/packagesToRelease.ts
@@ -3,6 +3,7 @@ import listAllChangedPackages from './github/listAllChangedPackages.js';
 
 import * as logger from 'vx/logger.js';
 import { packageNames } from 'vx/packageNames.js';
+import { isNightlyBranch } from 'vx/util/taggedBranch.js';
 
 // Gets all the packages that need to be released in the correct order
 
@@ -13,6 +14,14 @@ function packagesToRelease(): {
   const deps = buildDepsTree();
   const changedPackagesSet = listAllChangedPackages();
   const isTopLevelChange = changedPackagesSet.size === 0;
+
+  if (isNightlyBranch && isTopLevelChange) {
+    logger.info(
+      '🌙 Nightly branch: No package changes detected since stable. Skipping publish.',
+    );
+    return { packageListToRelease: [], isTopLevelChange: false };
+  }
+
   const changedPackagesArray = Array.from(changedPackagesSet);
   const release = new Set<string>();
   const unchangedDependents = new Set<string>();


### PR DESCRIPTION
Every day the nightly workflow force-published a new nightly version to NPM even when there was nothing to build.

**What this does**

- **Workflow guard** (`.github/workflows/nightly.yml`): checkout with `fetch-depth: 0`, install deps, run `checkNightlyChanges` which reuses `listAllChangedPackages` (same `IGNORE_PATTERN` + package-path filtering as the release pipeline). If `stable..latest` has no package-relevant changes, or if `origin/latest` == `origin/nightly` (already published), the `Push To Nightly Branch` step is skipped via `if: steps.verify.outputs.has_changes == 'true'`.

- **Release guard** (`vx/scripts/release/packagesToRelease.ts`): when `isNightlyBranch` and `changedPackagesSet.size === 0` (previously treated as `isTopLevelChange` → release all packages), now returns `{ packageListToRelease: [], isTopLevelChange: false }` with log `🌙 Nightly: No package changes...`.

- **Orchestrator guard** (`vx/commands/release/release.ts`): early return in `releaseAll()` when `packageListToRelease` is empty, so even if nightly is manually pushed, no build/publish happens.

- **Helper** (`vx/scripts/release/checkNightlyChanges.ts`): thin wrapper around `listAllChangedPackages` for the workflow.

This stops the daily NPM spam while still publishing nightly when there are real package changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Nightly releases now skip publishing when no package changes are detected since the stable release.
  - Unchanged nightly builds no longer create unnecessary release commits.
  - Release processing now exits cleanly when there are no packages to release, avoiding unnecessary operations.
  - Nightly change detection now handles workflow outputs more reliably and reports invalid results instead of proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->