### PR TITLE
feat(schema-relationships): inline dependsOn graph with selective changed() runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vest-monorepo",
   "scripts": {
     "build": "vx build && yarn build:llms",
-    "test": "vx test run --typecheck",
+    "test": "vx test run --typecheck && tsc --noEmit",
     "test:watch": "vx test",
     "bench": "npx tsx vx/scripts/benchmark-reporter.ts --update",
     "release": "vx release",

--- a/packages/context/src/__tests__/context.test.ts
+++ b/packages/context/src/__tests__/context.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect, beforeEach } from 'vitest';
 
 import { createContext, CtxApi } from '../context';
 
+type TestContextValue = string | Record<string, string> | undefined;
+
 describe('Context', () => {
-  let ctx: CtxApi<any>;
+  let ctx: CtxApi<TestContextValue>;
 
   beforeEach(() => {
-    ctx = createContext();
+    ctx = createContext<TestContextValue>();
   });
 
   describe('Exposed Methods', () => {
@@ -29,7 +31,7 @@ describe('Context', () => {
 
       describe('When a default value was provided', () => {
         beforeEach(() => {
-          ctx = createContext('i am the default value!');
+          ctx = createContext<TestContextValue>('i am the default value!');
         });
 
         it('should return the default value', () => {
@@ -55,7 +57,7 @@ describe('Context', () => {
 
       describe('When a default value was provided', () => {
         beforeEach(() => {
-          ctx = createContext('i am the default value!');
+          ctx = createContext<TestContextValue>('i am the default value!');
         });
         it('Should disregard default value', () => {
           expect(() => {
@@ -99,6 +101,36 @@ describe('Context', () => {
         });
         expect(ctx.use()).toBeUndefined();
       });
+
+      it('restores every context layer when a nested callback throws', () => {
+        const outer = { layer: 'outer' };
+        const inner = { layer: 'inner' };
+
+        ctx.run(outer, () => {
+          expect(() =>
+            ctx.run(inner, () => {
+              expect(ctx.use()).toBe(inner);
+              throw new Error('boom');
+            }),
+          ).toThrow('boom');
+          expect(ctx.use()).toBe(outer);
+        });
+
+        expect(ctx.use()).toBeUndefined();
+      });
+    });
+
+    it('restores the parent context when the callback throws', () => {
+      const value = { layer: 'throwing' };
+
+      expect(() =>
+        ctx.run(value, () => {
+          expect(ctx.use()).toBe(value);
+          throw new Error('boom');
+        }),
+      ).toThrow('boom');
+
+      expect(ctx.use()).toBeUndefined();
     });
   });
 });

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -38,11 +38,11 @@ export function createContext<T>(defaultContextValue?: T): CtxApi<T> {
     const parentContext = isInsideContext() ? use() : EMPTY_CONTEXT;
 
     contextValue = value;
-
-    const res = cb();
-
-    contextValue = parentContext;
-    return res;
+    try {
+      return cb();
+    } finally {
+      contextValue = parentContext;
+    }
   }
 
   function isInsideContext(): boolean {

--- a/packages/n4s/package.json
+++ b/packages/n4s/package.json
@@ -43,6 +43,11 @@
       "require": "./dist/exports/email.cjs",
       "import": "./dist/exports/email.mjs"
     },
+    "./exports/internal": {
+      "types": "./types/exports/internal.d.cts",
+      "require": "./dist/exports/internal.cjs",
+      "import": "./dist/exports/internal.mjs"
+    },
     "./exports/isURL": {
       "types": "./types/exports/isURL.d.cts",
       "require": "./dist/exports/isURL.cjs",
@@ -72,6 +77,11 @@
       "types": "./types/exports/email.d.cts",
       "require": "./dist/exports/email.cjs",
       "import": "./dist/exports/email.mjs"
+    },
+    "./internal": {
+      "types": "./types/exports/internal.d.cts",
+      "require": "./dist/exports/internal.cjs",
+      "import": "./dist/exports/internal.mjs"
     },
     "./isURL": {
       "types": "./types/exports/isURL.d.cts",

--- a/packages/n4s/src/__tests__/boundaryContext.test.ts
+++ b/packages/n4s/src/__tests__/boundaryContext.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import { compose, enforce } from '../n4s';
+
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      runsDanglingBoundaryProbe: (value: { a: string; b: string }) => boolean;
+    }
+  }
+}
+
+describe('standalone boundary validation context', () => {
+  it('enforces an independent schema evaluated inside a custom matcher', () => {
+    const dangling = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn($ => $.root.missing),
+    });
+
+    expect(() => dangling.test({ a: 'a', b: 'b' })).toThrowError(
+      /"b" depends on unknown field "missing"/,
+    );
+
+    enforce.extend({
+      runsDanglingBoundaryProbe: (value: { a: string; b: string }) =>
+        dangling.test(value),
+    });
+
+    const outer = enforce.shape({
+      pair: enforce.shape({
+        a: enforce.isString(),
+        b: enforce.isString().runsDanglingBoundaryProbe(),
+      }),
+    });
+
+    expect(() => outer.test({ pair: { a: 'a', b: 'b' } })).toThrowError(
+      /"b" depends on unknown field "missing"/,
+    );
+  });
+
+  it('keeps mounted fragments lenient until the final root', () => {
+    const inner = enforce.shape({
+      taxId: enforce.isString().dependsOn($ => $.root.accountType),
+    });
+    const outer = enforce.shape({
+      accountType: enforce.isString(),
+      company: inner,
+    });
+
+    expect(outer.test({ accountType: 'p', company: { taxId: 'x' } })).toBe(
+      true,
+    );
+  });
+
+  it('keeps a rooted fragment mounted through compose() lenient to the final root', () => {
+    const inner = enforce.shape({
+      taxId: enforce.isString().dependsOn($ => $.root.accountType),
+    });
+    const outer = enforce.shape({
+      accountType: enforce.isString(),
+      company: compose(inner),
+    });
+
+    expect(outer.test({ accountType: 'p', company: { taxId: 'x' } })).toBe(
+      true,
+    );
+  });
+
+  it('uses all structural children as the root of a standalone composition', () => {
+    const dependent = enforce.loose({
+      name: enforce.isString().dependsOn($ => $.root.id),
+    });
+    const provider = enforce.loose({ id: enforce.isString() });
+    const composed = compose(dependent, provider);
+
+    expect(composed.test({ id: '1', name: 'Ada' })).toBe(true);
+    expect(composed.run({ id: '1', name: 'Ada' }).pass).toBe(true);
+
+    const missingProvider = compose(
+      dependent,
+      enforce.loose({ other: enforce.isString() }),
+    );
+    expect(() =>
+      missingProvider.test({ name: 'Ada', other: 'value' }),
+    ).toThrowError(/"name" depends on unknown field "id"/);
+  });
+
+  it('still rejects a composed standalone fragment without its root provider', () => {
+    const inner = enforce.shape({
+      taxId: enforce.isString().dependsOn($ => $.root.accountType),
+    });
+    const wrapped = compose(inner);
+
+    expect(() => wrapped.test({ taxId: 'x' })).toThrowError(
+      /"taxId" depends on unknown field "accountType"/,
+    );
+  });
+
+  it('still rejects a middle mount missing the provider', () => {
+    const inner = enforce.shape({
+      taxId: enforce.isString().dependsOn($ => $.root.accountType),
+    });
+    const middle = enforce.shape({
+      company: inner,
+      note: enforce.isString(),
+    });
+
+    expect(() =>
+      middle.test({ company: { taxId: 'x' }, note: 'n' }),
+    ).toThrowError(/"taxId" depends on unknown field "accountType"/);
+  });
+
+  it('resolves a rooted path through a composed provider schema', () => {
+    const account = compose(
+      enforce.shape({
+        kind: enforce.isString(),
+      }),
+    );
+    const child = enforce.shape({
+      taxId: enforce.isString().dependsOn($ => $.root.account.kind),
+    });
+    const outer = enforce.shape({ account, child });
+
+    expect(
+      outer.test({
+        account: { kind: 'business' },
+        child: { taxId: '123' },
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/n4s/src/__tests__/compose.test.ts
+++ b/packages/n4s/src/__tests__/compose.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { compose, enforce } from '../n4s';
+import {
+  callRuleWithValue,
+  runRuleWithValue,
+  testRuleWithValue,
+} from './runtimeTestUtils';
 
 describe('compose() - Rule Composition', () => {
   describe('Basic composition', () => {
@@ -11,7 +16,7 @@ describe('compose() - Rule Composition', () => {
       );
 
       expect(() => NumberAboveTen(5)).toThrow();
-      expect(() => NumberAboveTen('11')).toThrow();
+      expect(() => callRuleWithValue(NumberAboveTen, '11')).toThrow();
       expect(() => NumberAboveTen(10)).toThrow();
       expect(() => NumberAboveTen(11)).not.toThrow();
     });
@@ -22,7 +27,7 @@ describe('compose() - Rule Composition', () => {
         enforce.isString().longerThan(5),
       );
 
-      expect(() => StringLongerThanFive(123)).toThrow(); // Not a string
+      expect(() => callRuleWithValue(StringLongerThanFive, 123)).toThrow(); // Not a string
       expect(() => StringLongerThanFive('hi')).toThrow(); // Too short
       expect(() => StringLongerThanFive('hello world')).not.toThrow();
     });
@@ -39,6 +44,42 @@ describe('compose() - Rule Composition', () => {
   });
 
   describe('Lazy evaluation', () => {
+    it('preserves RuleInstance methods and passes parser output forward', () => {
+      const ParsedPositiveNumber = compose(
+        enforce.isNumeric().toNumber(),
+        enforce.isNumber().greaterThan(0),
+      );
+
+      expect(ParsedPositiveNumber.parse('12')).toBe(12);
+      expect(ParsedPositiveNumber.validate('12')).toEqual({ value: 12 });
+      expect(ParsedPositiveNumber['~standard'].validate('12')).toEqual({
+        value: 12,
+      });
+      expect(ParsedPositiveNumber['~standard'].vendor).toBe('n4s');
+    });
+
+    it('keeps dependencies added to the composed facade', () => {
+      const dependent = compose(
+        enforce.isString().dependsOn($ => $.firstSource),
+      ).dependsOn($ => $.secondSource);
+      const schema = enforce.shape({
+        firstSource: enforce.isString(),
+        secondSource: enforce.isString(),
+        dependent,
+      });
+
+      expect(schema.describe().relationships).toMatchObject([
+        {
+          source: [{ type: 'property', key: 'firstSource' }],
+          target: [{ type: 'property', key: 'dependent' }],
+        },
+        {
+          source: [{ type: 'property', key: 'secondSource' }],
+          target: [{ type: 'property', key: 'dependent' }],
+        },
+      ]);
+    });
+
     it('Should support .run() method', () => {
       const NumericStringBetweenThreeAndFive = compose(
         enforce.isNumeric(),
@@ -189,7 +230,7 @@ describe('compose() - Rule Composition', () => {
       const User = compose(Name, Entity);
 
       expect(
-        User.run({
+        runRuleWithValue(User, {
           id: '1',
           name: {
             first: 'John',
@@ -200,7 +241,7 @@ describe('compose() - Rule Composition', () => {
       ).toBe(true);
 
       expect(() =>
-        User({
+        callRuleWithValue(User, {
           id: '1',
           name: {
             first: 'John',
@@ -211,7 +252,7 @@ describe('compose() - Rule Composition', () => {
       ).not.toThrow();
 
       expect(
-        User.run({
+        runRuleWithValue(User, {
           id: '_',
           name: {
             first: 'John',
@@ -220,7 +261,7 @@ describe('compose() - Rule Composition', () => {
       ).toBe(false);
 
       expect(() =>
-        User({
+        callRuleWithValue(User, {
           name: {
             first: 'John',
           },
@@ -309,7 +350,7 @@ describe('compose() - Rule Composition', () => {
       expect(StringOrNumber.test('hello')).toBe(true);
       expect(StringOrNumber.test(123)).toBe(true);
       expect(StringOrNumber.test('')).toBe(false);
-      expect(StringOrNumber.test(true)).toBe(false);
+      expect(testRuleWithValue(StringOrNumber, true)).toBe(false);
     });
 
     it('Should compose with allOf', () => {
@@ -396,7 +437,7 @@ describe('compose() - Rule Composition', () => {
         enforce.isString().matches(/test/),
       );
 
-      expect(() => Validator(123)).toThrow(); // Fails on isString
+      expect(() => callRuleWithValue(Validator, 123)).toThrow(); // Fails on isString
       expect(() => Validator('hi')).toThrow(); // Fails on longerThan
       expect(() => Validator('hello world')).toThrow(); // Fails on matches
     });
@@ -407,7 +448,7 @@ describe('compose() - Rule Composition', () => {
         enforce.isNumber().greaterThan(10),
       );
 
-      const result = Validator.run('not a number');
+      const result = runRuleWithValue(Validator, 'not a number');
       expect(result.pass).toBe(false);
       // Message may or may not be defined depending on the rule
     });
@@ -418,7 +459,7 @@ describe('compose() - Rule Composition', () => {
       const JustNumber = compose(enforce.isNumber());
 
       expect(JustNumber.test(123)).toBe(true);
-      expect(JustNumber.test('123')).toBe(false);
+      expect(testRuleWithValue(JustNumber, '123')).toBe(false);
     });
 
     it('Should handle empty composition gracefully', () => {
@@ -565,7 +606,7 @@ describe('compose() - Rule Composition', () => {
 
       expect(StringOrNumberComposite.test('hello')).toBe(true);
       expect(StringOrNumberComposite.test(123)).toBe(true);
-      expect(StringOrNumberComposite.test(true)).toBe(false);
+      expect(testRuleWithValue(StringOrNumberComposite, true)).toBe(false);
     });
 
     it('Should preserve type information through compositions', () => {

--- a/packages/n4s/src/__tests__/describe.isolation.test.ts
+++ b/packages/n4s/src/__tests__/describe.isolation.test.ts
@@ -1,0 +1,153 @@
+/* eslint-disable vitest/valid-expect -- expectTypeOf(...).returns chains lock the public type */
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import type {
+  DescribeResult,
+  ItemSegment,
+  PropertySegment,
+  SchemaDependency,
+  SchemaPath,
+  SchemaRelationship,
+} from '../n4s';
+import { enforce } from '../n4s';
+import type { InternalRelationship } from '../schema/SchemaRelationship';
+import { RESOLVED_RELATIONSHIPS } from '../schema/schemaSlots';
+import { RuleInstance } from '../utils/RuleInstance';
+import { RuleRunReturn } from '../utils/RuleRunReturn';
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+function liveGraph(schema: unknown): InternalRelationship[] {
+  return (schema as Record<symbol, unknown>)[
+    RESOLVED_RELATIONSHIPS
+  ] as InternalRelationship[];
+}
+
+function sourceKey(schema: unknown): unknown {
+  const [rel] = liveGraph(schema);
+  const [seg] = rel.source as Mutable<SchemaPath>;
+  return (seg as Mutable<PropertySegment>).key;
+}
+
+describe('describe() isolation', () => {
+  it('locks the DescribeResult public shape', () => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirm: enforce.isString().dependsOn($ => $.password),
+    });
+    expectTypeOf(schema.describe).returns.toEqualTypeOf<DescribeResult>();
+    const desc = schema.describe();
+    expectTypeOf(desc.dependencies).toEqualTypeOf<SchemaDependency[]>();
+    expectTypeOf(desc.relationships).toEqualTypeOf<SchemaRelationship[]>();
+  });
+
+  it('chainBuilder: mutating describe() output leaves the live graph intact', () => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirm: enforce.isString().dependsOn($ => $.password),
+    });
+
+    const snap = schema.describe();
+    expect(snap.relationships).toHaveLength(1);
+    // No internal flags leak into public output
+    expect(snap.relationships[0]).not.toHaveProperty('__isRootSource');
+    expect(snap.relationships[0]).not.toHaveProperty('__isRootTarget');
+
+    // P1 reproducer: poison the public snapshot
+    const seg = snap.relationships[0].source[0] as Mutable<PropertySegment>;
+    seg.key = 'attacker';
+    (snap.relationships[0].source as unknown[]).push({
+      type: 'property',
+      key: 'extra',
+    });
+    (snap.dependencies[0].sources[0] as unknown[]).push({
+      type: 'property',
+      key: 'extra',
+    });
+
+    // Live graph (the same array suite.changed() reads) is unaffected,
+    // so a later suite.changed('password') still matches confirm's source.
+    expect(sourceKey(schema)).toBe('password');
+    expect(liveGraph(schema)[0].source).toHaveLength(1);
+    expect(liveGraph(schema)[0].target).toHaveLength(1);
+
+    // A fresh describe() is unaffected too
+    const fresh = schema.describe();
+    expect((fresh.relationships[0].source[0] as PropertySegment).key).toBe(
+      'password',
+    );
+    expect(fresh.relationships[0].source).toHaveLength(1);
+    expect((fresh.dependencies[0].sources[0][0] as PropertySegment).key).toBe(
+      'password',
+    );
+  });
+
+  it('chainBuilder: separate describe() calls share no references', () => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirm: enforce.isString().dependsOn($ => $.password),
+    });
+    const a = schema.describe();
+    const b = schema.describe();
+    expect(a.relationships[0]).not.toBe(b.relationships[0]);
+    expect(a.relationships[0].source).not.toBe(b.relationships[0].source);
+    expect(a.relationships[0].source[0]).not.toBe(b.relationships[0].source[0]);
+    expect(a.relationships[0].target).not.toBe(b.relationships[0].target);
+    expect(a.dependencies[0]).not.toBe(b.dependencies[0]);
+    expect(a.dependencies[0].target).not.toBe(b.dependencies[0].target);
+    expect(a.dependencies[0].sources[0]).not.toBe(b.dependencies[0].sources[0]);
+    // dependencies and relationships outputs are independent of each other
+    expect(a.dependencies[0].target).not.toBe(a.relationships[0].target);
+    expect(a.dependencies[0].sources[0]).not.toBe(a.relationships[0].source);
+  });
+
+  it('RuleInstance.create: mutating describe() output leaves the live graph intact', () => {
+    type R = RuleInstance<string, [string]>;
+    const rule = RuleInstance.create<R, string, [string]>(value =>
+      RuleRunReturn.Passing(value),
+    );
+    (rule as unknown as Record<symbol, unknown>)[RESOLVED_RELATIONSHIPS] = [
+      {
+        __isRootSource: true,
+        effect: 'invalidate',
+        metadata: { reason: 'test' },
+        source: [{ type: 'property', key: 'password' }],
+        target: [{ type: 'property', key: 'confirm' }],
+      } satisfies InternalRelationship,
+    ];
+
+    const snap = rule.describe();
+    expect(snap.relationships).toHaveLength(1);
+    expect(snap.relationships[0]).not.toHaveProperty('__isRootSource');
+    expect(snap.relationships[0]).toEqual({
+      effect: 'invalidate',
+      metadata: { reason: 'test' },
+      source: [{ type: 'property', key: 'password' }],
+      target: [{ type: 'property', key: 'confirm' }],
+    });
+
+    (snap.relationships[0].source[0] as Mutable<PropertySegment>).key =
+      'attacker';
+    (snap.relationships[0].metadata as Mutable<{ reason?: string }>).reason =
+      'poisoned';
+    (snap.dependencies[0].target[0] as Mutable<PropertySegment>).key =
+      'attacker';
+
+    expect(sourceKey(rule)).toBe('password');
+    const fresh = rule.describe();
+    expect((fresh.relationships[0].source[0] as PropertySegment).key).toBe(
+      'password',
+    );
+    expect(fresh.relationships[0].metadata).toEqual({ reason: 'test' });
+    expect((fresh.dependencies[0].target[0] as PropertySegment).key).toBe(
+      'confirm',
+    );
+  });
+
+  it('segment types are exported from the entry', () => {
+    const prop: PropertySegment = { type: 'property', key: 'password' };
+    const item: ItemSegment = { type: 'item', binding: 'travelers.$item' };
+    const path: SchemaPath = [prop, item];
+    expect(path).toHaveLength(2);
+  });
+});

--- a/packages/n4s/src/__tests__/inference.dependsOn.test.ts
+++ b/packages/n4s/src/__tests__/inference.dependsOn.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Type inference tests for Schema Relationships
+ * Verifies that $ is inferrable without explicit annotation
+ */
+
+/* eslint-disable vitest/valid-expect, vitest/no-commented-out-tests */
+import { describe, it, expect, expectTypeOf } from 'vitest';
+
+import { enforce } from '../n4s';
+import type {
+  DescribeResult,
+  SchemaDependency,
+  SchemaPath,
+  SchemaRelationship,
+} from '../n4s';
+
+export function typeChecks() {
+  // $ should be inferred as Scope without annotation - scope inference
+  const schema1 = enforce.shape({
+    password: enforce.isString(),
+    confirmPassword: enforce.isString().dependsOn($ => {
+      expectTypeOf($).toMatchTypeOf<{ root: unknown }>();
+      expectTypeOf($.password).toMatchTypeOf<unknown>();
+      expectTypeOf($.root).toMatchTypeOf<unknown>();
+      return $.password;
+    }),
+    // $ => $.password should be valid, $ => $.missing should be valid (an arbitrary key is allowed via index signature)
+    // but the type of $ should be Scope, not an untyped fallback
+  });
+
+  // inferred data shape - schema1
+  expectTypeOf(schema1.infer).toEqualTypeOf<{
+    password: string;
+    confirmPassword: string;
+  }>();
+  expectTypeOf(schema1.describe).returns.toEqualTypeOf<DescribeResult>();
+  // dependency fields - describe output
+  const desc1 = schema1.describe();
+  expectTypeOf(desc1.dependencies).toEqualTypeOf<SchemaDependency[]>();
+  expectTypeOf(desc1.relationships).toEqualTypeOf<SchemaRelationship[]>();
+  expectTypeOf(desc1.dependencies[0]?.sources).toEqualTypeOf<
+    readonly SchemaPath[]
+  >();
+
+  // Chained dependsOn - scope and dependency fields
+  const schema3 = enforce.shape({
+    country: enforce.isString(),
+    state: enforce
+      .isString()
+      .dependsOn($ => {
+        expectTypeOf($).toMatchTypeOf<{ root: unknown }>();
+        return $.country;
+      })
+      .dependsOn($ => {
+        expectTypeOf($).toMatchTypeOf<{ root: unknown }>();
+        return $.country;
+      }),
+  });
+  expectTypeOf(schema3.infer).toEqualTypeOf<{
+    country: string;
+    state: string;
+  }>();
+
+  // Root escape - scope root inference
+  const inner = enforce.shape({
+    taxId: enforce.isString().dependsOn($ => {
+      expectTypeOf($).toMatchTypeOf<{ root: unknown }>();
+      expectTypeOf($.root).toMatchTypeOf<unknown>();
+      expectTypeOf($.root.accountType).toMatchTypeOf<unknown>();
+      return $.root.accountType;
+    }),
+  });
+  const outer = enforce.shape({
+    accountType: enforce.isString(),
+    company: inner,
+  });
+  expectTypeOf(inner.infer).toEqualTypeOf<{ taxId: string }>();
+  expectTypeOf(outer.infer).toEqualTypeOf<{
+    accountType: string;
+    company: { taxId: string };
+  }>();
+  expectTypeOf(outer.describe).returns.toEqualTypeOf<DescribeResult>();
+
+  // Array item - $ is still Scope, not array-specific - scope inference
+  // Item must declare its own dependency source
+  const item = enforce.shape({
+    country: enforce.isString(),
+    passport: enforce.isString().dependsOn($ => {
+      expectTypeOf($).toMatchTypeOf<{ root: unknown }>();
+      return $.country;
+    }),
+  });
+  const withArray = enforce.shape({
+    travelers: enforce.isArrayOf(item),
+  });
+  expectTypeOf(item.infer).toEqualTypeOf<{
+    country: string;
+    passport: string;
+  }>();
+  expectTypeOf(withArray.infer).toEqualTypeOf<{
+    travelers: Array<{ country: string; passport: string }>;
+  }>();
+
+  void schema1.describe();
+  void withArray.describe();
+  // describe() output for withArray
+  const withArrayDesc = withArray.describe();
+  expectTypeOf(withArrayDesc.dependencies).toBeArray();
+  expectTypeOf(withArrayDesc.relationships).toBeArray();
+
+  // Optional wrappers preserve describe - describe() output
+  const opt = enforce.optional(schema1);
+  const d1 = opt.describe();
+  expectTypeOf(opt.describe).returns.toEqualTypeOf<DescribeResult>();
+  expectTypeOf(d1.dependencies).toBeArray();
+  expectTypeOf(d1.relationships).toBeArray();
+
+  const partial = enforce.partial({
+    a: enforce.isString(),
+    b: enforce.isString().dependsOn($ => {
+      expectTypeOf($).toMatchTypeOf<{ root: unknown }>();
+      return $.a;
+    }),
+  });
+  const d2 = partial.describe();
+  expectTypeOf(partial.infer).toEqualTypeOf<{
+    a?: string | undefined;
+    b?: string | undefined;
+  }>();
+  expectTypeOf(d2.dependencies).toBeArray();
+  expectTypeOf(partial.describe).returns.toEqualTypeOf<DescribeResult>();
+  void d1;
+  void d2;
+}
+
+// typeChecks is type-only — not invoked at runtime to avoid enforce.shape side effects;
+// tsc --noEmit with expectTypeOf validates it statically
+void typeChecks;
+
+describe('inference.dependsOn', () => {
+  it('schema with dependsOn typechecks without explicit annotation', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/n4s/src/__tests__/runtimeTestUtils.ts
+++ b/packages/n4s/src/__tests__/runtimeTestUtils.ts
@@ -1,0 +1,27 @@
+export function callRuleWithValue<Result>(
+  rule: (value: never) => Result,
+  value: unknown,
+): Result {
+  return rule(value as never);
+}
+
+export function runRuleWithValue<Result>(
+  rule: { run(value: never): Result },
+  value: unknown,
+): Result {
+  return rule.run(value as never);
+}
+
+export function testRuleWithValue<Result>(
+  rule: { test(value: never): Result },
+  value: unknown,
+): Result {
+  return rule.test(value as never);
+}
+
+export function invokeWithUnknown<Result>(
+  fn: (...args: never[]) => Result,
+  ...args: unknown[]
+): Result {
+  return fn(...(args as never[]));
+}

--- a/packages/n4s/src/__tests__/scopeProxy.fields.test.ts
+++ b/packages/n4s/src/__tests__/scopeProxy.fields.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect } from 'vitest';
+
+import { enforce, FIELD } from '../n4s';
+import type { InternalRelationship } from '../schema/SchemaRelationship';
+import { RESOLVED_RELATIONSHIPS } from '../schema/schemaSlots';
+import { createScopeProxy, isDependencyRef } from '../schema/scopeProxy';
+import type { ScopeHandle } from '../utils/RuleInstance';
+
+function pathKeys(path: unknown): string[] {
+  if (!Array.isArray(path)) {
+    return [];
+  }
+  return (path as unknown as Array<{ key?: unknown }>).map(
+    (seg: { key?: unknown }): string => String(seg.key),
+  );
+}
+
+function sourcesFor(
+  described: { relationships: InternalRelationship[] },
+  target: string,
+): string[] {
+  return described.relationships
+    .filter(
+      (rel: InternalRelationship): boolean =>
+        pathKeys(rel.target).join('.') === target,
+    )
+    .map((rel: InternalRelationship): string => pathKeys(rel.source).join('.'));
+}
+
+describe('scopeProxy field collisions', (): void => {
+  it('chains a nested field named path as a reference', (): void => {
+    const inner = enforce.shape({ path: enforce.isString() });
+    const schema = enforce.shape({
+      nested: inner,
+      watcher: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $.nested.path),
+    });
+
+    expect(sourcesFor(schema.describe(), 'watcher')).toEqual(['nested.path']);
+    expect(schema.test({ nested: { path: 'x' }, watcher: 'y' })).toBe(true);
+  });
+
+  it('chains a nested field named isRoot as a reference', (): void => {
+    const inner = enforce.shape({ isRoot: enforce.isString() });
+    const schema = enforce.shape({
+      nested: inner,
+      watcher: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $.nested.isRoot),
+    });
+
+    expect(sourcesFor(schema.describe(), 'watcher')).toEqual(['nested.isRoot']);
+  });
+
+  it('chains nested fields named toJSON and valueOf as references', (): void => {
+    const inner = enforce.shape({
+      toJSON: enforce.isString(),
+      valueOf: enforce.isString(),
+    });
+    const schema = enforce.shape({
+      nested: inner,
+      a: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $.nested.toJSON),
+      b: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $.nested.valueOf),
+    });
+
+    expect(sourcesFor(schema.describe(), 'a')).toEqual(['nested.toJSON']);
+    expect(sourcesFor(schema.describe(), 'b')).toEqual(['nested.valueOf']);
+  });
+
+  it('references a real sibling field named self', (): void => {
+    const schema = enforce.shape({
+      self: enforce.isString(),
+      a: enforce.isString().dependsOn(($: ScopeHandle): unknown => $.self),
+    });
+
+    expect(sourcesFor(schema.describe(), 'a')).toEqual(['self']);
+  });
+
+  it('treats bare $.self as a self-dependency no-op when no sibling exists', (): void => {
+    const schema = enforce.shape({
+      a: enforce.isString().dependsOn(($: ScopeHandle): unknown => $.self),
+    });
+
+    expect(schema.describe().relationships).toEqual([]);
+    expect(schema.test({ a: 'x' })).toBe(true);
+  });
+
+  it('keeps then non-chainable so refs are never thenable', async (): Promise<void> => {
+    const $ = createScopeProxy([]);
+    expect($.then).toBeUndefined();
+    expect($.nested.then).toBeUndefined();
+    expect($.root.then).toBeUndefined();
+
+    const ref = $.nested;
+    expect(isDependencyRef(ref)).toBe(true);
+    expect(isDependencyRef($.then)).toBe(false);
+    // Awaiting a returned ref must fulfill with the ref, not assimilate it.
+    await expect(Promise.resolve(ref)).resolves.toBe(ref);
+  });
+
+  it('throws EnforceSchemaError when a resolver returns the non-chainable then', (): void => {
+    expect((): unknown =>
+      enforce.shape({
+        a: enforce.isString(),
+        b: enforce.isString().dependsOn(($: ScopeHandle): unknown => $.then),
+      }),
+    ).toThrow(/returned undefined/);
+  });
+
+  it('references a literal field named then via the FIELD escape hatch', (): void => {
+    const schema = enforce.shape({
+      then: enforce.isString(),
+      nested: enforce.shape({ then: enforce.isString() }),
+      a: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $[FIELD]('then')),
+      b: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $.nested[FIELD]('then')),
+      c: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $.root[FIELD]('then')),
+    });
+
+    expect(sourcesFor(schema.describe(), 'a')).toEqual(['then']);
+    expect(sourcesFor(schema.describe(), 'b')).toEqual(['nested.then']);
+    expect(sourcesFor(schema.describe(), 'c')).toEqual(['then']);
+  });
+
+  it('references a literal then field with full typing and no cast', (): void => {
+    const schema = enforce.shape({
+      then: enforce.isString(),
+      nested: enforce.shape({ then: enforce.isString() }),
+      a: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $[FIELD]('then')),
+      b: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $.nested[FIELD]('then')),
+      c: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $.root[FIELD]('then')),
+    });
+
+    expect(sourcesFor(schema.describe(), 'a')).toEqual(['then']);
+    expect(sourcesFor(schema.describe(), 'b')).toEqual(['nested.then']);
+    expect(sourcesFor(schema.describe(), 'c')).toEqual(['then']);
+    expect(
+      schema.test({
+        then: 't',
+        nested: { then: 'nt' },
+        a: 'x',
+        b: 'y',
+        c: 'z',
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps normal deep chaining working', (): void => {
+    const deep = enforce.shape({ leaf: enforce.isString() });
+    const mid = enforce.shape({ branch: deep });
+    const schema = enforce.shape({
+      tree: mid,
+      watcher: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $.tree.branch.leaf),
+    });
+
+    expect(sourcesFor(schema.describe(), 'watcher')).toEqual([
+      'tree.branch.leaf',
+    ]);
+  });
+
+  it('keeps $.root and deferred $.parent semantics', (): void => {
+    const inner = enforce.shape({
+      taxId: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $.root.accountType),
+    });
+    const outer = enforce.shape({
+      accountType: enforce.isString(),
+      company: inner,
+    });
+
+    expect(sourcesFor(outer.describe(), 'company.taxId')).toEqual([
+      'accountType',
+    ]);
+    expect(
+      outer.test({ accountType: 'personal', company: { taxId: '123' } }),
+    ).toBe(true);
+    expect((): unknown => createScopeProxy([]).parent).toThrow(
+      /\$\.parent deferred to v2/,
+    );
+  });
+
+  it('stores reference metadata off string keys', (): void => {
+    const $ = createScopeProxy([]);
+    for (const name of ['path', 'isRoot', 'toJSON', 'valueOf', 'self']) {
+      expect(isDependencyRef($.nested[name])).toBe(true);
+    }
+  });
+});
+
+describe('dependsOn resolver results', (): void => {
+  it('throws EnforceSchemaError for undefined (missing return)', (): void => {
+    expect((): void => {
+      enforce.shape({
+        a: enforce.isString(),
+        b: enforce.isString().dependsOn(($: ScopeHandle): unknown => {
+          if ($.a) {
+            // field accessed but intentionally never returned
+          }
+          return undefined;
+        }),
+      });
+    }).toThrow(/returned undefined/);
+  });
+
+  it('treats an explicit empty array as intentional zero dependencies', (): void => {
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn((): unknown[] => []),
+    });
+
+    expect(schema.describe().relationships).toEqual([]);
+    expect(schema.test({ a: 'x', b: 'y' })).toBe(true);
+  });
+
+  it('keeps throwing for scalar and mixed-array invalid results', (): void => {
+    expect((): unknown =>
+      enforce.shape({
+        a: enforce.isString(),
+        b: enforce.isString().dependsOn((): string => 'a'),
+      }),
+    ).toThrow(/must return a dependency ref/);
+    expect((): unknown =>
+      enforce.shape({
+        a: enforce.isString(),
+        b: enforce
+          .isString()
+          .dependsOn(($: ScopeHandle): unknown[] => [$.a, 'nope']),
+      }),
+    ).toThrow(/non-dependency values/);
+  });
+});
+
+describe('standalone rooted-path boundary', (): void => {
+  it('rejects a nested source below a scalar that has relationship metadata', (): void => {
+    const scalar = enforce.isString();
+    (scalar as unknown as Record<PropertyKey, unknown>)[
+      RESOLVED_RELATIONSHIPS
+    ] = [];
+
+    expect((): unknown =>
+      enforce.shape({
+        leaf: enforce.isString(),
+        scalar,
+        watcher: enforce
+          .isString()
+          .dependsOn(($: ScopeHandle): unknown => $.scalar.leaf),
+      }),
+    ).toThrow(/"watcher" depends on.*"scalar\.leaf"/);
+  });
+
+  it('reports dangling roots via describe() but throws at test()/run()', (): void => {
+    const standalone = enforce.shape({
+      a: enforce.isString(),
+      b: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $.root.missing),
+    });
+
+    expect(sourcesFor(standalone.describe(), 'b')).toEqual(['missing']);
+    expect((): unknown => standalone.test({ a: 'a', b: 'b' })).toThrowError(
+      /"b" depends on unknown field "missing"/,
+    );
+  });
+
+  it('keeps composition lenient for reusable fragments', (): void => {
+    const inner = enforce.shape({
+      taxId: enforce
+        .isString()
+        .dependsOn(($: ScopeHandle): unknown => $.root.accountType),
+    });
+
+    // A middle mount without the provider must not throw: the fragment
+    // cannot know its final root until mounted.
+    const middle = enforce.shape({ company: inner, note: enforce.isString() });
+    expect(middle.describe()).toBeDefined();
+
+    // The middle schema alone still dangles, so its own run throws…
+    expect((): unknown =>
+      middle.test({ company: { taxId: 'x' }, note: 'n' }),
+    ).toThrowError(/"taxId" depends on unknown field "accountType"/);
+
+    // …but the outer mount that provides the field is fully valid.
+    const outer = enforce.shape({
+      accountType: enforce.isString(),
+      company: inner,
+    });
+    expect(outer.test({ accountType: 'p', company: { taxId: 'x' } })).toBe(
+      true,
+    );
+  });
+});

--- a/packages/n4s/src/compose.ts
+++ b/packages/n4s/src/compose.ts
@@ -1,11 +1,63 @@
-import { StringObject, assign, invariant, mapFirst } from 'vest-utils';
+import { StringObject, assign, invariant } from 'vest-utils';
+import type { StandardSchemaV1 } from 'vest-utils/standardSchemaSpec';
 
 import { ctx } from './enforceContext';
+import {
+  COMPOSITION_CHILDREN,
+  ITEM_CONTAINER,
+  ITEM_SCHEMA,
+  RESOLVED_RELATIONSHIPS,
+  UNRESOLVED_DEPS,
+} from './schema/schemaSlots';
+import {
+  MAP_FULL_VALUE,
+  mapWithoutValidation,
+} from './schema/mapWithoutValidation';
 import { RuleInstance } from './utils/RuleInstance';
 import { RuleRunReturn } from './utils/RuleRunReturn';
+import { withStandaloneRootedBoundary } from './rules/chainBuilder/chainBuilder';
 
-type ComposeResult<T = any> = RuleInstance<T, [T]> & {
-  (value: T): void;
+type ComposableRule = {
+  readonly '~standard': {
+    readonly types?: StandardSchemaV1.Types<unknown, unknown>;
+  };
+  run(value: never): RuleRunReturn<unknown>;
+};
+
+type RuleInput<Rule> = Rule extends {
+  readonly '~standard': {
+    readonly types: StandardSchemaV1.Types<infer Input, unknown>;
+  };
+}
+  ? Input
+  : unknown;
+
+type RuleOutput<Rule> = Rule extends {
+  readonly '~standard': {
+    readonly types: StandardSchemaV1.Types<unknown, infer Output>;
+  };
+}
+  ? Output
+  : unknown;
+
+type FirstRule<Rules extends readonly ComposableRule[]> =
+  Rules extends readonly [infer First extends ComposableRule, ...unknown[]]
+    ? First
+    : never;
+
+type LastRule<Rules extends readonly ComposableRule[]> =
+  Rules extends readonly [...unknown[], infer Last extends ComposableRule]
+    ? Last
+    : never;
+
+type ComposeInput<Rules extends readonly ComposableRule[]> =
+  Rules extends readonly [] ? unknown : RuleInput<FirstRule<Rules>>;
+
+type ComposeOutput<Rules extends readonly ComposableRule[]> =
+  Rules extends readonly [] ? unknown : RuleOutput<LastRule<Rules>>;
+
+type ComposeResult<Input, Output> = RuleInstance<Output, [Input]> & {
+  (value: Input): void;
 };
 
 /**
@@ -13,7 +65,8 @@ type ComposeResult<T = any> = RuleInstance<T, [T]> & {
  * The composed rule executes rules in order and fails on the first failing rule.
  * Returns a RuleInstance that can be used with both eager and lazy APIs.
  *
- * @template T - The type of value to validate
+ * @template Rules - The ordered rules whose first input and final output
+ * determine the composed rule's public types.
  * @param composites - Validation rules to compose
  * @returns A composed rule that can be run with values or called directly
  *
@@ -26,60 +79,137 @@ type ComposeResult<T = any> = RuleInstance<T, [T]> & {
  *   enforce.lessThan(150)
  * );
  *
- * // Use with lazy API
  * isAdult.test(25); // true
  * isAdult.test(16); // false
  *
- * // Use with eager API
  * enforce(30).run(isAdult); // passes
  *
- * // Call directly (throws on failure)
  * isAdult(25); // ok
  * isAdult(16); // throws
  *
- * // Compose with other rules
  * const userSchema = enforce.shape({
  *   age: isAdult,
  *   name: enforce.isString()
  * });
  * ```
  */
-export function compose<T = any>(
-  ...composites: RuleInstance<any, [any]>[]
-): ComposeResult<T> {
-  const composedFn = assign(
-    (value: T) => {
-      const res = run(value);
-      invariant(res.pass, StringObject(res.message));
-    },
-    {
-      run,
-      test: (value: T) => run(value).pass,
-      infer: {} as T,
-    },
-  );
+export function compose<const Rules extends readonly ComposableRule[]>(
+  ...composites: Rules
+): ComposeResult<ComposeInput<Rules>, ComposeOutput<Rules>> {
+  type Input = ComposeInput<Rules>;
+  type Output = ComposeOutput<Rules>;
+  const instance = RuleInstance.create<
+    RuleInstance<Output, [Input]>,
+    Output,
+    [Input]
+  >(run);
+  const composedFn = assign((value: Input) => {
+    const res = run(value);
+    invariant(res.pass, StringObject(res.message));
+  }, instance);
+  const result = composedFn as ComposeResult<Input, Output>;
 
-  return composedFn as ComposeResult<T>;
+  // Preserve every composite's dependency metadata. Multiple validation
+  // chains may have different structural schemas, so only the unambiguous
+  // single-child container slots are forwarded; relationship edges themselves
+  // always have well-defined union semantics and are deduplicated below.
+  forwardCompositionSlots(composites, [instance, result]);
 
-  function run(value: T): RuleRunReturn<T> {
-    return ctx.run({ value }, () => {
-      let result: RuleRunReturn<T> = RuleRunReturn.Passing(value);
+  // RuleInstance.create() stores relationship metadata on its object. The
+  // callable facade is the value mounted into schemas, so both identities
+  // must carry identical slots. Keep dependencies added to the facade beside
+  // the dependencies inherited from its composed children.
+  const inheritedDependencies = readArraySlot(result, UNRESOLVED_DEPS);
+  const addedDependencies: unknown[] = [];
+  result.dependsOn = resolver => {
+    addedDependencies.push({ resolver });
+    for (const target of [instance, result]) {
+      const slots = target as unknown as Record<symbol, unknown>;
+      slots[UNRESOLVED_DEPS] = [...inheritedDependencies, ...addedDependencies];
+    }
+    return result;
+  };
 
-      mapFirst(
-        composites,
-        (
-          composite: RuleInstance<any, [any]>,
-          breakout: (conditional: boolean, res: RuleRunReturn<any>) => void,
-        ) => {
-          const res = composite.run(value);
-          if (!res.pass) {
-            result = res;
-            breakout(true, res);
-          }
-        },
-      );
+  return result;
 
-      return result;
-    });
+  function run(value: Input): RuleRunReturn<Output> {
+    return withStandaloneRootedBoundary(result, () =>
+      ctx.run({ value }, () => {
+        let current: unknown = value;
+        for (const composite of composites) {
+          const executable = composite as unknown as {
+            run(input: unknown): RuleRunReturn<unknown>;
+          };
+          const result = executable.run(current);
+          if (!result.pass) return result as RuleRunReturn<Output>;
+          current = result.type;
+        }
+        return RuleRunReturn.Passing(current as Output);
+      }),
+    );
   }
+}
+
+/**
+ * Forwards schema metadata onto the composed rule. Relationship lists are
+ * unioned and copied so later mounts cannot alias a source array. Structural
+ * slots carry over only for a single unambiguous child. COMPOSITION_CHILDREN
+ * retains every wrapper identity for graph traversal and root boundaries.
+ */
+// eslint-disable-next-line complexity -- metadata forwarding deliberately discriminates each independent slot
+function forwardCompositionSlots(
+  sources: readonly ComposableRule[],
+  targets: readonly object[],
+): void {
+  const unresolved: unknown[] = [];
+  const relationships = new Map<string, unknown>();
+
+  for (const source of sources) {
+    const from = source as unknown as Record<PropertyKey, unknown>;
+    const sourceUnresolved = from[UNRESOLVED_DEPS];
+    if (Array.isArray(sourceUnresolved)) unresolved.push(...sourceUnresolved);
+    const sourceRelationships = from[RESOLVED_RELATIONSHIPS];
+    if (Array.isArray(sourceRelationships)) {
+      for (const relationship of sourceRelationships) {
+        relationships.set(JSON.stringify(relationship), relationship);
+      }
+    }
+  }
+
+  const [single] = sources;
+  for (const target of targets) {
+    const to = target as Record<PropertyKey, unknown>;
+    if (unresolved.length > 0) to[UNRESOLVED_DEPS] = [...unresolved];
+    if (relationships.size > 0) {
+      to[RESOLVED_RELATIONSHIPS] = Array.from(relationships.values());
+    }
+    if (sources.length === 1 && single) {
+      const from = single as unknown as Record<PropertyKey, unknown>;
+      for (const slot of ['__schema', ITEM_SCHEMA, ITEM_CONTAINER]) {
+        if (from[slot] !== undefined) to[slot] = from[slot];
+      }
+    }
+    to[COMPOSITION_CHILDREN] = [...sources];
+    // A composition maps each source in sequence, including its structural
+    // mapping. This full-value slot prevents mapWithoutValidation() from first
+    // mapping the forwarded __schema and then mapping that same source again.
+    to[MAP_FULL_VALUE] = mapComposedValue(sources);
+  }
+}
+
+function mapComposedValue(
+  sources: readonly ComposableRule[],
+): (value: unknown) => RuleRunReturn<unknown> {
+  return value =>
+    RuleRunReturn.Passing(
+      sources.reduce(
+        (current, source) => mapWithoutValidation(source, current),
+        value,
+      ),
+    );
+}
+
+function readArraySlot(source: object, slot: symbol): unknown[] {
+  const value = (source as Record<PropertyKey, unknown>)[slot];
+  return Array.isArray(value) ? [...value] : [];
 }

--- a/packages/n4s/src/errors/EnforceSchemaError.ts
+++ b/packages/n4s/src/errors/EnforceSchemaError.ts
@@ -1,0 +1,6 @@
+export class EnforceSchemaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EnforceSchemaError';
+  }
+}

--- a/packages/n4s/src/exports/internal.ts
+++ b/packages/n4s/src/exports/internal.ts
@@ -1,0 +1,19 @@
+/**
+ * Integration surface shared by n4s and Vest.
+ *
+ * This entry is intentionally separate from the public n4s API. Applications
+ * should use schema rules, `dependsOn()`, and `describe()`; Vest alone consumes
+ * these planner and mapping operations to implement focused suite execution.
+ */
+export { assertSchemaRootPathsValid } from '../schema/dependencyResolver';
+export { mapWithoutValidation } from '../schema/mapWithoutValidation';
+export {
+  parseAffectedFieldName,
+  resolveAffectedPaths,
+  runSchemaPaths,
+} from '../schema/selectiveRun';
+export type {
+  SelectiveRunOptions,
+  SelectiveSchema,
+  SelectiveSchemaResult,
+} from '../schema/selectiveRun';

--- a/packages/n4s/src/extendLogic.ts
+++ b/packages/n4s/src/extendLogic.ts
@@ -3,6 +3,9 @@ import { ctx } from './enforceContext';
 import { addToChain, registerLazyRule } from './rules/genRuleChain';
 import { RuleRunReturn } from './utils/RuleRunReturn';
 
+type ExtensionRule = (...args: never[]) => unknown;
+type MutableEnforce = Record<string, unknown>;
+
 /**
  * Extends the enforce API with custom validation rules.
  * Custom rules are added to both eager and lazy APIs automatically.
@@ -39,27 +42,41 @@ import { RuleRunReturn } from './utils/RuleRunReturn';
  * });
  * ```
  */
-export function extendEnforce(
-  enforce: any,
-  rules: Record<string, (...args: any[]) => any>,
+export function extendEnforce<Rules extends Record<string, ExtensionRule>>(
+  enforce: MutableEnforce,
+  rules: Rules,
+  parserNames: ReadonlySet<string> = new Set(),
 ) {
   extendEager(rules);
 
   Object.keys(rules).forEach(ruleName => {
     const rule = rules[ruleName];
-    const ruleWrapper = (value: any, ...args: any[]) => {
-      const res = ctx.run({ value }, () => rule(value, ...args));
-      return RuleRunReturn.create(res, value);
+    const callableRule = rule as unknown as (
+      value: unknown,
+      ...args: unknown[]
+    ) => unknown;
+    const ruleWrapper = (value: unknown, ...args: unknown[]) => {
+      const res = ctx.run({ value }, () => callableRule(value, ...args));
+      return RuleRunReturn.create(
+        res as boolean | RuleRunReturn<unknown>,
+        value,
+      );
     };
 
-    enforce[ruleName] = (...args: any[]) =>
-      addToChain({}, (value: any) => ruleWrapper(value, ...args));
+    const mapsValue = parserNames.has(ruleName);
+    enforce[ruleName] = (...args: unknown[]) =>
+      addToChain(
+        {},
+        (value: unknown) => ruleWrapper(value, ...args),
+        mapsValue,
+      );
 
     registerLazyRule(
       ruleName,
-      (...args: any[]) =>
-        (value: any) =>
+      (...args: unknown[]) =>
+        (value: unknown) =>
           ruleWrapper(value, ...args),
+      mapsValue,
     );
   });
 }

--- a/packages/n4s/src/lazy.ts
+++ b/packages/n4s/src/lazy.ts
@@ -1,5 +1,5 @@
+/* eslint-disable complexity, max-lines-per-function, max-statements, sort-keys -- schema relationship rebasing */
 import { FirstParam } from './eager/typeUtils';
-import { ctx } from './enforceContext';
 import { adaptDynamicRules } from './lazy/ruleAdapter';
 import { typeRules } from './lazy/typeRules';
 import type { CustomMatcherArgs } from './n4sTypes';
@@ -16,7 +16,26 @@ import * as schemaRules from './rules/schemaRules/schemaRules';
 import { lazy as lazyRule } from './rules/schemaRules/lazy';
 import type { SchemaRuleLazyTypes } from './rules/schemaRules/schemaRules';
 import { type RuleInstance } from './utils/RuleInstance';
+import { asArray, isNullish } from 'vest-utils';
+import { ctx } from './enforceContext';
 import { RuleRunReturn } from './utils/RuleRunReturn';
+import { resolveInlineDeps } from './schema/dependencyResolver';
+import {
+  ITEM_CONTAINER,
+  ITEM_SCHEMA,
+  OPTIONAL_RULE,
+  PARTIAL_LIKE,
+  RESOLVED_RELATIONSHIPS,
+  UNRESOLVED_DEPS,
+} from './schema/schemaSlots';
+import { isSchemaExecutionProjection } from './schema/projectionContext';
+import type { ItemContainerKind } from './schema/schemaSlots';
+import { snapshotChainBaseline } from './rules/chainBuilder/chainBuilder';
+import { rebaseRelationships } from './schema/rebase';
+import type { SchemaPath } from './schema/SchemaPath';
+import type { InternalRelationship } from './schema/SchemaRelationship';
+import { MAP_FULL_VALUE, MAP_VALUE } from './schema/mapWithoutValidation';
+import { isRuleNode } from './schema/ruleNode';
 
 /**
  * Extracts the output type from a custom matcher function.
@@ -43,16 +62,375 @@ type TCustomLazyRules = {
   >;
 };
 
-// Explicitly adapt only the schema modifiers that act as wrappers
-const schemaModifiers = adaptDynamicRules<
-  RuleInstance<any, [any]>,
-  Pick<typeof schemaRules, 'omit' | 'optional' | 'partial' | 'pick'>
+function collectSchemaRelationships(
+  schema: Record<string, unknown>,
+  keyFilter?: (key: string) => boolean,
+): InternalRelationship[] {
+  // Execution-only fragments are built after the complete relationship
+  // graph has already produced the selective plan. Recompiling relationships
+  // here would force dependency providers back into executable fragments.
+  if (isSchemaExecutionProjection()) return [];
+  const relationships: InternalRelationship[] = resolveInlineDeps(
+    schema as Record<string, RuleInstance<unknown, unknown[]>>,
+    [],
+    schema,
+  );
+  for (const key of Object.keys(schema)) {
+    if (keyFilter && !keyFilter(key)) continue;
+    const fieldRule: unknown = schema[key];
+    const fieldSlots = isNullish(fieldRule) ? null : slotsOf(fieldRule);
+    const nested =
+      (fieldSlots?.[RESOLVED_RELATIONSHIPS] as
+        | InternalRelationship[]
+        | undefined) || [];
+    if (nested.length > 0) {
+      const prefix = [{ type: 'property', key } as const];
+      relationships.push(...rebaseRelationships(nested, prefix));
+    }
+    relationships.push(
+      ...collectItemRelationships(
+        fieldSlots?.[ITEM_SCHEMA],
+        [{ type: 'property', key } as const],
+        `${String(key)}.$item`,
+        new WeakSet(),
+      ),
+    );
+  }
+  return relationships;
+}
+
+/**
+ * Collects item-graph edges through arbitrarily nested containers. Each
+ * level appends an `item` segment to the accumulated prefix, so an edge
+ * inside `isArrayOf(isArrayOf(inner))` surfaces under
+ * `m.$item.$item.*` instead of vanishing. The seen-set guards only the
+ * current descent path (cycle safety): the same member rule object may
+ * legitimately recur under a different prefix — e.g. a diamond
+ * `isArrayOf(mid, inner)` where `mid = isArrayOf(inner)` emits both the
+ * direct `m.$item.*` edge and the nested `m.$item.$item.*` edge — and a
+ * shared set would swallow the second occurrence. It is per top-level
+ * field for the same reason: one member mounted under several fields
+ * rebases under each key independently.
+ */
+function collectItemRelationships(
+  item: unknown,
+  prefix: SchemaPath,
+  binding: string,
+  seen: WeakSet<object>,
+): InternalRelationship[] {
+  const relationships: InternalRelationship[] = [];
+  // Dedupe identical edges at every level: converging diamonds (the same
+  // member reachable via several same-depth paths) otherwise emit 2^d
+  // copies of one logical edge. Identity is structural — same source,
+  // target, effect, metadata and flags — so merging changes nothing
+  // downstream.
+  // (Traversal still visits shared subtrees repeatedly; composition-time
+  // cost on developer-authored schemas only, no output explosion.)
+  const emittedKeys = new Set<string>();
+  const pushUnique = (rels: InternalRelationship[]): void => {
+    for (const rel of rels) {
+      const key = JSON.stringify(rel);
+      if (!emittedKeys.has(key)) {
+        emittedKeys.add(key);
+        relationships.push(rel);
+      }
+    }
+  };
+  for (const entry of normalizeItemSchemas(item)) {
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    try {
+      const segment = { type: 'item', binding } as const;
+      const slots = entry as unknown as Record<symbol, unknown>;
+      const itemRels =
+        (slots[RESOLVED_RELATIONSHIPS] as InternalRelationship[] | undefined) ||
+        [];
+      if (itemRels.length > 0) {
+        pushUnique(rebaseRelationships(itemRels, [...prefix, segment]));
+      }
+      const nested = slots[ITEM_SCHEMA];
+      if (nested !== undefined) {
+        pushUnique(
+          collectItemRelationships(
+            nested,
+            [...prefix, segment],
+            `${binding}.$item`,
+            seen,
+          ),
+        );
+      }
+    } finally {
+      seen.delete(entry);
+    }
+  }
+  return relationships;
+}
+
+/**
+ * Normalizes an ITEM_SCHEMA slot to a list of item rules. Single-rule
+ * containers (record values, single-rule arrays) store the rule directly;
+ * multi-member containers (tuple elements, multi-rule arrays) store a list.
+ * Duplicate references within one list (e.g. a literal `isArrayOf(x, x)`)
+ * collapse to a single entry — each emits identical edges.
+ */
+function normalizeItemSchemas(item: unknown): Record<PropertyKey, unknown>[] {
+  if (!item) return [];
+  const entries = Array.isArray(item) ? item : [item];
+  const out: Record<PropertyKey, unknown>[] = [];
+  for (const entry of entries) {
+    if (!isRuleNode(entry)) continue;
+    if (!out.includes(entry as Record<PropertyKey, unknown>)) {
+      out.push(entry as Record<PropertyKey, unknown>);
+    }
+  }
+  return out;
+}
+
+/**
+ * Relationship-aware record wrapper: attaches the value rule (record(value)
+ * or record(key, value)) as the item schema, mirroring the single-object
+ * ITEM_SCHEMA pattern, so describe() rebases the value shape's item graph.
+ * Key rules are scalars and carry no item graph of their own.
+ */
+function createRecordWrapper(): (
+  arg1: unknown,
+  arg2?: unknown,
+) => RuleInstance<unknown, unknown[]> {
+  return (arg1: unknown, arg2?: unknown) => {
+    const recordRule = recordEvaluators.record as (
+      ...args: unknown[]
+    ) => RuleInstance<unknown, unknown[]>;
+    const rule = arg2 !== undefined ? recordRule(arg1, arg2) : recordRule(arg1);
+    const valueRule = arg2 !== undefined ? arg2 : arg1;
+    // Store every object value rule — not just graph-carrying ones — so
+    // per-member execution (e.g. suite.changed() projection) can reach
+    // primitive members too. describe() output is unchanged: members
+    // without resolved relationships simply contribute no edges.
+    // (Lazy RuleInstances are always objects — chain proxies — so the
+    // object gate cannot silently drop a real member rule.)
+    if (isRuleNode(valueRule)) {
+      const slots = slotsOf(rule);
+      slots[ITEM_SCHEMA] = valueRule;
+      slots[ITEM_CONTAINER] = 'record' as ItemContainerKind;
+    }
+    // Fresh-validation combinator: freeze the chain state a rebuild must
+    // reproduce (P1-1 bail-out compares this against the live chain).
+    snapshotChainBaseline(rule);
+    return rule;
+  };
+}
+
+/**
+ * Untyped view of a rule's relationship/marker slots. Rules are created
+ * through chains and proxies, so slot access goes through this record view
+ * instead of the public RuleInstance type.
+ */
+type SlotStore = Record<PropertyKey, unknown>;
+
+function slotsOf(rule: unknown): SlotStore {
+  return rule as unknown as SlotStore;
+}
+
+function wrapOptional(
+  rawOptional: (inner: unknown) => RuleInstance<unknown, unknown[]>,
+): (inner: unknown) => RuleInstance<unknown, unknown[]> {
+  return inner => {
+    const innerSlots: SlotStore = isNullish(inner) ? {} : slotsOf(inner);
+    const innerResolved = innerSlots[RESOLVED_RELATIONSHIPS];
+    const innerUnresolved = innerSlots[UNRESOLVED_DEPS];
+    // Use adapted rule to get lazy RuleInstance that preserves chain behavior
+    const rule = rawOptional(inner);
+    const slots = slotsOf(rule);
+    if (Array.isArray(innerResolved) && innerResolved.length > 0) {
+      slots[RESOLVED_RELATIONSHIPS] = [...innerResolved];
+    }
+    if (Array.isArray(innerUnresolved) && innerUnresolved.length > 0) {
+      slots[UNRESOLVED_DEPS] = [...innerUnresolved];
+    }
+    // Also copy __schema and ITEM_SCHEMA if present
+    if (innerSlots.__schema && !slots.__schema) {
+      slots.__schema = innerSlots.__schema;
+    }
+    if (innerSlots[ITEM_SCHEMA] && !slots[ITEM_SCHEMA]) {
+      slots[ITEM_SCHEMA] = innerSlots[ITEM_SCHEMA];
+    }
+    if (innerSlots[ITEM_CONTAINER] && !slots[ITEM_CONTAINER]) {
+      slots[ITEM_CONTAINER] = innerSlots[ITEM_CONTAINER];
+    }
+    const innerMapValue = innerSlots[MAP_VALUE];
+    if (typeof innerMapValue === 'function') {
+      slots[MAP_VALUE] = (value: unknown): unknown =>
+        isNullish(value)
+          ? RuleRunReturn.Passing(value)
+          : (innerMapValue as (input: unknown) => unknown)(value);
+    }
+    if (innerSlots[MAP_FULL_VALUE] && !slots[MAP_FULL_VALUE]) {
+      slots[MAP_FULL_VALUE] = innerSlots[MAP_FULL_VALUE];
+    }
+    // The wrapper validates through the inner rule, so the rebuild
+    // baseline is the inner rule's current chain state — not the fresh
+    // single-predicate wrapper chain. Partial-likeness also survives:
+    // narrowing inside a partial would gain requiredness either way.
+    snapshotChainBaseline(rule, inner);
+    slots[OPTIONAL_RULE] = true;
+    if (innerSlots[PARTIAL_LIKE] === true) {
+      slots[PARTIAL_LIKE] = true;
+    }
+    return rule;
+  };
+}
+
+// Explicitly adapt only the schema modifiers that act as wrappers — now relationship-aware
+const rawOptionalBase = adaptDynamicRules<
+  RuleInstance<unknown, [unknown]>,
+  Pick<typeof schemaRules, 'optional'>
 >({
-  omit: schemaRules.omit,
   optional: schemaRules.optional,
-  partial: schemaRules.partial,
-  pick: schemaRules.pick,
-});
+} as unknown as Pick<typeof schemaRules, 'optional'>) as unknown as {
+  optional: (inner: unknown) => RuleInstance<unknown, unknown[]>;
+};
+const optionalWrapper = wrapOptional(rawOptionalBase.optional);
+
+// For partial/pick/omit we need relationship-aware versions that also resolve
+function createPartialWrapper(): (
+  schema: Record<string, unknown>,
+) => RuleInstance<unknown, unknown[]> {
+  return schema => {
+    const relationships = collectSchemaRelationships(schema);
+    const base = adaptDynamicRules<
+      RuleInstance<unknown, [unknown]>,
+      Pick<typeof schemaRules, 'partial'>
+    >({
+      partial: schemaRules.partial,
+    } as unknown as Pick<typeof schemaRules, 'partial'>) as unknown as {
+      partial: (inner: unknown) => RuleInstance<unknown, unknown[]>;
+    };
+    const rule = base.partial(schema);
+    const slots = slotsOf(rule);
+    slots[RESOLVED_RELATIONSHIPS] = relationships;
+    slots.__schema = schema;
+    // partial() skips missing keys by construction — record it so the
+    // runner never has to probe for it (P1-2). Freeze the chain baseline
+    // for rebuild parity (P1-1).
+    slots[PARTIAL_LIKE] = true;
+    snapshotChainBaseline(rule);
+    return rule;
+  };
+}
+
+function createPickWrapper(): (
+  schema: Record<PropertyKey, unknown>,
+  keys: PropertyKey | PropertyKey[],
+) => RuleInstance<unknown, unknown[]> {
+  return (
+    schema: Record<PropertyKey, unknown>,
+    keys: PropertyKey | PropertyKey[],
+  ): RuleInstance<unknown, unknown[]> => {
+    const keysSet = new Set(asArray(keys));
+    let relationships = collectSchemaRelationships(
+      schema as unknown as Record<string, unknown>,
+      (key: string): boolean => keysSet.has(key),
+    );
+    // Filter fully rebased set: keep only relationships where both endpoints' top-level keys are kept.
+    // For rooted relationships, ignore the rooted endpoint as above.
+
+    relationships = filterRelationshipsByTopKey(relationships, (key: string) =>
+      keysSet.has(key),
+    );
+    const base = adaptDynamicRules<
+      RuleInstance<unknown, [unknown]>,
+      Pick<typeof schemaRules, 'pick'>
+    >({
+      pick: schemaRules.pick,
+    } as unknown as Pick<typeof schemaRules, 'pick'>) as unknown as {
+      pick: (s: unknown, k: unknown) => RuleInstance<unknown, unknown[]>;
+    };
+    const rule = base.pick(schema, keys);
+    slotsOf(rule)[RESOLVED_RELATIONSHIPS] = relationships;
+    // For pick, __schema is filtered shape
+    const filtered: Record<string, unknown> = {};
+    const set = new Set(asArray(keys));
+    for (const k of Object.keys(schema))
+      if (set.has(k)) filtered[k] = schema[k];
+    slotsOf(rule).__schema = filtered;
+    snapshotChainBaseline(rule);
+    return rule;
+  };
+}
+
+function createOmitWrapper(): (
+  schema: Record<PropertyKey, unknown>,
+  keys: PropertyKey | PropertyKey[],
+) => RuleInstance<unknown, unknown[]> {
+  return (
+    schema: Record<PropertyKey, unknown>,
+    keys: PropertyKey | PropertyKey[],
+  ): RuleInstance<unknown, unknown[]> => {
+    const keysSet = new Set(asArray(keys));
+    let relationships = collectSchemaRelationships(
+      schema as unknown as Record<string, unknown>,
+      (key: string): boolean => !keysSet.has(key),
+    );
+    // Filter fully rebased set: keep only relationships where both endpoints' top-level keys are not omitted.
+    // For rooted, filter only by local endpoint as above.
+
+    relationships = filterRelationshipsByTopKey(
+      relationships,
+      (key: string) => !keysSet.has(key),
+    );
+    const base = adaptDynamicRules<
+      RuleInstance<unknown, [unknown]>,
+      Pick<typeof schemaRules, 'omit'>
+    >({
+      omit: schemaRules.omit,
+    } as unknown as Pick<typeof schemaRules, 'omit'>) as unknown as {
+      omit: (s: unknown, k: unknown) => RuleInstance<unknown, unknown[]>;
+    };
+    const rule = base.omit(schema as unknown, keys as unknown);
+    (rule as unknown as Record<symbol, unknown>)[RESOLVED_RELATIONSHIPS] =
+      relationships;
+    const filtered: Record<string, unknown> = {};
+    const set = new Set(asArray(keys));
+    for (const k of Object.keys(schema as object))
+      if (!set.has(k)) filtered[k] = (schema as Record<string, unknown>)[k];
+    (rule as unknown as { __schema: unknown }).__schema = filtered;
+    snapshotChainBaseline(rule);
+    return rule;
+  };
+}
+
+function filterRelationshipsByTopKey(
+  relationships: InternalRelationship[],
+  keep: (key: string) => boolean,
+): InternalRelationship[] {
+  const topKey = (path: SchemaPath): string | null =>
+    path[0]?.type === 'property' ? String(path[0].key) : null;
+
+  return relationships.filter((relationship: InternalRelationship): boolean => {
+    const isRootSource = relationship.__isRootSource === true;
+    const isRootTarget = relationship.__isRootTarget === true;
+
+    if (isRootSource && isRootTarget) return true;
+
+    const sourceKey = topKey(relationship.source);
+    const targetKey = topKey(relationship.target);
+
+    if (isRootSource) return targetKey === null || keep(targetKey);
+    if (isRootTarget) return sourceKey === null || keep(sourceKey);
+
+    return (
+      (sourceKey === null || keep(sourceKey)) &&
+      (targetKey === null || keep(targetKey))
+    );
+  });
+}
+
+const schemaModifiers = {
+  optional: optionalWrapper,
+  partial: createPartialWrapper(),
+  pick: createPickWrapper(),
+  omit: createOmitWrapper(),
+};
 
 // Explicitly adapt the base schema evaluators that need __schema exposure
 const schemaEvaluators = adaptDynamicRules<
@@ -78,39 +456,123 @@ const recordEvaluators = adaptDynamicRules<
  */
 const schemaAttacher =
   (ruleFn: (schema: any) => RuleInstance<any, [any]>) => (schema: any) => {
+    const relationships = collectSchemaRelationships(schema);
+
+    /** @deferred v2 — effect:'revalidate' deferred, only 'invalidate' supported in V1 */
+    for (const rel of relationships) {
+      if (rel.effect !== 'invalidate') {
+        throw new Error(
+          `effect:'${rel.effect}' deferred to v2 — only 'invalidate' supported in V1`,
+        );
+      }
+    }
+
     const rule = ruleFn(schema);
     rule.__schema = schema;
+    slotsOf(rule)[RESOLVED_RELATIONSHIPS] = relationships;
+    snapshotChainBaseline(rule);
     return rule;
   };
 
 // Build the final schema rules object with special handling for arrays and base evaluators
 const schemaRulesWithArrayChaining = {
   ...schemaModifiers,
-  isArrayOf: <T>(...rules: any[]): ArrayRuleInstance<T> =>
-    addToChain<ArrayRuleInstance<T>>(arrayRules, (value: any) => {
-      const result = ctx.run({ value }, () =>
-        schemaRules.isArrayOf(value, ...rules),
-      );
-      return RuleRunReturn.create(result, value);
-    }),
+
+  isArrayOf: <T>(...rules: unknown[]): ArrayRuleInstance<T> => {
+    const rule = addToChain<ArrayRuleInstance<T>>(
+      arrayRules,
+      (value: unknown): RuleRunReturn<unknown> => {
+        const result = ctx.run({ value }, () =>
+          schemaRules.isArrayOf(value as unknown[], ...rules),
+        );
+        return RuleRunReturn.create(result, value);
+      },
+    );
+    // Store the single member rule (graph-carrying or primitive) so
+    // per-member execution can reach it; describe() rebasing skips
+    // members without resolved relationships, so output is unchanged.
+    // (Lazy RuleInstances are always objects — chain proxies — so the
+    // object gate cannot silently drop a real member rule.)
+    const slots = rule as unknown as Record<symbol, unknown>;
+    if (rules.length === 1 && isRuleNode(rules[0])) {
+      slots[ITEM_SCHEMA] = rules[0];
+      slots[ITEM_CONTAINER] = 'array' as ItemContainerKind;
+    } else if (rules.length > 1) {
+      // Multi-rule arrays accept an element matching ANY member rule (union
+      // semantics), so no single member owns the item graph. Store every
+      // object member — graph-carrying or primitive — so per-member
+      // execution (e.g. suite.changed() projection) can reach primitive
+      // members too. describe() output is unchanged: members without
+      // resolved relationships simply contribute no edges. This
+      // over-approximates (an edge fires for indices whose element matched
+      // a different member), but that is the invalidation-safe direction —
+      // and never a silent empty graph.
+      const schemas = rules.filter(isRuleNode);
+      if (schemas.length > 0) {
+        slots[ITEM_SCHEMA] = schemas;
+        slots[ITEM_CONTAINER] = 'array' as ItemContainerKind;
+      }
+    }
+    snapshotChainBaseline(rule);
+    return rule;
+  },
   lazy: lazyRule,
-  list: <T>(...rules: any[]): ArrayRuleInstance<T> =>
-    addToChain<ArrayRuleInstance<T>>(arrayRules, (value: any) => {
-      const result = ctx.run({ value }, () =>
-        schemaRules.isArrayOf(value, ...rules),
-      );
-      return RuleRunReturn.create(result, value);
-    }),
+
+  list: <T>(...rules: unknown[]): ArrayRuleInstance<T> => {
+    const rule = addToChain<ArrayRuleInstance<T>>(
+      arrayRules,
+      (value: unknown): RuleRunReturn<unknown> => {
+        const result = ctx.run({ value }, () =>
+          schemaRules.isArrayOf(value as unknown[], ...rules),
+        );
+        return RuleRunReturn.create(result, value);
+      },
+    );
+    const slots = rule as unknown as Record<symbol, unknown>;
+    if (rules.length === 1 && isRuleNode(rules[0])) {
+      slots[ITEM_SCHEMA] = rules[0];
+      slots[ITEM_CONTAINER] = 'array' as ItemContainerKind;
+    } else if (rules.length > 1) {
+      // Same union semantics as isArrayOf above: keep every object member
+      // (graph-carrying or primitive) so per-member execution reaches
+      // primitive members too; describe() output is unchanged.
+      const schemas = rules.filter(isRuleNode);
+      if (schemas.length > 0) {
+        slots[ITEM_SCHEMA] = schemas;
+        slots[ITEM_CONTAINER] = 'array' as ItemContainerKind;
+      }
+    }
+    snapshotChainBaseline(rule);
+    return rule;
+  },
   loose: schemaAttacher(schemaEvaluators.loose),
-  record: recordEvaluators.record,
+  record: createRecordWrapper(),
   shape: schemaAttacher(schemaEvaluators.shape),
-  tuple: (...rules: any[]) =>
-    addToChain(arrayRules, (value: any) => {
-      const result = ctx.run({ value }, () =>
-        schemaRules.tuple(value, ...rules),
-      );
-      return RuleRunReturn.create(result, value);
-    }),
+  tuple: (...rules: unknown[]): RuleInstance<unknown, unknown[]> => {
+    const rule = addToChain(
+      arrayRules,
+      (value: unknown): RuleRunReturn<unknown> => {
+        const result = ctx.run({ value }, () =>
+          schemaRules.tuple(value, ...rules),
+        );
+        return RuleRunReturn.create(result, value);
+      },
+    );
+    // Tuple elements are positional, but relationships inside an element are
+    // still same-item edges. Collect every object element — graph-carrying
+    // or primitive — so per-member execution reaches primitive positions
+    // too; describe() output is unchanged (members without resolved
+    // relationships contribute no edges).
+    const schemas = rules.filter(isRuleNode);
+    if (schemas.length > 0) {
+      // No ITEM_CONTAINER here: tuple members are positional, and vest
+      // readers discriminate list slots with Array.isArray without ever
+      // consulting the kind for them — so an absent kind cannot misroute.
+      (rule as unknown as Record<symbol, unknown>)[ITEM_SCHEMA] = schemas;
+    }
+    snapshotChainBaseline(rule);
+    return rule;
+  },
 };
 
 const baseEnforceLazy = {

--- a/packages/n4s/src/lazy/typeRules.ts
+++ b/packages/n4s/src/lazy/typeRules.ts
@@ -22,8 +22,11 @@ import { arrayParsers } from '../rules/parsers/arrayParsers';
 import { generalParsers } from '../rules/parsers/generalParsers';
 import { numberParsers } from '../rules/parsers/numberParsers';
 import { stringParsers } from '../rules/parsers/stringParsers';
+import { registerParserRules } from '../rules/parsers/parserUtils';
 import { isString } from '../rules/stringRules';
 import * as stringRules from '../rules/stringRules';
+
+registerParserRules({ toNumber: numberRules.toNumber });
 
 const lazyArrayRules = {
   ...arrayRules,

--- a/packages/n4s/src/n4s.ts
+++ b/packages/n4s/src/n4s.ts
@@ -39,7 +39,50 @@ export { ctx } from './enforceContext';
  */
 export { compose } from './compose';
 
-type ExtendFn = (rules: Record<string, (...args: any[]) => any>) => void;
+/**
+ * Public schema relationship introspection types.
+ * Returned by `describe()` on schema rules.
+ */
+export type {
+  ItemSegment,
+  PropertySegment,
+  SchemaPath,
+} from './schema/SchemaPath';
+export { isItemSegment, isPropertySegment } from './schema/SchemaPath';
+export type {
+  SchemaDependency,
+  SchemaRelationship,
+} from './schema/SchemaRelationship';
+export type { DescribeResult } from './utils/RuleInstance';
+
+/**
+ * Escape hatch for referencing a literal field whose name collides with a
+ * JavaScript internal (`then` is never chainable so refs stay non-thenable).
+ *
+ * @example
+ * ```typescript
+ * dependsOn($ => $[FIELD]('then'))
+ * ```
+ */
+export { FIELD } from './schema/scopeProxy';
+
+/**
+ * Error thrown for schema composition and boundary violations (unknown
+ * dependency fields, orphaned fragment sources). Public so consumers can
+ * catch it by identity regardless of which entry built the schema.
+ */
+export { EnforceSchemaError } from './errors/EnforceSchemaError';
+export type { ScopeHandle } from './utils/RuleInstance';
+export type { SchemaMemberRule } from './rules/schemaRules/schemaRulesLazyTypes';
+
+type ExtendOptions<Rules> = {
+  parsers?: readonly (keyof Rules & string)[];
+};
+type ExtensionRule = (...args: never[]) => unknown;
+type ExtendFn = <Rules extends Record<string, ExtensionRule>>(
+  rules: Rules,
+  options?: ExtendOptions<Rules>,
+) => void;
 type ContextFn = () => EnforceContext;
 type Enforce = typeof enforceEager &
   typeof enforceLazy & { extend: ExtendFn; context: ContextFn };
@@ -101,6 +144,9 @@ enforce.context = function context(): EnforceContext {
  * Custom rules become available on both eager and lazy APIs.
  *
  * @param rules - Object mapping rule names to validation functions
+ * @param options.parsers - Custom rules that are safe to execute as pure
+ * transformations when mapping an unfocused value. Rules are validators by
+ * default and are never speculatively executed.
  *
  * @example
  * ```typescript
@@ -125,8 +171,13 @@ enforce.context = function context(): EnforceContext {
  * }
  * ```
  */
-enforce.extend = function extend(
-  rules: Record<string, (...args: any[]) => any>,
+enforce.extend = function extend<Rules extends Record<string, ExtensionRule>>(
+  rules: Rules,
+  options?: ExtendOptions<Rules>,
 ) {
-  extendEnforce(enforce, rules);
+  extendEnforce(
+    enforce as unknown as Record<string, unknown>,
+    rules,
+    new Set(options?.parsers),
+  );
 };

--- a/packages/n4s/src/rules/chainBuilder/__tests__/lazyRegistry.test.ts
+++ b/packages/n4s/src/rules/chainBuilder/__tests__/lazyRegistry.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { getLazyRule } from '../lazyRegistry';
+
+describe('lazyRegistry', () => {
+  it('does not expose Object.prototype members as registered rules', () => {
+    expect(getLazyRule('toString')).toBeUndefined();
+    expect(getLazyRule('constructor')).toBeUndefined();
+    expect(getLazyRule('__proto__')).toBeUndefined();
+  });
+});

--- a/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
+++ b/packages/n4s/src/rules/chainBuilder/chainBuilder.ts
@@ -8,14 +8,42 @@ import {
 } from 'vest-utils';
 import { StandardSchemaV1 } from 'vest-utils/standardSchemaSpec';
 
-import { RuleInstance } from '../../utils/RuleInstance';
+import type {
+  InternalRelationship,
+  SchemaDependency,
+  SchemaRelationship,
+} from '../../schema/SchemaRelationship';
+import type { RuleInstance, ScopeHandle } from '../../utils/RuleInstance';
+import { cloneRelationship, groupDependencies } from '../../utils/RuleInstance';
+import { assertRuleRootedPathsValid } from '../../schema/dependencyResolver';
+import {
+  CHAIN_BASELINE,
+  CHAIN_INFO,
+  COMPOSITION_CHILDREN,
+  ITEM_SCHEMA,
+  RESOLVED_RELATIONSHIPS,
+  UNRESOLVED_DEPS,
+} from '../../schema/schemaSlots';
+import type { ChainBaseline, ChainInfo } from '../../schema/schemaSlots';
+import { isSchemaExecutionProjection } from '../../schema/projectionContext';
+import { MAP_VALUE } from '../../schema/mapWithoutValidation';
+import { isRuleNode } from '../../schema/ruleNode';
 
 import { executeChain, type Predicate } from './chainExecutor';
 import { createChainProxyHandlers } from './proxyHandlers';
 
-export type RuleFunctions<T extends RuleInstance<any, any>> = Record<
-  keyof Omit<T, 'infer' | 'test' | 'validate' | 'parse' | '~standard'>,
-  (...args: any[]) => boolean | ReturnType<Predicate>
+export type RuleFunctions<T extends RuleInstance<unknown, unknown[]>> = Record<
+  keyof Omit<
+    T,
+    | 'infer'
+    | 'test'
+    | 'validate'
+    | 'parse'
+    | '~standard'
+    | 'dependsOn'
+    | 'describe'
+  >,
+  (...args: unknown[]) => boolean | ReturnType<Predicate>
 >;
 
 type LazyMessage = DynamicValue<
@@ -23,26 +51,161 @@ type LazyMessage = DynamicValue<
   [value: unknown, originalMessage?: Stringable]
 >;
 
+type BoundaryFrame = {
+  members: WeakSet<object>;
+};
+
+// Only roots containing deferred $.root relationships need boundary tracking.
+// Each active root computes its composition membership once; nested chain runs
+// are then O(1) WeakSet lookups instead of repeatedly walking the schema graph.
+const activeBoundaryFrames: BoundaryFrame[] = [];
+
+// Maps each chain proxy to its internal target so composition membership
+// resolves by identity: __schema graphs store proxies while run()/validate()
+// receive their underlying targets.
+const proxyToTarget = new WeakMap<object, object>();
+
+function isObjectNode(node: unknown): node is object {
+  return isRuleNode(node);
+}
+
+function resolveBoundaryNode(node: unknown): object | null {
+  if (!isObjectNode(node)) return null;
+  return proxyToTarget.get(node as object) ?? (node as object);
+}
+
+function schemaChildNodes(record: Record<PropertyKey, unknown>): unknown[] {
+  const schema = record.__schema;
+  if (!schema || typeof schema !== 'object') return [];
+  return Object.values(schema);
+}
+
+function itemChildNodes(record: Record<PropertyKey, unknown>): unknown[] {
+  const item = record[ITEM_SCHEMA];
+  if (Array.isArray(item)) return item.filter(isObjectNode);
+  return isObjectNode(item) ? [item] : [];
+}
+
+function explicitCompositionChildren(
+  record: Record<PropertyKey, unknown>,
+): unknown[] {
+  const children = record[COMPOSITION_CHILDREN];
+  return Array.isArray(children) ? children.filter(isObjectNode) : [];
+}
+
+function childNodesOf(resolved: object): unknown[] {
+  const record = resolved as Record<PropertyKey, unknown>;
+  return [
+    ...schemaChildNodes(record),
+    ...itemChildNodes(record),
+    ...explicitCompositionChildren(record),
+  ];
+}
+
+function collectCompositionMembers(root: unknown): WeakSet<object> {
+  const members = new WeakSet<object>();
+  const seen = new Set<object>();
+  const pending: unknown[] = [root];
+  while (pending.length > 0) {
+    const raw = pending.pop();
+    if (isObjectNode(raw)) members.add(raw as object);
+    const resolved = resolveBoundaryNode(raw);
+    if (!resolved || seen.has(resolved)) continue;
+    seen.add(resolved);
+    members.add(resolved);
+    pending.push(...childNodesOf(resolved));
+  }
+  return members;
+}
+
+// eslint-disable-next-line complexity -- two identity forms across nested frames
+function isActiveCompositionMember(rule: unknown): boolean {
+  if (!isObjectNode(rule)) return false;
+  const resolved = resolveBoundaryNode(rule);
+  if (!resolved) return false;
+  for (let i = activeBoundaryFrames.length - 1; i >= 0; i--) {
+    const frame = activeBoundaryFrames[i];
+    if (frame?.members.has(rule as object) || frame?.members.has(resolved)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasRootedRelationships(rule: unknown): boolean {
+  if (!isObjectNode(rule)) return false;
+  const rels = (rule as Record<symbol, unknown>)[RESOLVED_RELATIONSHIPS];
+  return (
+    Array.isArray(rels) &&
+    (rels as InternalRelationship[]).some(
+      rel => rel.__isRootSource === true || rel.__isRootTarget === true,
+    )
+  );
+}
+
+export function withStandaloneRootedBoundary<R>(rule: unknown, fn: () => R): R {
+  // Selective execution has already consumed relationship metadata to plan
+  // the fragment. A planner-owned execution projection validates values only;
+  // re-enforcing $.root provider membership here would turn metadata into an
+  // execution dependency and force unrelated source validators to run.
+  if (isSchemaExecutionProjection()) return fn();
+
+  // The common case: ordinary rules and relationship graphs with only local
+  // edges pay no boundary bookkeeping at all.
+  if (!hasRootedRelationships(rule)) return fn();
+  if (activeBoundaryFrames.length > 0 && isActiveCompositionMember(rule)) {
+    return fn();
+  }
+
+  const frame = { members: collectCompositionMembers(rule) };
+  activeBoundaryFrames.push(frame);
+  try {
+    assertRuleRootedPathsValid(rule);
+    return fn();
+  } finally {
+    activeBoundaryFrames.pop();
+  }
+}
+
 /**
  * Creates a chain builder for rule validation.
  * Provides methods to add predicates, run validation, and apply custom messages.
  * Implements StandardSchema v1 support.
  */
-export function createChainBuilder<T extends RuleInstance<any, any>>(
-  rules: RuleFunctions<T> | Record<string, (...args: any[]) => any>,
+export function createChainBuilder<T extends RuleInstance<unknown, unknown[]>>(
+  rules: RuleFunctions<T> | Record<string, (...args: unknown[]) => unknown>,
 ) {
   const chain: Predicate[] = [];
+  const mappingChain: Predicate[] = [];
   const target: Partial<T> = {};
   let lazyMessage: Maybe<LazyMessage> = undefined;
+  const unresolvedDeps: Array<{
+    resolver: (scope: ScopeHandle) => unknown;
+  }> = [];
 
-  const add = (p: Predicate): T => {
+  const add = (p: Predicate, mapsValue = false): T => {
     chain.push(p);
+    if (mapsValue) mappingChain.push(p);
+    syncChainInfo();
     return proxy;
   };
 
-  const prepend = (p: Predicate): T => {
+  const prepend = (p: Predicate, mapsValue = false): T => {
     chain.unshift(p);
+    if (mapsValue) mappingChain.unshift(p);
+    syncChainInfo();
     return proxy;
+  };
+
+  const syncChainInfo = (): void => {
+    const slots = target as unknown as Record<symbol, unknown>;
+    const current = slots[CHAIN_INFO] as ChainInfo | undefined;
+    const next: ChainInfo = {
+      length: chain.length,
+      hasMessage: current?.hasMessage ?? false,
+    };
+    slots[CHAIN_INFO] = next;
+    (proxy as unknown as Record<symbol, unknown>)[CHAIN_INFO] = next;
   };
 
   const resolveMessage = (
@@ -50,61 +213,93 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
     value: unknown,
   ): string => {
     const defaultMessage = result.message || 'Validation failed';
-    if (!lazyMessage) {
-      return defaultMessage;
-    }
+    if (!lazyMessage) return defaultMessage;
     return dynamicValue(lazyMessage, value, result.message) ?? defaultMessage;
   };
 
-  const validate: T['validate'] = ((...args: any[]) => {
-    const result = executeChain(chain, args[0]);
-    if (result.pass) {
-      return { value: result.type };
-    }
-    return {
-      issues: [
-        {
-          message: resolveMessage(result, args[0]),
-          path: result.path || [],
-        },
-      ],
-    };
-  }) as T['validate'];
-
-  const test: T['test'] = ((...args: any[]) => {
-    const result = validate(...args);
-    return !result.issues;
-  }) as T['test'];
-
-  // Internal compatibility method - converts StandardSchema Result to RuleRunReturn
-
-  const parse: T['parse'] = ((...args: any[]) => {
-    const result = validate(...args);
-    if (!result.issues) {
-      return result.value;
-    }
-
-    const [firstIssue] = result.issues;
-    throw new TypeError(firstIssue?.message || 'Validation failed');
-  }) as T['parse'];
-
-  const run: T['run'] = ((...args: any[]) => {
-    const result = executeChain(chain, args[0]);
-    if (!result.pass && lazyMessage) {
+  const validate = ((...args: unknown[]) => {
+    return withStandaloneRootedBoundary(target, () => {
+      const result = executeChain(chain, args[0] as unknown);
+      if (result.pass) {
+        return { value: result.type } as ReturnType<T['validate']>;
+      }
       return {
-        ...result,
-        message:
-          dynamicValue(lazyMessage, args[0], result.message) ?? result.message,
-      };
-    }
-    return result;
-  }) as T['run'];
+        issues: [
+          {
+            message: resolveMessage(result, args[0] as unknown),
+            path: result.path || [],
+          },
+        ],
+      } as ReturnType<T['validate']>;
+    });
+  }) as unknown as T['validate'];
+
+  const test = ((...args: unknown[]) => {
+    const result = (
+      validate as unknown as (...a: unknown[]) => ReturnType<T['validate']>
+    )(...args);
+    return !result.issues;
+  }) as unknown as T['test'];
+
+  const parse = ((...args: unknown[]) => {
+    const result = (
+      validate as unknown as (...a: unknown[]) => ReturnType<T['validate']>
+    )(...args);
+    if (!result.issues) return result.value as ReturnType<T['parse']>;
+    const [firstIssue] = result.issues as Array<{ message?: string }>;
+    throw new TypeError(firstIssue?.message || 'Validation failed');
+  }) as unknown as T['parse'];
+
+  const run = ((...args: unknown[]) => {
+    return withStandaloneRootedBoundary(target, () => {
+      const result = executeChain(chain, args[0] as unknown);
+      if (!result.pass && lazyMessage) {
+        return {
+          ...result,
+          message:
+            dynamicValue(lazyMessage, args[0] as unknown, result.message) ??
+            result.message,
+        } as ReturnType<T['run']>;
+      }
+      return result as ReturnType<T['run']>;
+    });
+  }) as unknown as T['run'];
 
   const message = (msg: Stringable): T => {
     if (msg) {
       lazyMessage = msg;
+      const slots = target as unknown as Record<symbol, unknown>;
+      const current = slots[CHAIN_INFO] as ChainInfo | undefined;
+      const next: ChainInfo = {
+        length: current?.length ?? chain.length,
+        hasMessage: true,
+      };
+      slots[CHAIN_INFO] = next;
+      (proxy as unknown as Record<symbol, unknown>)[CHAIN_INFO] = next;
     }
     return proxy;
+  };
+
+  const dependsOn = (resolver: (scope: ScopeHandle) => unknown): T => {
+    unresolvedDeps.push({ resolver });
+    (target as unknown as Record<symbol, unknown>)[UNRESOLVED_DEPS] =
+      unresolvedDeps;
+    (proxy as unknown as Record<symbol, unknown>)[UNRESOLVED_DEPS] =
+      unresolvedDeps;
+    return proxy;
+  };
+
+  const describe = (): ReturnType<T['describe']> => {
+    const raw =
+      (target as unknown as Record<symbol, unknown>)[RESOLVED_RELATIONSHIPS] ||
+      (proxy as unknown as Record<symbol, unknown>)[RESOLVED_RELATIONSHIPS] ||
+      [];
+    const rawArray = raw as InternalRelationship[];
+    const resolved: SchemaRelationship[] = rawArray.map(cloneRelationship);
+    const dependencies: SchemaDependency[] = groupDependencies(resolved);
+    return { dependencies, relationships: resolved } as ReturnType<
+      T['describe']
+    >;
   };
 
   const proxy: T = new Proxy(
@@ -112,14 +307,29 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
     createChainProxyHandlers(rules, {
       '~standard': {
         types: {
-          input: undefined!,
-          output: undefined!,
+          input: undefined as unknown as T extends RuleInstance<
+            infer I,
+            unknown[]
+          >
+            ? I
+            : unknown,
+          output: undefined as unknown as T extends RuleInstance<
+            infer O,
+            unknown[]
+          >
+            ? O
+            : unknown,
         },
-        validate,
+        validate: validate as unknown as StandardSchemaV1.Props<
+          unknown,
+          unknown
+        >['validate'],
         vendor: 'n4s',
         version: 1 as const,
-      } as StandardSchemaV1.Props<any, any>,
+      } as StandardSchemaV1.Props<unknown, unknown>,
       add,
+      dependsOn,
+      describe,
       message,
       parse,
       prepend,
@@ -129,5 +339,44 @@ export function createChainBuilder<T extends RuleInstance<any, any>>(
     }),
   );
 
+  (proxy as unknown as Record<symbol, unknown>)[UNRESOLVED_DEPS] =
+    unresolvedDeps;
+  const mapValue = (value: unknown): ReturnType<typeof executeChain> =>
+    executeChain(mappingChain, value);
+  (target as unknown as Record<symbol, unknown>)[MAP_VALUE] = mapValue;
+  (proxy as unknown as Record<symbol, unknown>)[MAP_VALUE] = mapValue;
+  proxyToTarget.set(proxy as unknown as object, target as object);
+
   return { add, proxy } as const;
+}
+
+/**
+ * Freezes the chain baseline a rebuild must reproduce. Fresh-validation
+ * combinators snapshot their own rule; delegating wrappers (optional)
+ * snapshot the inner rule they validate through and capture it, so drift
+ * checks recurse into post-wrap mutations of the wrapped rule.
+ */
+export function snapshotChainBaseline(target: unknown, source?: unknown): void {
+  const frozen = freezeChainInfo(source ?? target);
+  const baseline: ChainBaseline = isDelegatedWrap(source, target)
+    ? { ...frozen, inner: source }
+    : frozen;
+  (target as unknown as Record<symbol, unknown>)[CHAIN_BASELINE] = baseline;
+}
+
+function freezeChainInfo(rule: unknown): {
+  length: number;
+  hasMessage: boolean;
+} {
+  const current = (rule as unknown as Record<symbol, unknown>)[CHAIN_INFO] as
+    | ChainInfo
+    | undefined;
+  return {
+    length: current?.length ?? 0,
+    hasMessage: current?.hasMessage ?? false,
+  };
+}
+
+function isDelegatedWrap(source: unknown, target: unknown): boolean {
+  return source !== undefined && source !== target;
 }

--- a/packages/n4s/src/rules/chainBuilder/lazyRegistry.ts
+++ b/packages/n4s/src/rules/chainBuilder/lazyRegistry.ts
@@ -1,16 +1,23 @@
 import type { Predicate } from './chainExecutor';
 
-const lazyRegistry: Record<string, (...args: any[]) => Predicate> = {};
+type LazyRule = {
+  readonly build: (args: readonly unknown[]) => Predicate;
+  readonly mapsValue: boolean;
+};
 
-export function registerLazyRule(
+const lazyRegistry = Object.create(null) as Record<string, LazyRule>;
+
+export function registerLazyRule<Args extends unknown[]>(
   name: string,
-  builder: (...args: any[]) => Predicate,
+  builder: (...args: Args) => Predicate,
+  mapsValue = false,
 ) {
-  lazyRegistry[name] = builder;
+  lazyRegistry[name] = {
+    build: args => builder(...(args as Args)),
+    mapsValue,
+  };
 }
 
-export function getLazyRule(
-  name: string,
-): ((...args: any[]) => Predicate) | undefined {
+export function getLazyRule(name: string): LazyRule | undefined {
   return lazyRegistry[name];
 }

--- a/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
+++ b/packages/n4s/src/rules/chainBuilder/proxyHandlers.ts
@@ -1,8 +1,12 @@
-import { hasOwnProperty } from 'vest-utils';
+import { hasOwnProperty, type Stringable } from 'vest-utils';
 import { StandardSchemaV1 } from 'vest-utils/standardSchemaSpec';
 
-import { RuleInstance } from '../../utils/RuleInstance';
-import { CHAIN_PREPEND } from '../parsers/parserUtils';
+import {
+  RuleInstance,
+  type DescribeResult,
+  type ScopeHandle,
+} from '../../utils/RuleInstance';
+import { CHAIN_PREPEND, isParserRule } from '../parsers/parserUtils';
 
 import type { Predicate } from './chainExecutor';
 import { getLazyRule } from './lazyRegistry';
@@ -11,26 +15,32 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
   rules: Record<string, (...args: any[]) => any>,
   {
     add,
+    dependsOn,
+    describe,
+    message,
+    parse,
+    prepend,
+    run,
     test,
     validate,
-    run,
-    parse,
-    message,
-    prepend,
     '~standard': standard,
   }: {
-    add: (p: Predicate) => T;
+    add: (p: Predicate, mapsValue?: boolean) => T;
+    dependsOn: (resolver: (scope: ScopeHandle) => unknown) => T;
+    describe: () => DescribeResult;
+    message: (msg: Stringable) => T;
+    parse: T['parse'];
+    prepend: (p: Predicate, mapsValue?: boolean) => T;
+    run: T['run'];
     test: T['test'];
     validate: T['validate'];
-    run: T['run'];
-    parse: T['parse'];
-    message: (msg: any) => T;
-    prepend: (p: Predicate) => T;
     '~standard': StandardSchemaV1.Props<any, any>;
   },
 ) {
   const methods = {
     '~standard': standard,
+    dependsOn,
+    describe,
     message,
     parse,
     run,
@@ -38,12 +48,14 @@ export function createChainProxyHandlers<T extends RuleInstance<any, any>>(
     validate,
   };
   const methodKeys = new Set([
+    'dependsOn',
+    'describe',
     'infer',
+    'message',
+    'parse',
+    'run',
     'test',
     'validate',
-    'run',
-    'parse',
-    'message',
     '~standard',
   ]);
 
@@ -57,7 +69,10 @@ function createProxyHandlersHelper<T extends RuleInstance<any, any>>(
   rules: Record<string, any>,
   methods: Record<string, any>,
   methodKeys: Set<string>,
-  inserters: { add: (p: Predicate) => T; prepend: (p: Predicate) => T },
+  inserters: {
+    add: (p: Predicate, mapsValue?: boolean) => T;
+    prepend: (p: Predicate, mapsValue?: boolean) => T;
+  },
 ) {
   function getRuleHandler(prop: string | symbol) {
     if (hasOwnProperty(rules, prop)) {
@@ -65,13 +80,17 @@ function createProxyHandlersHelper<T extends RuleInstance<any, any>>(
         ? inserters.prepend
         : inserters.add;
       return (...args: any[]) =>
-        insert((value: any) => rules[prop](value, ...args));
+        insert(
+          (value: unknown) => rules[prop](value, ...args),
+          isParserRule(rules[prop]),
+        );
     }
 
     if (typeof prop === 'string') {
       const lazyRule = getLazyRule(prop);
       if (lazyRule) {
-        return (...args: any[]) => inserters.add(lazyRule(...args));
+        return (...args: unknown[]) =>
+          inserters.add(lazyRule.build(args), lazyRule.mapsValue);
       }
     }
 
@@ -90,7 +109,8 @@ function createProxyHandlersHelper<T extends RuleInstance<any, any>>(
     },
     has(_target: T, prop: string | symbol) {
       if (typeof prop === 'string') {
-        if (methodKeys.has(prop) || getLazyRule(prop)) return true;
+        if (methodKeys.has(prop) || getLazyRule(prop) !== undefined)
+          return true;
       }
       if (hasOwnProperty(rules, prop)) return true;
       return Reflect.has(_target as object, prop);

--- a/packages/n4s/src/rules/genRuleChain.ts
+++ b/packages/n4s/src/rules/genRuleChain.ts
@@ -15,8 +15,9 @@ export { registerLazyRule };
 export function addToChain<T extends RuleInstance<any, any>>(
   rules: RuleFunctions<T> | Record<string, (...args: any[]) => any>,
   predicate: Predicate,
+  mapsValue = false,
 ): T {
   const { add, proxy } = createChainBuilder<T>(rules);
-  add(predicate);
+  add(predicate, mapsValue);
   return proxy as T;
 }

--- a/packages/n4s/src/rules/parsers/arrayParsers.ts
+++ b/packages/n4s/src/rules/parsers/arrayParsers.ts
@@ -1,4 +1,4 @@
-import { mapPassing } from './parserUtils';
+import { mapPassing, registerParserRules } from './parserUtils';
 
 export const join = (value: unknown[], separator = ',') =>
   mapPassing((current: unknown[]) => current.join(separator))(value);
@@ -10,3 +10,5 @@ export const arrayParsers = {
   join,
   uniq,
 } as const;
+
+registerParserRules(arrayParsers);

--- a/packages/n4s/src/rules/parsers/generalParsers.ts
+++ b/packages/n4s/src/rules/parsers/generalParsers.ts
@@ -1,5 +1,5 @@
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
-import { CHAIN_PREPEND } from './parserUtils';
+import { CHAIN_PREPEND, registerParserRules } from './parserUtils';
 import { toBoolean } from './toBoolean';
 
 export function defaultTo<TValue>(
@@ -28,3 +28,5 @@ export const generalParsers = {
   parseJSON,
   toBoolean,
 } as const;
+
+registerParserRules(generalParsers);

--- a/packages/n4s/src/rules/parsers/numberParsers.ts
+++ b/packages/n4s/src/rules/parsers/numberParsers.ts
@@ -1,6 +1,6 @@
 import { RuleRunReturn } from '../../utils/RuleRunReturn';
 
-import { mapPassing } from './parserUtils';
+import { mapPassing, registerParserRules } from './parserUtils';
 
 export const ceil = (value: number) =>
   mapPassing((current: number) => Math.ceil(current))(value);
@@ -83,3 +83,5 @@ export const numberParsers = {
   toFloat,
   toInteger,
 } as const;
+
+registerParserRules(numberParsers);

--- a/packages/n4s/src/rules/parsers/parserUtils.ts
+++ b/packages/n4s/src/rules/parsers/parserUtils.ts
@@ -7,6 +7,18 @@ import { RuleRunReturn } from '../../utils/RuleRunReturn';
  */
 export const CHAIN_PREPEND: unique symbol = Symbol('chainPrepend');
 
+const parserRules = new WeakSet<CallableFunction>();
+
+export function registerParserRules(
+  rules: Readonly<Record<string, CallableFunction>>,
+): void {
+  for (const rule of Object.values(rules)) parserRules.add(rule);
+}
+
+export function isParserRule(rule: unknown): rule is CallableFunction {
+  return typeof rule === 'function' && parserRules.has(rule);
+}
+
 export function mapPassing<TInput, TOutput>(
   transform: (value: TInput) => TOutput,
 ): (value: TInput) => RuleRunReturn<TOutput> {

--- a/packages/n4s/src/rules/parsers/stringParsers.ts
+++ b/packages/n4s/src/rules/parsers/stringParsers.ts
@@ -1,4 +1,4 @@
-import { mapPassing } from './parserUtils';
+import { mapPassing, registerParserRules } from './parserUtils';
 
 function toCamelCase(value: string): string {
   return value
@@ -146,3 +146,5 @@ export const stringParsers = {
   trimEnd,
   trimStart,
 } as const;
+
+registerParserRules(stringParsers);

--- a/packages/n4s/src/rules/schemaRules/__tests__/itemRelationships.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/itemRelationships.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect } from 'vitest';
+
+import { compose, enforce } from '../../../n4s';
+import type { SchemaMemberRule } from '../../../n4s';
+import { EnforceSchemaError } from '../../../errors/EnforceSchemaError';
+import { RESOLVED_RELATIONSHIPS } from '../../../schema/schemaSlots';
+import type { SchemaRelationship } from '../../../schema/SchemaRelationship';
+
+type PathSegment = {
+  type?: string;
+  key?: unknown;
+  binding?: unknown;
+};
+
+function pathString(path: unknown): string {
+  return ((path ?? []) as PathSegment[])
+    .map(seg => (seg.type === 'item' ? String(seg.binding) : String(seg.key)))
+    .join('.');
+}
+
+function sourcesFor(
+  described: { relationships: SchemaRelationship[] },
+  target: string,
+): string[] {
+  return described.relationships
+    .filter(rel => pathString(rel.target) === target)
+    .map(rel => pathString(rel.source));
+}
+
+describe('item relationships', () => {
+  it('tuple with an inner dependsOn describes the rebased edge', () => {
+    const schema = enforce.shape({
+      t: enforce.tuple(
+        enforce.shape({
+          country: enforce.isString(),
+          state: enforce.isString().dependsOn($ => $.country),
+        }),
+      ),
+    });
+
+    expect(sourcesFor(schema.describe(), 't.t.$item.state')).toEqual([
+      't.t.$item.country',
+    ]);
+  });
+
+  it('tuple collects edges from every graph-carrying element', () => {
+    const schema = enforce.shape({
+      pair: enforce.tuple(
+        enforce.shape({
+          country: enforce.isString(),
+          state: enforce.isString().dependsOn($ => $.country),
+        }),
+        enforce.shape({
+          city: enforce.isString(),
+          zip: enforce.isString().dependsOn($ => $.city),
+        }),
+      ),
+    });
+
+    const described = schema.describe();
+    expect(sourcesFor(described, 'pair.pair.$item.state')).toEqual([
+      'pair.pair.$item.country',
+    ]);
+    expect(sourcesFor(described, 'pair.pair.$item.zip')).toEqual([
+      'pair.pair.$item.city',
+    ]);
+  });
+
+  it('record with an inner dependsOn describes the rebased edge', () => {
+    const schema = enforce.shape({
+      d: enforce.record(
+        enforce.shape({
+          country: enforce.isString(),
+          state: enforce.isString().dependsOn($ => $.country),
+        }),
+      ),
+    });
+
+    expect(sourcesFor(schema.describe(), 'd.d.$item.state')).toEqual([
+      'd.d.$item.country',
+    ]);
+  });
+
+  it('record with a key rule still describes the value rule edge', () => {
+    const schema = enforce.shape({
+      d: enforce.record(
+        enforce.isString(),
+        enforce.shape({
+          country: enforce.isString(),
+          state: enforce.isString().dependsOn($ => $.country),
+        }),
+      ),
+    });
+
+    expect(sourcesFor(schema.describe(), 'd.d.$item.state')).toEqual([
+      'd.d.$item.country',
+    ]);
+  });
+
+  it('multi-rule isArrayOf describes the union of member edges', () => {
+    const schema = enforce.shape({
+      items: enforce.isArrayOf(
+        enforce.shape({
+          country: enforce.isString(),
+          kind: enforce.isString().dependsOn($ => $.country),
+        }),
+        enforce.isString(),
+      ),
+    });
+
+    expect(sourcesFor(schema.describe(), 'items.items.$item.kind')).toEqual([
+      'items.items.$item.country',
+    ]);
+  });
+
+  it('single-rule isArrayOf keeps describing its edge', () => {
+    const schema = enforce.shape({
+      items: enforce.isArrayOf(
+        enforce.shape({
+          country: enforce.isString(),
+          kind: enforce.isString().dependsOn($ => $.country),
+        }),
+      ),
+    });
+
+    expect(sourcesFor(schema.describe(), 'items.items.$item.kind')).toEqual([
+      'items.items.$item.country',
+    ]);
+  });
+
+  it('doubly nested isArrayOf describes the inner edge', () => {
+    const schema = enforce.shape({
+      m: enforce.isArrayOf(
+        enforce.isArrayOf(
+          enforce.shape({
+            country: enforce.isString(),
+            state: enforce.isString().dependsOn($ => $.country),
+          }),
+        ),
+      ),
+    });
+
+    expect(
+      sourcesFor(schema.describe(), 'm.m.$item.m.$item.$item.state'),
+    ).toEqual(['m.m.$item.m.$item.$item.country']);
+  });
+
+  it('diamond members emit both the direct and the nested edge', () => {
+    const inner = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+    const schema = enforce.shape({
+      m: enforce.isArrayOf(enforce.isArrayOf(inner), inner),
+    });
+
+    expect(sourcesFor(schema.describe(), 'm.m.$item.state')).toEqual([
+      'm.m.$item.country',
+    ]);
+    expect(
+      sourcesFor(schema.describe(), 'm.m.$item.m.$item.$item.state'),
+    ).toEqual(['m.m.$item.m.$item.$item.country']);
+  });
+
+  it('converging diamonds emit one edge, not 2^d copies', () => {
+    const inner = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+    const schema = enforce.shape({
+      m: enforce.isArrayOf(enforce.isArrayOf(inner), enforce.isArrayOf(inner)),
+    });
+
+    const described = schema.describe();
+    expect(described.relationships).toHaveLength(1);
+    expect(sourcesFor(described, 'm.m.$item.m.$item.$item.state')).toEqual([
+      'm.m.$item.m.$item.$item.country',
+    ]);
+  });
+
+  it('multi-rule array with a nested container member keeps the edge', () => {
+    const schema = enforce.shape({
+      m: enforce.isArrayOf(
+        enforce.isArrayOf(
+          enforce.shape({
+            country: enforce.isString(),
+            state: enforce.isString().dependsOn($ => $.country),
+          }),
+        ),
+        enforce.isString(),
+      ),
+    });
+
+    expect(
+      sourcesFor(schema.describe(), 'm.m.$item.m.$item.$item.state'),
+    ).toEqual(['m.m.$item.m.$item.$item.country']);
+  });
+
+  it('record of arrays describes the inner edge', () => {
+    const schema = enforce.shape({
+      d: enforce.record(
+        enforce.isArrayOf(
+          enforce.shape({
+            country: enforce.isString(),
+            state: enforce.isString().dependsOn($ => $.country),
+          }),
+        ),
+      ),
+    });
+
+    expect(
+      sourcesFor(schema.describe(), 'd.d.$item.d.$item.$item.state'),
+    ).toEqual(['d.d.$item.d.$item.$item.country']);
+  });
+
+  it('composed graph-carrying rule keeps its edge when mounted', () => {
+    const inner = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+    const schema = enforce.shape({ name: compose(inner) });
+
+    expect(
+      schema
+        .describe()
+        .relationships.filter(rel => pathString(rel.target) === 'name.state'),
+    ).toHaveLength(1);
+  });
+
+  it('composed array rule keeps its item edge when mounted', () => {
+    const schema = enforce.shape({
+      m: compose(
+        enforce.isArrayOf(
+          enforce.shape({
+            country: enforce.isString(),
+            state: enforce.isString().dependsOn($ => $.country),
+          }),
+        ),
+      ),
+    });
+
+    expect(sourcesFor(schema.describe(), 'm.m.$item.state')).toEqual([
+      'm.m.$item.country',
+    ]);
+  });
+
+  it.each([
+    ['array', (rule: SchemaMemberRule) => enforce.isArrayOf(rule)],
+    ['tuple', (rule: SchemaMemberRule) => enforce.tuple(rule)],
+    ['record', (rule: SchemaMemberRule) => enforce.record(rule)],
+  ])('keeps a composed inner edge in a %s container', (_name, container) => {
+    const inner = compose(
+      enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+    );
+    const schema = enforce.shape({ rows: container(inner) });
+
+    expect(
+      schema
+        .describe()
+        .relationships.map(relationship => [
+          pathString(relationship.source),
+          pathString(relationship.target),
+        ]),
+    ).toEqual([['rows.rows.$item.country', 'rows.rows.$item.state']]);
+  });
+
+  it('unions relationship graphs from every composed rule', () => {
+    const first = enforce.shape({
+      w: enforce.isString(),
+      x: enforce.isString().dependsOn($ => $.y),
+      y: enforce.isString(),
+      z: enforce.isString(),
+    });
+    const second = enforce.shape({
+      w: enforce.isString(),
+      x: enforce.isString(),
+      y: enforce.isString(),
+      z: enforce.isString().dependsOn($ => $.w),
+    });
+    const schema = enforce.shape({ block: compose(first, second) });
+
+    expect(sourcesFor(schema.describe(), 'block.x')).toEqual(['block.y']);
+    expect(sourcesFor(schema.describe(), 'block.z')).toEqual(['block.w']);
+  });
+
+  it('non-invalidate effects throw the deferred-to-v2 error at composition', () => {
+    const inner = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+    const slots = inner as unknown as Record<symbol, unknown>;
+    const rels = slots[RESOLVED_RELATIONSHIPS] as Array<
+      Record<string, unknown>
+    >;
+    slots[RESOLVED_RELATIONSHIPS] = [
+      ...rels,
+      { ...rels[0], effect: 'revalidate' },
+    ];
+    expect(() => enforce.shape({ m: enforce.isArrayOf(inner) })).toThrow(
+      /deferred to v2/,
+    );
+  });
+});
+
+describe('dotted dependsOn with a missing intermediate', () => {
+  it('throws EnforceSchemaError naming the full dotted path', () => {
+    let caught: unknown;
+    try {
+      enforce.shape({
+        x: enforce.isString().dependsOn($ => $.a.b),
+      });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(EnforceSchemaError);
+    expect((caught as Error).message).toMatch(
+      /EnforceSchemaError: "x" depends on unknown field "a\.b"/,
+    );
+  });
+
+  it('quotes the full dotted path for a missing nested intermediate', () => {
+    let caught: unknown;
+    try {
+      enforce.shape({
+        x: enforce.isString().dependsOn($ => $.a.b.c),
+        a: enforce.shape({
+          z: enforce.isString(),
+        }),
+      });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(EnforceSchemaError);
+    expect((caught as Error).message).toMatch(
+      /EnforceSchemaError: "x" depends on unknown field "a\.b\.c"/,
+    );
+  });
+});

--- a/packages/n4s/src/rules/schemaRules/__tests__/omit.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/omit.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { enforce } from '../../../n4s';
+import { invokeWithUnknown } from '../../../__tests__/runtimeTestUtils';
 
 describe('omit', () => {
+  it('rejects unknown keys at compile time', () => {
+    const schema = {
+      name: enforce.isString(),
+    };
+
+    expectTypeOf<'typo'>().not.toMatchTypeOf<keyof typeof schema>();
+  });
+
   it('Should successfully validate a schema ignoring omitted keys', () => {
     const schema = {
       name: enforce.isString(),
@@ -12,7 +21,6 @@ describe('omit', () => {
     const omittedSchema = enforce.omit(schema, ['email']);
 
     // Omit email, validating valid inputs for name and age
-    // @ts-expect-error - partial object, omitted keys missing
     const result = omittedSchema.run({ name: 'John Doe', age: 30 });
     expect(result.pass).toBe(true);
 
@@ -34,7 +42,6 @@ describe('omit', () => {
     // omit name
     const omittedSchema = enforce.omit(schema, 'name');
 
-    // @ts-expect-error - partial object, omitted keys missing
     const result = omittedSchema.run({ id: 1 });
     expect(result.pass).toBe(true);
 
@@ -61,9 +68,9 @@ describe('omit', () => {
     const schema = { name: enforce.isString() };
     const omittedSchema = enforce.omit(schema, ['name']);
 
-    // @ts-expect-error - testing non-object value
+    // Note: the fully-omitted schema type is `{}` so non-null payloads
+    // typecheck here; the runtime still rejects them (asserted below).
     expect(omittedSchema.run('string_value').pass).toBe(false);
-    // @ts-expect-error - testing non-object value
     expect(omittedSchema.run(123).pass).toBe(false);
     // @ts-expect-error - testing non-object value
     expect(omittedSchema.run(null).pass).toBe(false);
@@ -71,7 +78,7 @@ describe('omit', () => {
 
   it('Should protect against dangerous prototype keys', () => {
     const schema = { admin: enforce.isBoolean() };
-    const omittedSchema = enforce.omit(schema, ['id']);
+    const omittedSchema = invokeWithUnknown(enforce.omit, schema, ['id']);
 
     const dangerousValue = JSON.parse('{"__proto__": {"admin": true}}');
     const result = omittedSchema.run(dangerousValue);
@@ -92,7 +99,6 @@ describe('omit', () => {
     const omittedSchema = enforce.omit(schema, ['id']);
 
     const result = omittedSchema.run({
-      // @ts-expect-error - intentionally passing string instead of number
       id: 'invalid_type_but_omitted',
     });
     expect(result.pass).toBe(true);
@@ -122,10 +128,34 @@ describe('omit', () => {
       name: 'John',
       // @ts-expect-error - intentionally passing string instead of number
       age: 'thirty',
-      // @ts-expect-error - intentionally passing number instead of string
       email: 123,
     });
 
     expect(invalidResult.pass).toBe(false);
+  });
+
+  it('preserves rooted edges so an omitted schema can be mounted', () => {
+    const schema = {
+      accountType: enforce.isString(),
+      child: enforce.isString().dependsOn($ => $.root.accountType),
+      discarded: enforce.isString(),
+    };
+
+    const omittedSchema = enforce.omit(schema, ['accountType', 'discarded']);
+
+    expect(omittedSchema.describe().relationships).toHaveLength(1);
+    expect(() => omittedSchema.test({ child: 'x' })).toThrow(
+      /depends on unknown field "accountType"/,
+    );
+
+    const mounted = enforce.shape({
+      accountType: enforce.isString(),
+      nested: omittedSchema,
+    });
+
+    expect(
+      mounted.test({ accountType: 'business', nested: { child: 'x' } }),
+    ).toBe(true);
+    expect(mounted.describe().relationships).toHaveLength(1);
   });
 });

--- a/packages/n4s/src/rules/schemaRules/__tests__/pick.test.ts
+++ b/packages/n4s/src/rules/schemaRules/__tests__/pick.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { enforce } from '../../../n4s';
 
 describe('pick', () => {
@@ -12,7 +12,6 @@ describe('pick', () => {
     const pickedSchema = enforce.pick(schema, ['name', 'age']);
 
     // Pick name and age, validating valid inputs
-    // @ts-expect-error - partial object, un-picked keys omitted
     const result = pickedSchema.run({ name: 'John Doe', age: 30 });
     expect(result.pass).toBe(true);
 
@@ -33,7 +32,6 @@ describe('pick', () => {
 
     const pickedSchema = enforce.pick(schema, 'id');
 
-    // @ts-expect-error - partial object, un-picked keys omitted
     const result = pickedSchema.run({ id: 1 });
     expect(result.pass).toBe(true);
 
@@ -54,7 +52,6 @@ describe('pick', () => {
     // 'email' is in the schema but missing in the value.
     // If we only pick 'name' and 'age', it should still pass.
     const pickedSchema = enforce.pick(schema, ['name', 'age']);
-    // @ts-expect-error - partial object, un-picked keys omitted
     const result = pickedSchema.run({ name: 'John Doe', age: 30 });
     expect(result.pass).toBe(true);
   });
@@ -106,7 +103,6 @@ describe('pick', () => {
     const pickedSchema = enforce.pick(schema, []);
 
     const result = pickedSchema.run({
-      // @ts-expect-error - intentionally passing string instead of number
       id: 'invalid_type_but_not_checked',
     });
     expect(result.pass).toBe(true);
@@ -136,10 +132,41 @@ describe('pick', () => {
       name: 'John',
       // @ts-expect-error - intentionally passing string instead of number
       age: 'thirty',
-      // @ts-expect-error - intentionally passing number instead of string
       email: 123,
     });
 
     expect(invalidResult.pass).toBe(false);
+  });
+
+  it('rejects unknown keys at compile time', () => {
+    const schema = {
+      name: enforce.isString(),
+    };
+
+    expectTypeOf<'typo'>().not.toMatchTypeOf<keyof typeof schema>();
+  });
+
+  it('preserves rooted edges so a picked schema can be mounted', () => {
+    const schema = {
+      accountType: enforce.isString(),
+      child: enforce.isString().dependsOn($ => $.root.accountType),
+    };
+
+    const pickedSchema = enforce.pick(schema, ['child']);
+
+    expect(pickedSchema.describe().relationships).toHaveLength(1);
+    expect(() => pickedSchema.test({ child: 'x' })).toThrow(
+      /depends on unknown field "accountType"/,
+    );
+
+    const mounted = enforce.shape({
+      accountType: enforce.isString(),
+      nested: pickedSchema,
+    });
+
+    expect(
+      mounted.test({ accountType: 'business', nested: { child: 'x' } }),
+    ).toBe(true);
+    expect(mounted.describe().relationships).toHaveLength(1);
   });
 });

--- a/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
+++ b/packages/n4s/src/rules/schemaRules/schemaRulesLazyTypes.ts
@@ -11,7 +11,13 @@ import './shape';
 import './record';
 import './tuple';
 
-import type { RuleInstance } from '../../utils/RuleInstance';
+import type {
+  DescribeResult,
+  RuleInstance,
+  ScopeHandle,
+} from '../../utils/RuleInstance';
+import type { RuleRunReturn } from '../../utils/RuleRunReturn';
+import type { StandardSchemaV1 } from 'vest-utils/standardSchemaSpec';
 import { MultiTypeInput, MultiTypeInputArgs } from './schemaRulesTypes';
 
 import type {
@@ -28,8 +34,27 @@ import type {
 } from './schemaRules';
 
 /**
- * Type mappings for schema rule lazy API return types
+ * Minimal structural schema-member rule. Method syntax keeps parameters
+ * bivariant so concrete rules stay assignable, while full member coverage
+ * lets Pick<S, K> / Omit<S, K> satisfy the PickRuleInstance /
+ * OmitRuleInstance constraints with fully precise types.
  */
+export interface SchemaMemberRule {
+  infer: unknown;
+  test(value: unknown): boolean;
+  run(value: unknown, ...rest: unknown[]): RuleRunReturn<unknown>;
+  validate(
+    value: unknown,
+    ...rest: unknown[]
+  ): StandardSchemaV1.Result<unknown>;
+  parse(value: unknown, ...rest: unknown[]): unknown;
+  '~standard': StandardSchemaV1.Props<unknown, unknown> & {
+    readonly types: StandardSchemaV1.Types<unknown, unknown>;
+  };
+  dependsOn(resolver: (scope: ScopeHandle) => unknown): SchemaMemberRule;
+  describe(): DescribeResult;
+}
+
 export type SchemaRuleLazyTypes = {
   isArrayOf: <Rules extends RuleInstance<any, any>[]>(
     ...rules: Rules
@@ -47,14 +72,14 @@ export type SchemaRuleLazyTypes = {
   partial: <S extends Record<string, RuleInstance<any>>>(
     schema: S,
   ) => PartialRuleInstance<S>;
-  pick: <S extends Record<string, RuleInstance<any>>>(
+  pick: <S extends Record<string, SchemaMemberRule>, K extends keyof S>(
     schema: S,
-    keys: string[] | string,
-  ) => PickRuleInstance<S>;
-  omit: <S extends Record<string, RuleInstance<any>>>(
+    keys: readonly K[] | K,
+  ) => PickRuleInstance<Pick<S, K>>;
+  omit: <S extends Record<string, SchemaMemberRule>, K extends keyof S>(
     schema: S,
-    keys: string[] | string,
-  ) => OmitRuleInstance<S>;
+    keys: readonly K[] | K,
+  ) => OmitRuleInstance<Omit<S, K>>;
   shape: <S extends Record<string, RuleInstance<any>>>(
     schema: S,
   ) => ShapeRuleInstance<S>;

--- a/packages/n4s/src/schema/SchemaPath.ts
+++ b/packages/n4s/src/schema/SchemaPath.ts
@@ -1,0 +1,31 @@
+export type PropertySegment = { type: 'property'; key: PropertyKey };
+export type ItemSegment = { type: 'item'; binding: string };
+export type SchemaPath = readonly (PropertySegment | ItemSegment)[];
+
+export function propertySegment(key: PropertyKey): PropertySegment {
+  return { type: 'property', key };
+}
+
+export function itemSegment(binding: string): ItemSegment {
+  return { type: 'item', binding };
+}
+
+export function isPropertySegment(
+  seg: PropertySegment | ItemSegment,
+): seg is PropertySegment {
+  return seg.type === 'property';
+}
+
+export function isItemSegment(
+  seg: PropertySegment | ItemSegment,
+): seg is ItemSegment {
+  return seg.type === 'item';
+}
+
+export function pathToString(path: SchemaPath): string {
+  return path
+    .map(seg =>
+      seg.type === 'property' ? String(seg.key) : `{item:${seg.binding}}`,
+    )
+    .join('.');
+}

--- a/packages/n4s/src/schema/SchemaRelationship.ts
+++ b/packages/n4s/src/schema/SchemaRelationship.ts
@@ -1,0 +1,18 @@
+import type { SchemaPath } from './SchemaPath';
+
+export interface SchemaRelationship {
+  source: SchemaPath;
+  target: SchemaPath;
+  effect: 'invalidate';
+  metadata?: { reason?: string };
+}
+
+export type InternalRelationship = SchemaRelationship & {
+  __isRootSource?: boolean;
+  __isRootTarget?: boolean;
+};
+
+export interface SchemaDependency {
+  target: SchemaPath;
+  sources: readonly SchemaPath[];
+}

--- a/packages/n4s/src/schema/__tests__/mapWithoutValidation.test.ts
+++ b/packages/n4s/src/schema/__tests__/mapWithoutValidation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { enforce } from '../../n4s';
+import { mapWithoutValidation } from '../mapWithoutValidation';
+
+describe('mapWithoutValidation', () => {
+  it('returns the declared parser output even when parser validation fails', () => {
+    const mapped = mapWithoutValidation(
+      enforce.isNumeric().toNumber(),
+      'not-numeric',
+    );
+
+    expect(typeof mapped).toBe('number');
+    if (typeof mapped !== 'number') {
+      throw new TypeError('Expected the parser output type');
+    }
+    expect(Number.isNaN(mapped)).toBe(true);
+  });
+
+  it('maps a parser wrapped in optional while preserving nullish values', () => {
+    const optionalNumber = enforce.optional(enforce.isNumeric().toNumber());
+
+    expect(mapWithoutValidation(optionalNumber, '42')).toBe(42);
+    expect(mapWithoutValidation(optionalNumber, undefined)).toBeUndefined();
+    expect(mapWithoutValidation(optionalNumber, null)).toBeNull();
+  });
+});

--- a/packages/n4s/src/schema/__tests__/projectionContext.test.ts
+++ b/packages/n4s/src/schema/__tests__/projectionContext.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isSchemaExecutionProjection,
+  withSchemaExecutionProjection,
+} from '../projectionContext';
+
+describe('schema execution projection context', () => {
+  it('is scoped and nestable', () => {
+    expect(isSchemaExecutionProjection()).toBe(false);
+    withSchemaExecutionProjection(() => {
+      expect(isSchemaExecutionProjection()).toBe(true);
+      withSchemaExecutionProjection(() => {
+        expect(isSchemaExecutionProjection()).toBe(true);
+      });
+      expect(isSchemaExecutionProjection()).toBe(true);
+    });
+    expect(isSchemaExecutionProjection()).toBe(false);
+  });
+
+  it('rejects asynchronous execution before it can silently lose context', () => {
+    expect(() => withSchemaExecutionProjection(async () => {})).toThrow(
+      'Schema execution projection must remain synchronous.',
+    );
+    expect(isSchemaExecutionProjection()).toBe(false);
+  });
+});

--- a/packages/n4s/src/schema/__tests__/runSchemaPaths.flatProjection.test.ts
+++ b/packages/n4s/src/schema/__tests__/runSchemaPaths.flatProjection.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import { runSchemaPaths } from '../../exports/internal';
+import { enforce } from '../../n4s';
+
+describe('runSchemaPaths flat execution projection', () => {
+  it('does not execute a dependency source when only the target changed', () => {
+    const calls: string[] = [];
+    const schema = enforce.shape({
+      country: enforce.condition((value: unknown) => {
+        calls.push(`country:${String(value)}`);
+        return typeof value === 'string';
+      }),
+      state: enforce
+        .condition((value: unknown) => {
+          calls.push(`state:${String(value)}`);
+          return typeof value === 'string';
+        })
+        .dependsOn($ => $.country),
+    });
+
+    const result = runSchemaPaths(
+      schema,
+      { country: 'US', state: 'NY' },
+      { affected: ['state'] },
+    );
+
+    expect(result.every(entry => entry.pass)).toBe(true);
+    expect(calls).toEqual(['state:NY']);
+  });
+
+  it('executes a changed source and its direct dependent exactly once', () => {
+    const calls: string[] = [];
+    const schema = enforce.shape({
+      country: enforce.condition((value: unknown) => {
+        calls.push(`country:${String(value)}`);
+        return typeof value === 'string';
+      }),
+      state: enforce
+        .condition((value: unknown) => {
+          calls.push(`state:${String(value)}`);
+          return typeof value === 'string';
+        })
+        .dependsOn($ => $.country),
+      email: enforce.condition((value: unknown) => {
+        calls.push(`email:${String(value)}`);
+        return typeof value === 'string';
+      }),
+    });
+
+    runSchemaPaths(
+      schema,
+      { country: 'US', state: 'NY', email: 'a@example.com' },
+      { affected: ['country'] },
+    );
+
+    expect(calls).toEqual(['country:US', 'state:NY']);
+  });
+
+  it('keeps dependency fan-out non-transitive', () => {
+    const calls: string[] = [];
+    const schema = enforce.shape({
+      a: enforce.condition((value: unknown) => {
+        calls.push(`a:${String(value)}`);
+        return true;
+      }),
+      b: enforce
+        .condition((value: unknown) => {
+          calls.push(`b:${String(value)}`);
+          return true;
+        })
+        .dependsOn($ => $.a),
+      c: enforce
+        .condition((value: unknown) => {
+          calls.push(`c:${String(value)}`);
+          return true;
+        })
+        .dependsOn($ => $.b),
+    });
+
+    runSchemaPaths(schema, { a: 'a', b: 'b', c: 'c' }, { affected: ['a'] });
+
+    expect(calls).toEqual(['a:a', 'b:b']);
+  });
+
+  it('deduplicates a flat cycle without recursing', () => {
+    const calls: string[] = [];
+    const schema = enforce.shape({
+      a: enforce
+        .condition((value: unknown) => {
+          calls.push(`a:${String(value)}`);
+          return true;
+        })
+        .dependsOn($ => $.b),
+      b: enforce
+        .condition((value: unknown) => {
+          calls.push(`b:${String(value)}`);
+          return true;
+        })
+        .dependsOn($ => $.a),
+    });
+
+    runSchemaPaths(schema, { a: 'a', b: 'b' }, { affected: ['a'] });
+
+    expect(calls).toEqual(['a:a', 'b:b']);
+  });
+
+  it('lets only() narrow the dependency-aware affected set', () => {
+    const calls: string[] = [];
+    const schema = enforce.shape({
+      a: enforce.condition(() => {
+        calls.push('a');
+        return true;
+      }),
+      b: enforce
+        .condition(() => {
+          calls.push('b');
+          return true;
+        })
+        .dependsOn($ => $.a),
+    });
+
+    runSchemaPaths(
+      schema,
+      { a: 'a', b: 'b' },
+      { affected: ['a'], only: ['a'] },
+    );
+
+    expect(calls).toEqual(['a']);
+  });
+
+  it('still applies parser chains to affected members', () => {
+    const schema = enforce.shape({
+      age: enforce.isNumeric().toNumber(),
+      note: enforce.isString(),
+    });
+
+    const result = runSchemaPaths(
+      schema,
+      { age: '42', note: 'unchanged' },
+      { affected: ['age'] },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].pass).toBe(true);
+    expect(result[0].type).toEqual({ age: 42, note: 'unchanged' });
+  });
+});

--- a/packages/n4s/src/schema/__tests__/selectiveRun.test.ts
+++ b/packages/n4s/src/schema/__tests__/selectiveRun.test.ts
@@ -1,0 +1,887 @@
+import { describe, expect, it } from 'vitest';
+
+import { compose, EnforceSchemaError, enforce } from '../../n4s';
+import {
+  assertSchemaRootPathsValid,
+  parseAffectedFieldName,
+  resolveAffectedPaths,
+  runSchemaPaths,
+} from '../../exports/internal';
+import type { SelectiveSchemaResult } from '../../exports/internal';
+import type { RuleInstance } from '../../utils/RuleInstance';
+import {
+  buildProjectedSchema,
+  filterSchemaResultsToAffected,
+  mergeSupplementalResults,
+} from '../selectiveRun';
+
+/**
+ * A runtime-foreign shape member: only `run` exists at runtime, so the
+ * engine takes the vendor-gated exotic path (no construction markers, no
+ * n4s vendor tag). The cast keeps this proven runtime object while
+ * satisfying the builder's member constraint — it asserts the engine's
+ * documented tolerance for absent member surface, nothing more.
+ */
+function foreignMember(
+  run: (value: unknown) => unknown,
+): RuleInstance<unknown, unknown[]> {
+  return { run } as RuleInstance<unknown, unknown[]>;
+}
+
+describe('runSchemaPaths selective contract', () => {
+  it('runs the full schema when no affected paths are given', () => {
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString(),
+    });
+
+    const [failure] = runSchemaPaths(schema, { a: 42, b: 'ok' });
+    expect(failure?.pass).toBe(false);
+    expect(failure?.path).toEqual(['a']);
+  });
+
+  it('narrows top-level failures to the affected paths', () => {
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString(),
+    });
+
+    const results = runSchemaPaths(
+      schema,
+      { a: 42, b: 43 },
+      { affected: ['b'] },
+    );
+    const failures = results.filter(result => !result.pass);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.path).toEqual(['b']);
+  });
+
+  it('projects nested fragments so unaffected validators never execute', () => {
+    const seenOther: unknown[] = [];
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        state: enforce.isString(),
+        country: enforce.isString(),
+      }),
+      other: enforce.condition((value: unknown): boolean => {
+        seenOther.push(value);
+        return typeof value === 'string';
+      }),
+    });
+
+    const data = { profile: { state: 42, country: 'US' }, other: 'ok' };
+    const results = runSchemaPaths(schema, data, {
+      affected: ['profile.state'],
+    });
+
+    expect(
+      results.some(
+        result =>
+          !result.pass && (result.path ?? []).join('.') === 'profile.state',
+      ),
+    ).toBe(true);
+    expect(seenOther).toEqual([]);
+  });
+
+  it('throws EnforceSchemaError when the schema is absent', () => {
+    const data = { a: 1 };
+    expect(() => runSchemaPaths(undefined, data)).toThrowError(
+      EnforceSchemaError,
+    );
+    expect(() => runSchemaPaths(null, data)).toThrowError(EnforceSchemaError);
+  });
+});
+
+describe('assertSchemaRootPathsValid suite finalizer', () => {
+  it('accepts rooted providers from every child of a composition', () => {
+    const schema = compose(
+      enforce.loose({
+        name: enforce.isString().dependsOn($ => $.root.id),
+      }),
+      enforce.loose({ id: enforce.isString() }),
+    );
+
+    expect(() => assertSchemaRootPathsValid(schema)).not.toThrow();
+  });
+
+  it('accepts a schema with resolvable rooted endpoints', () => {
+    const schema = enforce.shape({
+      accountType: enforce.isString(),
+      company: enforce.shape({
+        country: enforce.isString(),
+        taxId: enforce
+          .isString()
+          .dependsOn($ => [$.country, $.root.accountType]),
+      }),
+    });
+
+    expect(() => assertSchemaRootPathsValid(schema)).not.toThrow();
+  });
+
+  it('throws on a dangling rooted endpoint', () => {
+    const schema = enforce.shape({
+      company: enforce.shape({
+        country: enforce.isString(),
+        taxId: enforce.isString().dependsOn($ => [$.country, $.root.missing]),
+      }),
+    });
+
+    expect(() => assertSchemaRootPathsValid(schema)).toThrowError(
+      /unknown field "missing"/,
+    );
+  });
+
+  it('quotes the full dotted path for a nested dangling endpoint', () => {
+    const schema = enforce.shape({
+      account: enforce.shape({ country: enforce.isString() }),
+      company: enforce.shape({
+        name: enforce.isString(),
+        taxId: enforce
+          .isString()
+          .dependsOn($ => [$.name, $.root.account.missing]),
+      }),
+    });
+
+    expect(() => assertSchemaRootPathsValid(schema)).toThrowError(
+      /unknown field "account\.missing"/,
+    );
+  });
+
+  it('quotes the full dotted path for a nested inline miss', () => {
+    // Inner shapes resolve against their own scope, so the full quoted
+    // path is scope-relative ("nested.path", not the leaf "path").
+    expect(() =>
+      enforce.shape({
+        profile: enforce.shape({
+          country: enforce.isString(),
+          state: enforce.isString().dependsOn($ => $.nested.path),
+        }),
+      }),
+    ).toThrowError(/unknown field "nested\.path"/);
+  });
+
+  it('ignores schemas without relationships', () => {
+    expect(() => assertSchemaRootPathsValid(undefined)).not.toThrow();
+    expect(() => assertSchemaRootPathsValid({})).not.toThrow();
+  });
+
+  it('propagates unexpected finalizer traversal failures', () => {
+    const schema = {};
+    Object.defineProperty(schema, '__schema', {
+      get: () => {
+        throw new TypeError('broken schema metadata');
+      },
+    });
+
+    expect(() => assertSchemaRootPathsValid(schema)).toThrowError(
+      new TypeError('broken schema metadata'),
+    );
+  });
+});
+
+describe('runSchemaPaths parse failures', () => {
+  it('lets an unexpected TypeError from a foreign parse surface instead of falling back', () => {
+    const buggy = {
+      run: () => [{ pass: true, type: 'coerced' }],
+      parse: () => {
+        throw new TypeError(
+          "Cannot read properties of undefined (reading 'x')",
+        );
+      },
+    };
+    expect(() => runSchemaPaths(buggy, { a: 1 })).toThrowError(
+      /Cannot read properties/,
+    );
+    expect(() =>
+      runSchemaPaths(buggy, { a: 1 }, { affected: ['a'] }),
+    ).toThrowError(/Cannot read properties/);
+  });
+
+  it('lets an unexpected n4s validator TypeError surface loudly', () => {
+    const schema = enforce.shape({ a: enforce.isString() });
+    const data: Record<string, unknown> = { a: 'ok' };
+    Object.defineProperty(data, 'a', {
+      enumerable: true,
+      get(): unknown {
+        throw new TypeError('getter bug');
+      },
+    });
+    expect(() => runSchemaPaths(schema, data)).toThrowError(/getter bug/);
+    expect(() =>
+      runSchemaPaths(schema, data, { affected: ['a'] }),
+    ).toThrowError(/getter bug/);
+  });
+});
+
+describe('runSchemaPaths foreign executable schemas', () => {
+  it('matches full-run output for a truly foreign { run, parse } schema', () => {
+    const exotic = {
+      run: (value: unknown) =>
+        (value as { a: unknown }).a === 'ok'
+          ? [{ pass: true, type: value }]
+          : [{ pass: false, path: ['a'], message: 'bad a' }],
+      parse: (value: unknown) => {
+        if ((value as { a: unknown }).a === 'ok') return value;
+        const error = new Error('bad a') as Error & { isValidation: boolean };
+        error.isValidation = true;
+        throw error;
+      },
+    };
+    const bad = { a: 'nope' };
+    expect(runSchemaPaths(exotic, bad, { affected: ['a'] })).toEqual(
+      runSchemaPaths(exotic, bad),
+    );
+    const good = { a: 'ok' };
+    expect(runSchemaPaths(exotic, good, { affected: ['a'] })).toEqual(
+      runSchemaPaths(exotic, good),
+    );
+  });
+});
+
+describe('runSchemaPaths unknown extra keys', () => {
+  const strictUser = () =>
+    enforce.shape({
+      a: enforce.isString(),
+      profile: enforce.shape({ state: enforce.isString() }),
+    });
+
+  it('matches the full-run verdict for an explicitly-undefined unknown key', () => {
+    const schema = strictUser();
+    const data = {
+      a: 'ok',
+      profile: { state: 'ok' },
+      extra: undefined as unknown as string,
+    };
+    const full = runSchemaPaths(schema, data);
+    expect(
+      full.some(
+        result => !result.pass && (result.path ?? []).join('.') === 'extra',
+      ),
+    ).toBe(true);
+    expect(
+      runSchemaPaths(schema, data, { affected: ['extra', 'profile.state'] }),
+    ).toEqual(full);
+  });
+
+  it('matches the full-run verdict for a nested explicitly-undefined unknown key', () => {
+    const schema = strictUser();
+    const data = {
+      a: 'ok',
+      profile: { state: 'ok', extra: undefined as unknown as string },
+    };
+    const full = runSchemaPaths(schema, data);
+    expect(
+      full.some(
+        result =>
+          !result.pass && (result.path ?? []).join('.') === 'profile.extra',
+      ),
+    ).toBe(true);
+    expect(
+      runSchemaPaths(schema, data, { affected: ['profile.extra'] }),
+    ).toEqual(full);
+  });
+
+  it('still fails present-with-value unknown keys selectively', () => {
+    const schema = strictUser();
+    const data = { a: 'ok', profile: { state: 'ok' }, extra: 'nope' };
+    const selective = runSchemaPaths(schema, data, {
+      affected: ['extra', 'profile.state'],
+    });
+    expect(
+      selective.some(
+        result => !result.pass && (result.path ?? []).join('.') === 'extra',
+      ),
+    ).toBe(true);
+  });
+
+  it('passes absent unknown keys on both runs', () => {
+    const schema = strictUser();
+    const data = { a: 'ok', profile: { state: 'ok' } };
+    expect(
+      runSchemaPaths(schema, data, { affected: ['extra', 'profile.state'] }),
+    ).toEqual(runSchemaPaths(schema, data));
+  });
+
+  it('treats non-enumerable unknown keys as absent', () => {
+    const schema = strictUser();
+    const data: Record<string, unknown> = {
+      a: 'ok',
+      profile: { state: 'ok' },
+    };
+    Object.defineProperty(data, 'extra', {
+      value: undefined,
+      enumerable: false,
+    });
+    const full = runSchemaPaths(schema, data);
+    expect(full.every(result => result.pass)).toBe(true);
+    expect(
+      runSchemaPaths(schema, data, { affected: ['extra', 'profile.state'] }),
+    ).toEqual(full);
+  });
+});
+
+describe('runSchemaPaths only/skip focus', () => {
+  const twoStrings = () =>
+    enforce.shape({ a: enforce.isString(), b: enforce.isString() });
+
+  it('intersects only with affected instead of dropping it', () => {
+    const failures = runSchemaPaths(
+      twoStrings(),
+      { a: 42, b: 43 },
+      {
+        affected: ['a', 'b'],
+        only: 'a',
+      },
+    ).filter(result => !result.pass);
+    expect(failures.map(result => result.path)).toEqual([['a']]);
+  });
+
+  it('treats a parent only as selecting the whole subtree', () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        state: enforce.isString(),
+        country: enforce.isString(),
+      }),
+      other: enforce.isString(),
+    });
+    const data = { profile: { state: 1, country: 2 }, other: 3 };
+    const failures = runSchemaPaths(schema, data, {
+      affected: ['profile.state', 'profile.country'],
+      only: ['profile'],
+    }).filter(result => !result.pass);
+    expect(
+      failures.map(result => (result.path ?? []).join('.')).sort(),
+    ).toEqual(['profile.country', 'profile.state']);
+  });
+
+  it('runs nothing on a disjoint only', () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({ state: enforce.isString() }),
+      other: enforce.isString(),
+    });
+    const data = { profile: { state: 42 }, other: 'ok' };
+    const results = runSchemaPaths(schema, data, {
+      affected: ['profile.state'],
+      only: ['other'],
+    });
+    expect(results.every(result => result.pass)).toBe(true);
+    expect(results).toEqual([{ pass: true, type: data }]);
+  });
+
+  it('runs nothing for an explicit empty affected set', () => {
+    const data = { a: 42, b: 43 };
+    expect(runSchemaPaths(twoStrings(), data, { affected: [] })).toEqual([
+      { pass: true, type: data },
+    ]);
+  });
+
+  it('narrows synthesized failures by skip', () => {
+    const failures = runSchemaPaths(
+      twoStrings(),
+      { a: 42, b: 43 },
+      {
+        affected: ['a', 'b'],
+        skip: ['a'],
+      },
+    ).filter(result => !result.pass);
+    expect(failures.map(result => result.path)).toEqual([['b']]);
+  });
+
+  it('passes everything through on skip-all', () => {
+    const results = runSchemaPaths(
+      twoStrings(),
+      { a: 42, b: 43 },
+      {
+        affected: ['a', 'b'],
+        skip: true,
+      },
+    );
+    expect(results.every(result => result.pass)).toBe(true);
+  });
+
+  it('carries raw input — not a filtered failure type — on fabricated passes', () => {
+    const coercing = foreignMember(() => ({
+      pass: false,
+      type: 42,
+      message: 'too small',
+    }));
+    const schema = enforce.shape({
+      doc: coercing,
+      other: enforce.isString(),
+    });
+    const data = { doc: 'raw', other: 'ok' };
+    expect(runSchemaPaths(schema, data).some(result => !result.pass)).toBe(
+      true,
+    );
+    expect(runSchemaPaths(schema, data, { affected: ['missing'] })).toEqual([
+      { pass: true, type: data },
+    ]);
+  });
+});
+
+describe('runSchemaPaths container supplementation', () => {
+  it('surfaces affected array members hidden behind earlier failures', () => {
+    const schema = enforce.shape({
+      items: enforce.isArrayOf(enforce.isString()),
+      other: enforce.isString(),
+    });
+    const failures = runSchemaPaths(
+      schema,
+      { items: [42, 'ok', 43], other: 'ok' },
+      { affected: ['items.2'] },
+    ).filter(result => !result.pass);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.path).toEqual(['items', '2']);
+  });
+
+  it('runs affected tuple members positionally', () => {
+    const schema = enforce.shape({
+      pair: enforce.tuple(enforce.isString(), enforce.isNumber()),
+    });
+    const failures = runSchemaPaths(
+      schema,
+      { pair: [42, 'x'] },
+      {
+        affected: ['pair.1'],
+      },
+    ).filter(result => !result.pass);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.path).toEqual(['pair', '1']);
+  });
+
+  it('resolves affected union members with whole-member matching', () => {
+    const schema = enforce.shape({
+      list: enforce.isArrayOf(enforce.isString(), enforce.isNumber()),
+    });
+    const failures = runSchemaPaths(
+      schema,
+      { list: ['ok', true] },
+      {
+        affected: ['list.1'],
+      },
+    ).filter(result => !result.pass);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.path).toEqual(['list', '1']);
+  });
+
+  it('runs affected record keys shadowed by earlier entries', () => {
+    const schema = enforce.shape({
+      dict: enforce.record(enforce.isNumber()),
+    });
+    const failures = runSchemaPaths(
+      schema,
+      { dict: { first: 'x', second: 'y' } },
+      {
+        affected: ['dict.second'],
+      },
+    ).filter(result => !result.pass);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.path).toEqual(['dict', 'second']);
+  });
+
+  it('evaluates affected record keys against the key rule', () => {
+    const schema = enforce.shape({
+      dict: enforce.record(
+        enforce.isString().matches(/^k/),
+        enforce.isNumber(),
+      ),
+    });
+    const failures = runSchemaPaths(
+      schema,
+      { dict: { zz: 1, bad: 2 } },
+      {
+        affected: ['dict.bad'],
+      },
+    ).filter(result => !result.pass);
+    expect(failures.map(result => (result.path ?? []).join('.'))).toEqual([
+      'dict.bad',
+    ]);
+  });
+});
+
+describe('runSchemaPaths dependency expansion', () => {
+  it('terminates and expands raw changes on cyclic dependencies', () => {
+    const schema = enforce.shape({
+      a: enforce.isString().dependsOn($ => $.b),
+      b: enforce.isString().dependsOn($ => $.a),
+    });
+    // Raw 'a' fans out to its dependent 'b' inside the run: both invalid
+    // members are reported, and the cyclic fixpoint still terminates.
+    const bad = { a: 42, b: 43 };
+    expect(
+      runSchemaPaths(schema, bad, { affected: ['a'] })
+        .filter(result => !result.pass)
+        .map(result => result.path),
+    ).toEqual([['a'], ['b']]);
+    const good = { a: 'x', b: 'y' };
+    expect(runSchemaPaths(schema, good, { affected: ['a'] })).toEqual(
+      runSchemaPaths(schema, good),
+    );
+  });
+
+  it('retains multi-segment root sources and attributes affected leaves', () => {
+    const schema = enforce.shape({
+      account: enforce.shape({ country: enforce.isString() }),
+      company: enforce.shape({
+        name: enforce.isString(),
+        taxId: enforce.isString().dependsOn($ => $.root.account.country),
+      }),
+    });
+    const badTax = {
+      account: { country: 'US' },
+      company: { name: 'x', taxId: 42 },
+    };
+    const taxFailures = runSchemaPaths(schema, badTax, {
+      affected: ['company.taxId'],
+    }).filter(result => !result.pass);
+    expect(taxFailures.map(result => result.path)).toEqual([
+      ['company', 'taxId'],
+    ]);
+    const badSource = {
+      account: { country: 42 },
+      company: { name: 'x', taxId: 'y' },
+    };
+    expect(
+      runSchemaPaths(schema, badSource, {
+        affected: ['company.taxId'],
+      }).every(result => result.pass),
+    ).toBe(true);
+  });
+});
+
+describe('runSchemaPaths standalone boundaries', () => {
+  const shapeWithMember = (thrown: unknown) =>
+    enforce.shape({
+      a: enforce.isString(),
+      z: foreignMember(() => {
+        throw thrown;
+      }),
+    });
+
+  it('treats a same-copy EnforceSchemaError member as a boundary', () => {
+    const schema = shapeWithMember(
+      new EnforceSchemaError('EnforceSchemaError: orphaned source'),
+    );
+    const results = runSchemaPaths(
+      schema,
+      { a: 42, z: 'ok' },
+      {
+        affected: ['a', 'z'],
+      },
+    );
+    expect(
+      results.filter(result => !result.pass).map(result => result.path),
+    ).toEqual([['a']]);
+  });
+
+  it('treats a cross-copy EnforceSchemaError (name fallback) as a boundary', () => {
+    const crossCopy = Object.assign(new Error('orphaned source'), {
+      name: 'EnforceSchemaError',
+    });
+    const schema = shapeWithMember(crossCopy);
+    const results = runSchemaPaths(
+      schema,
+      { a: 42, z: 'ok' },
+      {
+        affected: ['a', 'z'],
+      },
+    );
+    expect(
+      results.filter(result => !result.pass).map(result => result.path),
+    ).toEqual([['a']]);
+  });
+
+  it('lets a non-EnforceSchemaError member failure propagate', () => {
+    const schema = shapeWithMember(new TypeError('member bug'));
+    expect(() =>
+      runSchemaPaths(schema, { a: 42, z: 'ok' }, { affected: ['a', 'z'] }),
+    ).toThrowError(/member bug/);
+  });
+});
+
+describe('parseAffectedFieldName canonical parser', () => {
+  it('parses dotted and bracket spellings to one SchemaPath', () => {
+    const expected = [
+      { type: 'property', key: 'travelers' },
+      { type: 'item', binding: '1' },
+      { type: 'property', key: 'country' },
+    ];
+    expect(parseAffectedFieldName('travelers.1.country')).toEqual(expected);
+    expect(parseAffectedFieldName('travelers[1].country')).toEqual(expected);
+  });
+
+  it('coerces numeric segments to item segments and back to numbers', () => {
+    // Unified behavior: the canonical parser emits item segments for
+    // numeric parts (suite-side vocabulary), and the selective engine
+    // reads those same bindings back as numeric indices.
+    const [travelers, index, country] = parseAffectedFieldName(
+      'travelers[1].country',
+    );
+    expect(travelers).toEqual({ type: 'property', key: 'travelers' });
+    expect(index?.type).toBe('item');
+    expect(country).toEqual({ type: 'property', key: 'country' });
+    const failures = runSchemaPaths(
+      enforce.shape({
+        travelers: enforce.isArrayOf(
+          enforce.shape({ country: enforce.isString() }),
+        ),
+      }),
+      { travelers: [{ country: 'US' }, { country: 42 }] },
+      { affected: ['travelers[1].country'] },
+    ).filter(result => !result.pass);
+    expect(failures.map(result => result.path)).toEqual([
+      ['travelers', '1', 'country'],
+    ]);
+  });
+});
+
+describe('runSchemaPaths single expansion', () => {
+  const chain = () =>
+    enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn($ => $.a),
+      c: enforce.isString().dependsOn($ => $.b),
+    });
+
+  it('fans raw changed fields out to direct dependents without caller pre-expansion', () => {
+    const failures = runSchemaPaths(
+      chain(),
+      { a: 42, b: 43, c: 44 },
+      {
+        affected: ['a'],
+      },
+    ).filter(result => !result.pass);
+    expect(failures.map(result => result.path)).toEqual([['a'], ['b']]);
+  });
+
+  it('stays non-transitive: a second fan-out would pull c', () => {
+    const failures = runSchemaPaths(
+      chain(),
+      { a: 42, b: 'ok', c: 44 },
+      {
+        affected: ['a'],
+      },
+    ).filter(result => !result.pass);
+    expect(failures.map(result => result.path)).toEqual([['a']]);
+    expect(failures.some(result => (result.path ?? []).join('.') === 'c')).toBe(
+      false,
+    );
+  });
+
+  it('accepts one pre-resolved plan without expanding it again', () => {
+    const schema = chain();
+    const resolved = resolveAffectedPaths(schema, ['a']);
+    expect(resolved).toEqual(['a', 'b']);
+
+    const failures = runSchemaPaths(
+      schema,
+      { a: 42, b: 43, c: 44 },
+      { resolvedAffected: resolved },
+    ).filter(result => !result.pass);
+
+    expect(failures.map(result => result.path)).toEqual([['a'], ['b']]);
+  });
+
+  it('fans a raw array-parent change out from run data', () => {
+    const schema = enforce.shape({
+      region: enforce.isString(),
+      travelers: enforce.isArrayOf(
+        enforce.shape({
+          country: enforce.isString(),
+          tax: enforce.isString().dependsOn($ => $.root.region),
+        }),
+      ),
+    });
+    // Only the second member is invalid: without data fan-out the raw
+    // 'region' change (itself valid) would report nothing.
+    const data = {
+      region: 'US',
+      travelers: [
+        { country: 'US', tax: 'ok' },
+        { country: 'IL', tax: 42 },
+      ],
+    };
+    const failures = runSchemaPaths(schema, data, {
+      affected: ['region'],
+    }).filter(result => !result.pass);
+    expect(failures.map(result => result.path)).toEqual([
+      ['travelers', '1', 'tax'],
+    ]);
+  });
+});
+
+describe('selectiveRun projection internals', () => {
+  it('records keep the full rule under projection (key-rule parity)', () => {
+    // Narrowing through record(value) would drop a two-arg record's key
+    // rule (n4s exposes only the value rule in the item slot), so the
+    // projection keeps the whole record rule. Suffixes alone cannot tell
+    // numeric record keys from indices — the container-kind marker routes
+    // here instead of the array rebuild, which would reject record data.
+    const schema = enforce.shape({
+      dictionary: enforce.record(
+        enforce.isString().longerThan(3),
+        enforce.shape({
+          country: enforce.isString(),
+          state: enforce.isString().dependsOn($ => $.country),
+        }),
+      ),
+    });
+    const projected = buildProjectedSchema(schema, ['dictionary.1.country']);
+    expect(projected).not.toBeNull();
+    if (projected === null) {
+      throw new Error('projected schema must compose');
+    }
+    type DictData = Parameters<typeof schema.parse>[0];
+    const parse = (projected as unknown as ExecutableFragment<DictData>).parse;
+    expect(() =>
+      parse({ dictionary: { abcd: { country: 'CA', state: 'abc' } } }),
+    ).not.toThrow();
+    // Key validation matches the full run exactly — nothing was dropped
+    // (keys validate before values, so the short key throws either way).
+    expect(() =>
+      parse({ dictionary: { '1': { country: 'CA', state: 'abc' } } }),
+    ).toThrow();
+    expect(() =>
+      schema.parse({ dictionary: { '1': { country: 'CA', state: 'abc' } } }),
+    ).toThrow();
+  });
+});
+
+describe('filterSchemaResultsToAffected post-filter', () => {
+  // Nested skip names are unreachable through the typed focus API, so the
+  // post-filter contract is pinned directly: exact skips drop, parent skips
+  // do not (runtime parity), parent matching keeps in both directions, root
+  // failures stay, numeric coercions ('1' vs 1) compare equal, and dotted
+  // record keys keep the historical keep-behavior (dedupe collisions for
+  // them are handled by structured result keys).
+  const failure = (
+    path: readonly string[],
+    message = 'invalid',
+  ): SelectiveSchemaResult => ({ pass: false, path, message });
+  const data = {};
+  const live = (results: SelectiveSchemaResult[]): boolean =>
+    results.some(result => !result.pass);
+
+  it('drops exact skips and keeps parent-skipped synthesis', () => {
+    // Exact skip drops (an empty keep-set falls back to a pass entry).
+    expect(
+      live(
+        filterSchemaResultsToAffected(
+          [failure(['profile', 'state'])],
+          ['profile'],
+          data,
+          ['profile.state'],
+        ),
+      ),
+    ).toBe(false);
+
+    // Parent skip does not suppress nested synthesis (runtime parity):
+    // the failure is affected, and only an exact skip drops it.
+    expect(
+      live(
+        filterSchemaResultsToAffected(
+          [failure(['profile', 'state'])],
+          ['profile.state'],
+          data,
+          ['profile'],
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('compares numeric coercions equal and keeps dotted record keys', () => {
+    // Numeric coercions compare equal on both sides.
+    expect(
+      live(
+        filterSchemaResultsToAffected(
+          [failure(['dictionary', '1', 'state'])],
+          ['dictionary.1.country', 'dictionary.1.state'],
+          data,
+          null,
+        ),
+      ),
+    ).toBe(true);
+
+    // Dotted record keys keep the historical keep-behavior.
+    expect(
+      live(
+        filterSchemaResultsToAffected(
+          [failure(['dictionary', 'a.b', 'state'])],
+          ['dictionary.a'],
+          data,
+          null,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps pathless failures and honors dotted skip spellings', () => {
+    // Pathless failures read as global: kept, never skipped.
+    expect(
+      live(filterSchemaResultsToAffected([failure([])], ['a'], data, ['a'])),
+    ).toBe(true);
+
+    // Bracket-spelled skips do not suppress dotted synthesis (runtime
+    // parity): the runtime matches skip entries against test names exactly,
+    // so skip('items[0]') leaves a synthesized 'items.0' failure in
+    // place — exactly what the full run reports, where nested skips are
+    // no-ops in omit().
+    expect(
+      live(
+        filterSchemaResultsToAffected(
+          [failure(['items', '0'])],
+          ['items.0'],
+          data,
+          ['items[0]'],
+        ),
+      ),
+    ).toBe(true);
+
+    // The exact dotted spelling still drops.
+    expect(
+      live(
+        filterSchemaResultsToAffected(
+          [failure(['items', '0'])],
+          ['items.0'],
+          data,
+          ['items.0'],
+        ),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('mergeSupplementalResults merger', () => {
+  it('keeps same-message failures on colliding dotted paths', () => {
+    // A literal dotted record key and a nested path join identically —
+    // structured keys must not collapse them into one failure.
+    const main: SelectiveSchemaResult[] = [
+      { pass: false, path: ['dictionary', 'a', 'b', 'state'], message: 'x' },
+    ];
+    const extra: SelectiveSchemaResult[] = [
+      { pass: false, path: ['dictionary', 'a.b', 'state'], message: 'x' },
+    ];
+    expect(mergeSupplementalResults(main, extra)).toHaveLength(2);
+  });
+
+  it('folds passing supplement types instead of appending them', () => {
+    const main: SelectiveSchemaResult[] = [
+      { pass: true, type: { rows: ['42'] } },
+    ];
+    const extra: SelectiveSchemaResult[] = [
+      { pass: true, path: ['rows', '0'], type: 42 },
+    ];
+    const merged = mergeSupplementalResults(main, extra);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.type).toEqual({ rows: [42] });
+  });
+});
+
+/**
+ * Executable view of a projected fragment. The generic schema type cannot
+ * name its own data type, so each test pins it from its own schema instead
+ * of reaching for an untyped escape hatch.
+ */
+type ExecutableFragment<Data> = {
+  parse: (value: Data) => unknown;
+};

--- a/packages/n4s/src/schema/dependencyResolver.ts
+++ b/packages/n4s/src/schema/dependencyResolver.ts
@@ -1,0 +1,745 @@
+import { hasOwnProperty, isNullish, isObject } from 'vest-utils';
+
+import { EnforceSchemaError } from '../errors/EnforceSchemaError';
+import type { RuleInstance } from '../utils/RuleInstance';
+import type { ItemSegment, PropertySegment, SchemaPath } from './SchemaPath';
+import { propertySegment } from './SchemaPath';
+import { isRuleNode } from './ruleNode';
+import {
+  COMPOSITION_CHILDREN,
+  ITEM_SCHEMA,
+  RESOLVED_RELATIONSHIPS,
+  UNRESOLVED_DEPS,
+} from './schemaSlots';
+import type { InternalRelationship } from './SchemaRelationship';
+import {
+  createScopeProxy,
+  getRefPath,
+  isRootRef,
+  normalizeResolverResult,
+} from './scopeProxy';
+import type { Scope } from './scopeProxy';
+
+export type UnresolvedDep = {
+  resolver: (scope: Scope) => unknown;
+};
+
+/**
+ * Collects unresolved deps from a field RuleInstance.
+ */
+function getUnresolvedDeps(
+  rule: RuleInstance<unknown, unknown[]>,
+): UnresolvedDep[] {
+  return (
+    ((rule as unknown as Record<symbol, unknown>)[
+      UNRESOLVED_DEPS
+    ] as UnresolvedDep[]) || []
+  );
+}
+
+/**
+ * Resolves inline deps for a shape's own fields.
+ * Returns relationships where source → target.
+ */
+// eslint-disable-next-line complexity
+export function resolveInlineDeps(
+  shape: Record<string, RuleInstance<unknown, unknown[]>>,
+  scopePath: SchemaPath,
+  rootShape: Record<PropertyKey, unknown>,
+): InternalRelationship[] {
+  const relationships: InternalRelationship[] = [];
+  const scopeProxy = createScopeProxy(scopePath);
+
+  for (const fieldKey of Object.keys(shape)) {
+    const fieldRule = shape[fieldKey];
+    if (!fieldRule) continue;
+
+    const unresolved = getUnresolvedDeps(
+      fieldRule as unknown as RuleInstance<unknown, unknown[]>,
+    );
+    if (!unresolved || unresolved.length === 0) continue;
+
+    const targetPath: SchemaPath = [...scopePath, propertySegment(fieldKey)];
+
+    for (const dep of unresolved) {
+      if (typeof dep.resolver !== 'function') {
+        throw new EnforceSchemaError(
+          `EnforceSchemaError: "${String(fieldKey)}" dependsOn expects a function, got ${typeof dep.resolver}`,
+        );
+      }
+      let result: unknown;
+      try {
+        result = dep.resolver(scopeProxy);
+      } catch (e) {
+        // Resolver threw — treat as error
+        throw new EnforceSchemaError(
+          `Failed to resolve dependency for "${String(fieldKey)}": ${(e as Error).message}`,
+        );
+      }
+
+      if (result === undefined) {
+        throw new EnforceSchemaError(
+          `EnforceSchemaError: "${String(fieldKey)}" dependsOn resolver returned undefined. Did you forget to return the dependency (e.g., $ => $.other)? Return an explicit empty array [] for intentionally zero dependencies.`,
+        );
+      }
+      const refs = normalizeResolverResult(result);
+      // An explicit empty array is the intentional zero-dependency form.
+      if (
+        refs.length === 0 &&
+        !(Array.isArray(result) && result.length === 0)
+      ) {
+        throw new EnforceSchemaError(
+          `EnforceSchemaError: "${String(fieldKey)}" dependsOn resolver must return a dependency ref (e.g., $ => $.other) or array of refs, got ${typeof result}`,
+        );
+      }
+      if (
+        Array.isArray(result) &&
+        refs.length !== (result as unknown[]).length
+      ) {
+        throw new EnforceSchemaError(
+          `EnforceSchemaError: "${String(fieldKey)}" dependsOn resolver array contains non-dependency values`,
+        );
+      }
+
+      for (const ref of refs) {
+        let sourcePath: SchemaPath = getRefPath(ref);
+        const isRoot = isRootRef(ref);
+
+        // Self-dependency normalization: bare $.self means the field itself,
+        // e.g., enforce.isString().dependsOn($ => $.self) inside field "a"
+        // resolves to the owning field (filtered as a no-op below). A real
+        // sibling field named "self" takes precedence: when the current scope
+        // declares its own "self" field, $.self references that sibling.
+        if (
+          sourcePath.length > 0 &&
+          sourcePath[sourcePath.length - 1].type === 'property' &&
+          String(
+            (sourcePath[sourcePath.length - 1] as unknown as PropertySegment)
+              .key,
+          ) === 'self'
+        ) {
+          // Single self: $.self => owning field (unless shadowed by sibling)
+          if (
+            sourcePath.length === scopePath.length + 1 &&
+            isPathPrefixedBy(sourcePath.slice(0, -1), scopePath) &&
+            !hasOwnProperty(shape, 'self')
+          ) {
+            sourcePath = targetPath;
+          } else {
+            // $.self.foo etc., or sibling "self" — validated as a normal ref
+          }
+        }
+
+        // Self-dependency is no-op: deduplicate / filter
+        // If a field depends on itself, it creates no useful edge — skip silently.
+        // Documented decision: self-dependency is filtered, not thrown.
+        if (pathsEqual(sourcePath, targetPath)) {
+          continue;
+        }
+
+        // Validate existence — skip for rooted refs at inner creation time
+        // (they will be validated at outermost mount if needed)
+        if (!isRoot) {
+          validateSourceExists(
+            sourcePath,
+            rootShape,
+            String(fieldKey),
+            scopePath,
+          );
+        }
+
+        const rel: InternalRelationship = isRoot
+          ? {
+              source: sourcePath,
+              target: targetPath,
+              effect: 'invalidate',
+              __isRootSource: true,
+            }
+          : { source: sourcePath, target: targetPath, effect: 'invalidate' };
+
+        relationships.push(rel);
+      }
+    }
+  }
+
+  // Composition stays lenient: a reusable fragment cannot know its final root
+  // until mounted, so dangling $.root edges are NOT rejected here. They are
+  // validated at finalization — standalone n4s runs via
+  // assertRuleRootedPathsValid (called from the chain test/run/parse/validate
+  // path) and Vest suites via the createSuite() finalizer.
+
+  return relationships;
+}
+
+/**
+ * Finalization boundary for standalone n4s schemas: validates the rooted
+ * endpoints of a rule's own stored relationships against the rule's own root
+ * shape. Called from the chain test/run/parse/validate path so the same
+ * schema is valid or invalid regardless of whether it passes through Vest.
+ * Rules without rooted relationships (the common case) return immediately.
+ */
+export function assertRuleRootedPathsValid(rule: unknown): void {
+  if (!isRuleNode(rule)) return;
+  const rels = checkableRootedRels(rule);
+  if (!rels) return;
+  const rootShape = rootShapeOf(rule);
+  if (!rootShape) return;
+  validateRootedRels(rels, rootShape);
+}
+
+function checkableRootedRels(rule: object): InternalRelationship[] | null {
+  const rels = (rule as Record<symbol, unknown>)[RESOLVED_RELATIONSHIPS];
+  if (!Array.isArray(rels)) return null;
+  const checkable = (rels as unknown[]).filter(isCheckableRel);
+  const hasRooted = checkable.some(
+    rel => rel.__isRootSource === true || rel.__isRootTarget === true,
+  );
+  return hasRooted ? checkable : null;
+}
+
+function rootShapeOf(rule: object): Record<PropertyKey, unknown> | null {
+  const record = rule as Record<PropertyKey, unknown>;
+  const rootShape = record.__schema;
+  if (rootShape && typeof rootShape === 'object') {
+    return rootShape as Record<PropertyKey, unknown>;
+  }
+  const compositionChildren = record[COMPOSITION_CHILDREN];
+  return Array.isArray(compositionChildren)
+    ? mergedChildShapes(compositionChildren)
+    : null;
+}
+
+function validateRootedRels(
+  rels: InternalRelationship[],
+  rootShape: Record<PropertyKey, unknown>,
+): void {
+  for (const rel of rels) {
+    if (rel.__isRootSource === true) {
+      validateRootedPath(rel.source, rootShape, targetFieldName(rel.target));
+    }
+    if (rel.__isRootTarget === true) {
+      validateRootedPath(rel.target, rootShape, targetFieldName(rel.source));
+    }
+  }
+}
+
+function isCheckableRel(rel: unknown): rel is InternalRelationship {
+  return (
+    !!rel &&
+    typeof rel === 'object' &&
+    Array.isArray((rel as InternalRelationship).source) &&
+    Array.isArray((rel as InternalRelationship).target)
+  );
+}
+
+function targetFieldName(path: SchemaPath | undefined): string {
+  if (Array.isArray(path) && path.length) {
+    const last = path[path.length - 1];
+    if (last && last.type === 'property') {
+      return String((last as unknown as PropertySegment).key);
+    }
+  }
+  return 'unknown';
+}
+
+/**
+ * Walks a rooted path against the current root shape. Same boundary as the
+ * suite finalizer: missing keys (including missing descendants of scalar
+ * fields) throw EnforceSchemaError.
+ */
+function validateRootedPath(
+  path: SchemaPath,
+  rootShape: Record<PropertyKey, unknown>,
+  fieldForMsg: string,
+): void {
+  const unknownField = dottedSchemaPath(path);
+  let current: unknown = rootShape;
+  for (let i = 0; i < path.length; i++) {
+    current = checkRootedSegment(
+      path[i],
+      current,
+      i === path.length - 1,
+      fieldForMsg,
+      unknownField,
+    );
+  }
+}
+
+function checkRootedSegment(
+  seg: SchemaPath[number] | undefined,
+  current: unknown,
+  isLast: boolean,
+  fieldForMsg: string,
+  unknownField: string,
+): unknown {
+  if (!seg || seg.type !== 'property') return current;
+  const key = String((seg as unknown as PropertySegment).key);
+  assertRootKeyExists(current, key, fieldForMsg, unknownField);
+  if (isLast) return (current as Record<PropertyKey, unknown>)[key];
+  return childShape((current as Record<PropertyKey, unknown>)[key]);
+}
+
+/**
+ * Canonical dotted form of a schema path for error messages (property keys
+ * by name, item segments by binding). Unknown-field errors always quote
+ * this full path, never the leaf alone, so nested misses like
+ * `$.root.account.missing` read as "account.missing".
+ */
+function dottedSchemaPath(path: SchemaPath): string {
+  return path
+    .map(seg =>
+      seg.type === 'property' ? String(seg.key) : String(seg.binding),
+    )
+    .join('.');
+}
+
+function assertRootKeyExists(
+  current: unknown,
+  key: string,
+  fieldForMsg: string,
+  unknownField: string,
+): void {
+  if (
+    !current ||
+    typeof current !== 'object' ||
+    !hasOwnProperty(current, key)
+  ) {
+    throw new EnforceSchemaError(
+      `EnforceSchemaError: "${fieldForMsg}" depends on unknown field "${unknownField}"`,
+    );
+  }
+}
+
+function childShape(rule: unknown): unknown {
+  if (!isRuleNode(rule)) return {};
+  const candidate = rule as {
+    __schema?: Record<PropertyKey, unknown>;
+    [key: symbol]: unknown;
+  };
+  if (candidate.__schema) return candidate.__schema;
+  const compositionChildren = candidate[COMPOSITION_CHILDREN];
+  if (Array.isArray(compositionChildren)) {
+    return mergedChildShapes(compositionChildren);
+  }
+  return itemChildShape(candidate[ITEM_SCHEMA]);
+}
+
+function itemChildShape(item: unknown): unknown {
+  if (!isRuleNode(item)) return {};
+  if (Array.isArray(item)) return mergedItemShape(item);
+  return childShape(item);
+}
+
+function mergedChildShapes(children: unknown[]): Record<PropertyKey, unknown> {
+  const merged: Record<PropertyKey, unknown> = {};
+  for (const child of children) {
+    const shape = childShape(child);
+    if (isObject(shape)) Object.assign(merged, shape);
+  }
+  return merged;
+}
+
+/**
+ * Merges the __schemas of several item rules (tuple elements or multi-rule
+ * array members) so dotted-path validation can traverse the union. Members
+ * without a __schema contribute nothing.
+ */
+function mergedItemShape(itemSchemas: unknown[]): Record<PropertyKey, unknown> {
+  const merged: Record<PropertyKey, unknown> = {};
+  for (const entry of itemSchemas) {
+    Object.assign(merged, itemEntryShape(entry));
+  }
+  return merged;
+}
+
+function itemEntryShape(entry: unknown): Record<PropertyKey, unknown> {
+  const inner = childShape(entry);
+  return isObject(inner) ? recordOf(inner) : {};
+}
+
+// eslint-disable-next-line complexity
+function validateSourceExists(
+  sourcePath: SchemaPath,
+  rootShape: Record<PropertyKey, unknown>,
+  targetField: string,
+  scopePath: SchemaPath,
+): void {
+  let current: Record<PropertyKey, unknown> = rootShape as unknown as Record<
+    PropertyKey,
+    unknown
+  >;
+  // Walk to scopePath to find the containing shape
+  for (const seg of scopePath) {
+    if (seg.type === 'property') {
+      const next = (current as Record<PropertyKey, unknown>)[
+        seg.key as PropertyKey
+      ];
+      if (isRuleNode(next) && hasOwnProperty(next, '__schema')) {
+        current = (
+          next as unknown as { __schema: Record<PropertyKey, unknown> }
+        ).__schema;
+      } else if (isRuleNode(next)) {
+        current = next as Record<PropertyKey, unknown>;
+      } else {
+        return;
+      }
+    } else if (seg.type === 'item') {
+      // Descend into the item shape so leaf checks run against the member
+      // shape. (No writer ever produced the legacy `__itemSchema` string
+      // slot — the graph lives in the ITEM_SCHEMA symbol slot.)
+      const itemSchema = (current as unknown as Record<symbol, unknown>)[
+        ITEM_SCHEMA
+      ];
+      if (isRuleNode(itemSchema)) {
+        current = (
+          Array.isArray(itemSchema)
+            ? mergedItemShape(itemSchema)
+            : ((itemSchema as { __schema?: unknown }).__schema ?? {})
+        ) as Record<PropertyKey, unknown>;
+      }
+    }
+  }
+
+  const isRooted = !isPathPrefixedBy(sourcePath, scopePath);
+
+  // Quoted in every unknown-field error below: the full dotted source path,
+  // never the leaf alone.
+  const unknownField = dottedSchemaPath(sourcePath);
+
+  // Scalar-descendant check: walk sourcePath intermediates and ensure each
+  // prefix before the next property is a shape-like (has __schema), not a scalar.
+  // For path [obj, leaf] where obj is string, the field `obj` scalar has a child `leaf` → error.
+  // We check from the effective root of sourcePath.
+  const sourceRoot: Record<PropertyKey, unknown> = (
+    isRooted ? rootShape : current
+  ) as Record<PropertyKey, unknown>;
+  let walkShape: Record<PropertyKey, unknown> | null =
+    sourceRoot as unknown as Record<PropertyKey, unknown> | null;
+  // For non-rooted paths, strip scopePath prefix to get relative path within current scope
+  const relativePath: SchemaPath = isRooted
+    ? sourcePath
+    : sourcePath.slice(scopePath.length);
+
+  for (let i = 0; i < relativePath.length - 1; i++) {
+    const seg = relativePath[i];
+    if (seg.type !== 'property') continue;
+    const rule = (walkShape as Record<PropertyKey, unknown>)?.[
+      seg.key as string
+    ];
+    if (!rule) continue;
+    const isShapeLike =
+      isRuleNode(rule) &&
+      (hasOwnProperty(rule, '__schema') ||
+        hasOwnProperty(rule, RESOLVED_RELATIONSHIPS) ||
+        hasOwnProperty(rule, ITEM_SCHEMA));
+    if (!isShapeLike) {
+      // This segment is scalar but has a descendant — invalid
+      const descendant = String(
+        (relativePath[relativePath.length - 1] as unknown as PropertySegment)
+          .key,
+      );
+      const scalarKey = String(seg.key);
+      throw new EnforceSchemaError(
+        `EnforceSchemaError: "${targetField}" depends on "${unknownField}" but "${scalarKey}" is a scalar field and has no child "${descendant}"`,
+      );
+    }
+    // Descend into shape for next iteration
+    if (
+      (rule as unknown as { __schema?: Record<PropertyKey, unknown> }).__schema
+    ) {
+      walkShape = (
+        rule as unknown as { __schema: Record<PropertyKey, unknown> }
+      ).__schema;
+    } else if ((rule as unknown as Record<symbol, unknown>)[ITEM_SCHEMA]) {
+      const itemSchema = (rule as unknown as Record<symbol, unknown>)[
+        ITEM_SCHEMA
+      ];
+      walkShape = Array.isArray(itemSchema)
+        ? mergedItemShape(itemSchema)
+        : ((
+            itemSchema as unknown as {
+              __schema?: Record<PropertyKey, unknown>;
+            }
+          )?.__schema ?? (itemSchema as Record<PropertyKey, unknown>));
+    } else {
+      walkShape = null;
+    }
+  }
+
+  const shapeToCheck: Record<PropertyKey, unknown> = isRooted
+    ? rootShape
+    : current;
+  // For scalar-descendant with chained path, leaf already handled above;
+  // for simple path, check leaf existence.
+  // Resolve the immediate parent shape for leaf check
+  let parentShape: Record<PropertyKey, unknown> | null =
+    sourceRoot as unknown as Record<PropertyKey, unknown> | null;
+  if (relativePath.length > 1) {
+    // Walk to parent of leaf
+    for (let i = 0; i < relativePath.length - 1; i++) {
+      const seg = relativePath[i];
+      if (seg.type !== 'property') continue;
+      const key = String((seg as unknown as PropertySegment).key);
+      if (!parentShape || typeof parentShape !== 'object') {
+        throw new EnforceSchemaError(
+          `EnforceSchemaError: "${targetField}" depends on unknown field "${unknownField}"`,
+        );
+      }
+      const rule = (parentShape as Record<PropertyKey, unknown>)[key] as
+        | (Record<PropertyKey, unknown> & {
+            __schema?: Record<PropertyKey, unknown>;
+            [key: symbol]: unknown;
+          })
+        | null
+        | undefined;
+      if (rule === undefined || rule === null) {
+        const suggestion = findClosestKey(key, Object.keys(parentShape));
+        let msg = `EnforceSchemaError: "${targetField}" depends on unknown field "${unknownField}"`;
+        if (suggestion) {
+          msg += `. Did you mean "${suggestion}"?`;
+        }
+        throw new EnforceSchemaError(msg);
+      }
+      if (
+        (rule as unknown as { __schema?: Record<PropertyKey, unknown> })
+          ?.__schema
+      )
+        parentShape = (
+          rule as unknown as { __schema: Record<PropertyKey, unknown> }
+        ).__schema;
+      else if ((rule as unknown as Record<symbol, unknown>)[ITEM_SCHEMA]) {
+        const itemSchema = (rule as unknown as Record<symbol, unknown>)[
+          ITEM_SCHEMA
+        ];
+        parentShape = Array.isArray(itemSchema)
+          ? mergedItemShape(itemSchema)
+          : ((
+              itemSchema as unknown as {
+                __schema?: Record<PropertyKey, unknown>;
+              }
+            )?.__schema ?? parentShape);
+      } else parentShape = null;
+    }
+  } else {
+    parentShape = shapeToCheck as Record<PropertyKey, unknown> | null;
+  }
+  const keyToCheck = sourcePath[sourcePath.length - 1];
+  if (!keyToCheck || keyToCheck.type !== 'property') return;
+
+  if (parentShape === null) {
+    throw new EnforceSchemaError(
+      `EnforceSchemaError: "${targetField}" depends on unknown field "${unknownField}"`,
+    );
+  }
+  const checkShape = parentShape;
+  const exists = hasOwnProperty(checkShape, keyToCheck.key as string);
+  if (!exists) {
+    const suggestion = findClosestKey(
+      String(keyToCheck.key),
+      Object.keys(checkShape),
+    );
+    let msg = `EnforceSchemaError: "${targetField}" depends on unknown field "${unknownField}"`;
+    if (suggestion) {
+      msg += `. Did you mean "${suggestion}"?`;
+    }
+    throw new EnforceSchemaError(msg);
+  }
+}
+
+// eslint-disable-next-line complexity
+function pathsEqual(a: SchemaPath, b: SchemaPath): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].type !== b[i].type) return false;
+    if (
+      a[i].type === 'property' &&
+      (a[i] as unknown as PropertySegment).key !==
+        (b[i] as unknown as PropertySegment).key
+    )
+      return false;
+    if (
+      a[i].type === 'item' &&
+      (a[i] as unknown as ItemSegment).binding !==
+        (b[i] as unknown as ItemSegment).binding
+    )
+      return false;
+  }
+  return true;
+}
+
+// eslint-disable-next-line complexity
+function isPathPrefixedBy(path: SchemaPath, prefix: SchemaPath): boolean {
+  if (prefix.length === 0) return true;
+  if (path.length < prefix.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (path[i].type !== prefix[i].type) return false;
+    if (
+      path[i].type === 'property' &&
+      (path[i] as unknown as PropertySegment).key !==
+        (prefix[i] as unknown as PropertySegment).key
+    )
+      return false;
+  }
+  return true;
+}
+
+function findClosestKey(input: string, keys: string[]): string | null {
+  let best: string | null = null;
+  let bestDist = Infinity;
+  for (const key of keys) {
+    const dist = levenshtein(input, key);
+    if (dist < bestDist && dist <= 2) {
+      bestDist = dist;
+      best = key;
+    }
+  }
+  return best;
+}
+
+// eslint-disable-next-line complexity
+function levenshtein(a: string, b: string): number {
+  const matrix: number[][] = [];
+  for (let i = 0; i <= b.length; i++) matrix[i] = [i];
+  for (let j = 0; j <= a.length; j++) matrix[0][j] = j;
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1))
+        matrix[i][j] = matrix[i - 1][j - 1];
+      else
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j - 1] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j] + 1,
+        );
+    }
+  }
+  return matrix[b.length][a.length];
+}
+
+function recordOf(value: unknown): Record<PropertyKey, unknown> {
+  return value as unknown as Record<PropertyKey, unknown>;
+}
+
+function nestedShapeOf(rule: unknown): Record<PropertyKey, unknown> {
+  const nested = childShape(rule);
+  return isObject(nested) ? recordOf(nested) : {};
+}
+
+function lastPropertyKeyOf(path: SchemaPath): string {
+  const last: SchemaPath[number] | undefined = path[path.length - 1];
+  if (last !== undefined && last.type === 'property') return String(last.key);
+  return 'unknown';
+}
+
+/**
+ * Suite-creation finalizer for deferred (`$.root`) relationship endpoints.
+ * Composition stays lenient so focused fragments keep composing; this
+ * boundary validates the rooted endpoints of the whole mounted graph
+ * against the final root shape and throws EnforceSchemaError on unknown
+ * fields. Unexpected traversal failures propagate instead of being treated
+ * as a valid graph.
+ */
+export function assertSchemaRootPathsValid(schema: unknown): void {
+  if (!isRuleNode(schema)) return;
+  assertSchemaRootPathsValidInner(schema);
+}
+
+// eslint-disable-next-line complexity -- moved suite finalizer, branchy by nature
+function assertSchemaRootPathsValidInner(schema: unknown): void {
+  const relationships: InternalRelationship[] = [];
+  const seen = new WeakSet<object>();
+  // eslint-disable-next-line complexity -- moved suite finalizer, branchy by nature
+  const collect = (node: unknown): void => {
+    if (!isRuleNode(node) || seen.has(node)) return;
+    seen.add(node);
+    const rels = recordOf(node)[RESOLVED_RELATIONSHIPS] as
+      | InternalRelationship[]
+      | undefined;
+    if (Array.isArray(rels) && rels.length) relationships.push(...rels);
+    const inner: unknown = recordOf(node).__schema;
+    if (!isNullish(inner) && typeof inner === 'object') {
+      if (Array.isArray(inner)) {
+        for (const v of inner as unknown[]) collect(v);
+      } else {
+        for (const v of Object.values(recordOf(inner))) collect(v);
+        collect(inner);
+      }
+    }
+    const item: unknown = recordOf(node)[ITEM_SCHEMA];
+    if (item) collect(item);
+    // Plain shape object (no __schema/RESOLVED wrapper)
+    if (
+      !recordOf(node).__schema &&
+      !recordOf(node)[RESOLVED_RELATIONSHIPS] &&
+      !recordOf(node)[ITEM_SCHEMA]
+    ) {
+      // Check if this looks like a plain shape record
+      const vals = Object.values(recordOf(node));
+      if (
+        vals.length &&
+        vals.some(
+          (v: unknown): boolean =>
+            isRuleNode(v) && recordOf(v).__schema !== undefined,
+        )
+      ) {
+        for (const v of vals) collect(v);
+      } else if (
+        vals.length &&
+        vals.some(
+          (v: unknown): boolean =>
+            isRuleNode(v) && recordOf(v)[RESOLVED_RELATIONSHIPS] !== undefined,
+        )
+      ) {
+        for (const v of vals) collect(v);
+      }
+    }
+  };
+  collect(schema);
+  // Also collect from schema.__schema directly if schema is a RuleInstance wrapping a plain shape
+  const schemaInner: unknown = recordOf(schema).__schema;
+  if (schemaInner) collect(schemaInner);
+  if (!relationships.length) return;
+  // Also consider top-level keys from describe dependencies target
+  for (const rel of relationships) {
+    const isRootSource = rel.__isRootSource === true;
+    const isRootTarget = rel.__isRootTarget === true;
+    if (!isRootSource && !isRootTarget) continue;
+    // For root source, check full path exists in final schema (not just top-level)
+    // to catch missing descendant like $.root.account.missing
+
+    const checkPath = (path: SchemaPath, fieldForMsg: string): void => {
+      const rootShape: unknown = recordOf(schema).__schema;
+      const unknownField = dottedSchemaPath(path);
+      let current: Record<PropertyKey, unknown> = isObject(rootShape)
+        ? recordOf(rootShape)
+        : {};
+      path.forEach((seg: SchemaPath[number], i: number): void => {
+        if (seg.type !== 'property') return;
+        const key = String(seg.key);
+        if (!hasOwnProperty(current, key)) {
+          throw new EnforceSchemaError(
+            `EnforceSchemaError: "${fieldForMsg}" depends on unknown field "${unknownField}"`,
+          );
+        }
+        const rule: unknown = current[key];
+        if (i < path.length - 1) {
+          current = nestedShapeOf(rule);
+        }
+      });
+    };
+    const targetField =
+      Array.isArray(rel.target) && rel.target.length
+        ? lastPropertyKeyOf(rel.target)
+        : 'unknown';
+    const sourceField =
+      Array.isArray(rel.source) && rel.source.length
+        ? lastPropertyKeyOf(rel.source)
+        : 'unknown';
+    if (isRootSource) {
+      checkPath(rel.source, targetField);
+    }
+    if (isRootTarget) {
+      checkPath(rel.target, sourceField);
+    }
+  }
+}

--- a/packages/n4s/src/schema/dependencyResolver.ts
+++ b/packages/n4s/src/schema/dependencyResolver.ts
@@ -708,7 +708,7 @@ function assertSchemaRootPathsValidInner(schema: unknown): void {
     // to catch missing descendant like $.root.account.missing
 
     const checkPath = (path: SchemaPath, fieldForMsg: string): void => {
-      const rootShape: unknown = recordOf(schema).__schema;
+      const rootShape: unknown = rootShapeOf(schema as object);
       const unknownField = dottedSchemaPath(path);
       let current: Record<PropertyKey, unknown> = isObject(rootShape)
         ? recordOf(rootShape)

--- a/packages/n4s/src/schema/mapWithoutValidation.ts
+++ b/packages/n4s/src/schema/mapWithoutValidation.ts
@@ -1,0 +1,85 @@
+import { hasOwnProperty, isArray, isObject } from 'vest-utils';
+
+import { ITEM_CONTAINER, ITEM_SCHEMA } from './schemaSlots';
+import { isRuleNode } from './ruleNode';
+
+export const MAP_VALUE = Symbol.for('vest:mapValue');
+export const MAP_FULL_VALUE = Symbol.for('vest:mapFullValue');
+
+type MappingResult = { type: unknown };
+type InternalRule = Record<PropertyKey, unknown>;
+
+/**
+ * Applies known parser steps without executing validation predicates.
+ *
+ * This is the n4s-owned mapping contract used to seed Vest's callback data
+ * for a first focused run. Parser results always provide their declared output
+ * type, even when their validation verdict fails. Using that output keeps the
+ * consuming callback's schema-output type truthful without adding untouched
+ * fields to the focused run's validation verdict.
+ *
+ * @internal
+ */
+// eslint-disable-next-line max-statements -- mapping dispatch follows independent structural and parser slots
+export function mapWithoutValidation(rule: unknown, value: unknown): unknown {
+  if (!isRuleNode(rule)) return value;
+  const slots = rule as InternalRule;
+  const mapFullValue = slots[MAP_FULL_VALUE];
+  if (typeof mapFullValue === 'function') {
+    const result = (mapFullValue as (input: unknown) => MappingResult)(value);
+    return result.type;
+  }
+  const mapped = mapStructuredValue(slots, value);
+  const mapValue = slots[MAP_VALUE];
+  if (typeof mapValue !== 'function') return mapped;
+  const result = (mapValue as (input: unknown) => MappingResult)(mapped);
+  return result.type;
+}
+
+// eslint-disable-next-line complexity, max-statements -- discriminates n4s container metadata
+function mapStructuredValue(rule: InternalRule, value: unknown): unknown {
+  const shape = rule.__schema;
+  if (isObject(shape) && isObject(value) && !isArray(value)) {
+    return mapShape(shape as Record<string, unknown>, value as object);
+  }
+
+  const itemSchema = rule[ITEM_SCHEMA];
+  if (isArray(value) && itemSchema !== undefined) {
+    if (isArray(itemSchema)) {
+      // Multi-rule arrays are unions, so choosing a mapper would require
+      // validation. Tuple metadata has no container discriminator.
+      if (rule[ITEM_CONTAINER] === 'array') return value;
+      return value.map((item, index) =>
+        mapWithoutValidation(itemSchema[index], item),
+      );
+    }
+    return value.map(item => mapWithoutValidation(itemSchema, item));
+  }
+  if (
+    rule[ITEM_CONTAINER] === 'record' &&
+    itemSchema !== undefined &&
+    isObject(value) &&
+    !isArray(value)
+  ) {
+    return Object.fromEntries(
+      Object.entries(value as object).map(([key, item]) => [
+        key,
+        mapWithoutValidation(itemSchema, item),
+      ]),
+    );
+  }
+  return value;
+}
+
+function mapShape(
+  shape: Record<string, unknown>,
+  value: object,
+): Record<string, unknown> {
+  const output = { ...value } as Record<string, unknown>;
+  for (const key of Object.keys(shape)) {
+    if (hasOwnProperty(output, key)) {
+      output[key] = mapWithoutValidation(shape[key], output[key]);
+    }
+  }
+  return output;
+}

--- a/packages/n4s/src/schema/projectionContext.ts
+++ b/packages/n4s/src/schema/projectionContext.ts
@@ -1,0 +1,30 @@
+import { createContext } from 'context';
+import { invariant, isPromise } from 'vest-utils';
+
+const projectionContext = createContext(false);
+
+/**
+ * Runs an internal selective-validation fragment after the relationship graph
+ * has already been consumed by the planner.
+ *
+ * `dependsOn()` is invalidation metadata, not executable validation. A
+ * projected fragment therefore must not re-resolve or enforce relationship
+ * providers merely to execute the validators the planner selected. The
+ * original user schema remains unchanged and keeps its normal composition
+ * and standalone-root checks outside this synchronous boundary.
+ *
+ * @internal
+ */
+export function withSchemaExecutionProjection<T>(fn: () => T): T {
+  const result = projectionContext.run(true, fn);
+  invariant(
+    !isPromise(result),
+    'Schema execution projection must remain synchronous.',
+  );
+  return result;
+}
+
+/** @internal */
+export function isSchemaExecutionProjection(): boolean {
+  return projectionContext.use();
+}

--- a/packages/n4s/src/schema/rebase.ts
+++ b/packages/n4s/src/schema/rebase.ts
@@ -1,0 +1,49 @@
+/* eslint-disable complexity */
+import type { SchemaPath } from './SchemaPath';
+import type { InternalRelationship } from './SchemaRelationship';
+
+/**
+ * Pure rebasing: prefixes non-rooted paths with given prefix.
+ * Rooted paths (those that escaped via $.root) are left as-is.
+ * Preserves internal rootedness flags across composition; stripping
+ * is done only in public describe() output.
+ */
+export function rebaseRelationships(
+  relationships: InternalRelationship[],
+  prefix: SchemaPath,
+): InternalRelationship[] {
+  return relationships.map(rel => {
+    const isRootSource = rel.__isRootSource === true;
+    const isRootTarget = rel.__isRootTarget === true;
+    const source = isRootSource ? rel.source : rebasePath(rel.source, prefix);
+    const target = isRootTarget ? rel.target : rebasePath(rel.target, prefix);
+    const rebased: InternalRelationship = {
+      source,
+      target,
+      effect: rel.effect,
+      ...(rel.metadata ? { metadata: { ...rel.metadata } } : {}),
+      ...(isRootSource ? { __isRootSource: true as const } : {}),
+      ...(isRootTarget ? { __isRootTarget: true as const } : {}),
+    };
+    return rebased;
+  });
+}
+
+export function rebasePath(path: SchemaPath, prefix: SchemaPath): SchemaPath {
+  return [...prefix, ...path];
+}
+
+/**
+ * Rebase for array item case: injects item segment between prefix and child paths.
+ */
+export function rebaseRelationshipsForArray(
+  relationships: InternalRelationship[],
+  arrayProperty: string | symbol,
+  itemBinding: string,
+): InternalRelationship[] {
+  const prefix: SchemaPath = [
+    { type: 'property', key: arrayProperty },
+    { type: 'item', binding: itemBinding },
+  ];
+  return rebaseRelationships(relationships, prefix);
+}

--- a/packages/n4s/src/schema/ruleNode.ts
+++ b/packages/n4s/src/schema/ruleNode.ts
@@ -1,0 +1,12 @@
+/**
+ * Runtime predicate for n4s rule nodes.
+ *
+ * Most lazy rules are proxy-backed objects, while `compose()` deliberately
+ * returns a callable function. Graph traversal must treat both forms as rule
+ * nodes; `vest-utils/isObject` intentionally covers objects only.
+ */
+export function isRuleNode(value: unknown): value is object {
+  return (
+    value !== null && (typeof value === 'object' || typeof value === 'function')
+  );
+}

--- a/packages/n4s/src/schema/schemaSlots.ts
+++ b/packages/n4s/src/schema/schemaSlots.ts
@@ -1,0 +1,50 @@
+/** Internal metadata shared by rule construction and selective execution. */
+export const UNRESOLVED_DEPS = Symbol.for('vest:unresolvedDeps');
+export const RESOLVED_RELATIONSHIPS = Symbol.for('vest:resolvedRelationships');
+export const ITEM_SCHEMA = Symbol.for('vest:itemSchema');
+export const COMPOSITION_CHILDREN = Symbol.for('vest:compositionChildren');
+export const CHAIN_INFO = Symbol.for('vest:chainInfo');
+export const CHAIN_BASELINE = Symbol.for('vest:chainBaseline');
+export const PARTIAL_LIKE = Symbol.for('vest:partialLike');
+export const OPTIONAL_RULE = Symbol.for('vest:optionalRule');
+export const ITEM_CONTAINER = Symbol.for('vest:itemContainer');
+
+export type ChainInfo = {
+  readonly length: number;
+  readonly hasMessage: boolean;
+};
+
+export type ChainBaseline = {
+  readonly length: number;
+  readonly hasMessage: boolean;
+  readonly inner?: unknown;
+};
+
+export type ItemContainerKind = 'array' | 'record';
+
+function slotOf(rule: unknown, slot: symbol): unknown {
+  if (rule === null) return undefined;
+  const kind = typeof rule;
+  if (kind !== 'object' && kind !== 'function') return undefined;
+  return (rule as Record<symbol, unknown>)[slot];
+}
+
+export function hasChainBaseline(rule: unknown): boolean {
+  return slotOf(rule, CHAIN_BASELINE) !== undefined;
+}
+
+export function chainBaselineMatches(rule: unknown): boolean {
+  const baseline = slotOf(rule, CHAIN_BASELINE) as ChainBaseline | undefined;
+  const current = slotOf(rule, CHAIN_INFO) as ChainInfo | undefined;
+  if (baseline === undefined || current === undefined) return false;
+  if (!sameChainState(current, baseline)) return false;
+  if (baseline.inner === undefined) return true;
+  return chainBaselineMatches(baseline.inner);
+}
+
+function sameChainState(current: ChainInfo, baseline: ChainBaseline): boolean {
+  return (
+    current.length === baseline.length &&
+    current.hasMessage === baseline.hasMessage
+  );
+}

--- a/packages/n4s/src/schema/scopeProxy.ts
+++ b/packages/n4s/src/schema/scopeProxy.ts
@@ -1,0 +1,165 @@
+import type { SchemaPath } from './SchemaPath';
+import { propertySegment } from './SchemaPath';
+
+// Symbol to mark DependencyRef objects
+export const DEPENDENCY_REF = Symbol('vest:dependencyRef');
+export const ROOT_MARKER = Symbol('vest:rootMarker');
+
+// Reference metadata lives on symbols — never on string keys — so EVERY
+// string property access chains as a field name. Previously `path`/`isRoot`
+// were string-keyed metadata, which made `$.nested.path` / `$.nested.isRoot`
+// return metadata instead of a field reference.
+export const REF_PATH = Symbol('vest:refPath');
+export const REF_IS_ROOT = Symbol('vest:refIsRoot');
+
+/**
+ * Escape hatch for referencing a literal field whose name collides with a
+ * JavaScript internal.
+ *
+ * `then` is intentionally the ONLY non-chainable string key on dependency
+ * refs: if `ref.then` were defined, `await ref` / `Promise.resolve(ref)`
+ * could mistake a returned ref for a thenable and throw a TypeError via
+ * GetMethod. Every other string key — including `toJSON`, `valueOf`,
+ * `path`, `isRoot`, and `self` — chains as a normal field name.
+ *
+ * To depend on a literal field named `then`, use the hatch:
+ *   dependsOn($ => $[FIELD]('then'))
+ *   dependsOn($ => $.nested[FIELD]('then'))
+ *   dependsOn($ => $.root[FIELD]('then'))
+ */
+export const FIELD = Symbol('vest:scopeField');
+
+export type DependencyRef = {
+  [DEPENDENCY_REF]: true;
+  [REF_PATH]: SchemaPath;
+  [REF_IS_ROOT]: boolean;
+};
+
+export function isDependencyRef(value: unknown): value is DependencyRef {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as DependencyRef)[DEPENDENCY_REF] === true
+  );
+}
+
+export function getRefPath(ref: DependencyRef): SchemaPath {
+  return ref[REF_PATH];
+}
+
+export function isRootRef(ref: DependencyRef): boolean {
+  return ref[REF_IS_ROOT] === true;
+}
+
+export interface Scope {
+  readonly root: Scope;
+  [FIELD]: (fieldName: string) => Scope;
+  [key: string]: Scope;
+}
+
+/**
+ * Creates the `$` scope proxy for a given scope.
+ * `$` is scoped to current schema by default.
+ * `$.root` escapes to top-level schema scope.
+ */
+export function createScopeProxy(scopePath: SchemaPath): Scope {
+  const createRootProxy = (): Scope['root'] =>
+    new Proxy({} as Record<PropertyKey, DependencyRef>, {
+      get(_target, prop) {
+        if (prop === ROOT_MARKER) return true as unknown as unknown;
+        if (prop === FIELD)
+          return (fieldName: string) =>
+            createDependencyRef([propertySegment(fieldName)], true);
+        if (typeof prop === 'symbol') return undefined;
+        // `then` stays non-chainable so returned refs are never thenable.
+        // A root-level field literally named `then` is reachable via $[FIELD].
+        if (prop === 'then') return undefined;
+        const path: SchemaPath = [propertySegment(prop as string)];
+        return createDependencyRef(path, true);
+      },
+    }) as unknown as Scope['root'];
+
+  return new Proxy({} as Record<PropertyKey, unknown>, {
+    get(_target, prop) {
+      if (prop === FIELD)
+        return (fieldName: string) =>
+          createDependencyRef(
+            [...scopePath, propertySegment(fieldName)],
+            false,
+          );
+      if (typeof prop === 'symbol') return undefined;
+      return scopeStringProp(scopePath, createRootProxy, prop);
+    },
+  }) as unknown as Scope;
+}
+
+function scopeStringProp(
+  scopePath: SchemaPath,
+  createRootProxy: () => Scope['root'],
+  prop: string | number,
+): unknown {
+  if (prop === 'root') {
+    return createRootProxy();
+  }
+  /** @deferred v2 */
+  if (prop === 'parent') {
+    throw new Error('$.parent deferred to v2');
+  }
+  // `then` stays non-chainable so returned refs are never thenable.
+  // A field literally named `then` is reachable via $[FIELD].
+  if (prop === 'then') return undefined;
+  const path: SchemaPath = [...scopePath, propertySegment(String(prop))];
+  return createDependencyRef(path, false);
+}
+
+function createDependencyRef(path: SchemaPath, isRoot: boolean): DependencyRef {
+  const base = {
+    [DEPENDENCY_REF]: true,
+    [REF_PATH]: path,
+    [REF_IS_ROOT]: isRoot,
+  } as DependencyRef;
+  // Proxy to support chained access like $.obj.leaf or $.root.foo.bar.
+  // Every string key chains as a field name — except `then`, which must stay
+  // undefined so refs are never thenable (see FIELD for the escape hatch).
+  return new Proxy(base as unknown as object, {
+    get(target: unknown, prop: PropertyKey) {
+      if (prop === FIELD)
+        return (fieldName: string) =>
+          createDependencyRef(
+            [
+              ...(target as unknown as DependencyRef)[REF_PATH],
+              propertySegment(fieldName),
+            ],
+            (target as unknown as DependencyRef)[REF_IS_ROOT],
+          );
+      if (typeof prop === 'symbol')
+        return (target as unknown as Record<symbol, unknown>)[prop];
+      return chainStringProp(target, prop);
+    },
+  }) as DependencyRef;
+}
+
+function chainStringProp(target: unknown, prop: string | number): unknown {
+  // `then` stays undefined so refs are never thenable (see FIELD).
+  if (String(prop) === 'then') return undefined;
+  const ref = target as unknown as DependencyRef;
+  const extendedPath: SchemaPath = [
+    ...ref[REF_PATH],
+    propertySegment(String(prop)),
+  ];
+  return createDependencyRef(extendedPath, ref[REF_IS_ROOT]);
+}
+
+/**
+ * Normalizes resolver return value to array of DependencyRefs.
+ */
+export function normalizeResolverResult(result: unknown): DependencyRef[] {
+  if (!result) return [];
+  if (Array.isArray(result)) {
+    return result.filter(isDependencyRef);
+  }
+  if (isDependencyRef(result)) {
+    return [result];
+  }
+  return [];
+}

--- a/packages/n4s/src/schema/selectiveRun.ts
+++ b/packages/n4s/src/schema/selectiveRun.ts
@@ -1,0 +1,3221 @@
+import {
+  asArray,
+  hasOwnProperty,
+  isArray,
+  isFunction,
+  isNullish,
+  isObject,
+  isUnsafeKey,
+} from 'vest-utils';
+
+import { EnforceSchemaError } from '../errors/EnforceSchemaError';
+import { enforceLazy } from '../lazy';
+import type { SchemaMemberRule } from '../rules/schemaRules/schemaRulesLazyTypes';
+import type { DescribeResult } from '../utils/RuleInstance';
+import {
+  ITEM_CONTAINER,
+  ITEM_SCHEMA,
+  OPTIONAL_RULE,
+  PARTIAL_LIKE,
+  chainBaselineMatches,
+  hasChainBaseline,
+} from './schemaSlots';
+import type { ItemContainerKind } from './schemaSlots';
+import type { ItemSegment, PropertySegment, SchemaPath } from './SchemaPath';
+import { isPropertySegment } from './SchemaPath';
+import { withSchemaExecutionProjection } from './projectionContext';
+import type { SchemaRelationship } from './SchemaRelationship';
+
+/**
+ * Structural view of a schema rule for selective execution. Covers every
+ * member the projection reads or rebuilds (`__schema` containers, item
+ * slots, `describe()` dependencies, `run`/`parse` entry points).
+ */
+export type SelectiveSchema = {
+  readonly __schema?: Record<string, SelectiveSchema>;
+  readonly describe?: () => DescribeResult;
+  /**
+   * Runtime validation entry points. Declared with method syntax (bivariant)
+   * on purpose: every rule tests/runs/parses unknown values at runtime,
+   * while each rule's declared input type is narrower. Invoked only with
+   * real run data when executing (projected or full) fragments — never
+   * with synthetic values to infer schema semantics, and never to bypass
+   * argument checking.
+   */
+  test?(value: unknown): boolean;
+  run?(...args: unknown[]): unknown;
+  parse?(...args: unknown[]): unknown;
+};
+
+/**
+ * Outcome of one selective schema run. This is the canonical definition:
+ * Vest's suite-side `SchemaRunResult` is a deliberate alias of this type
+ * (see `useCreateSuiteRunner.ts`), so a schema failure means the same
+ * shape on both sides of the boundary and stays comparable by structure.
+ */
+export type SelectiveSchemaResult = {
+  readonly message?: string;
+  readonly pass: boolean;
+  readonly path?: readonly string[];
+  readonly type?: unknown;
+};
+
+export type SelectiveRunOptions = {
+  /**
+   * Raw changed fields in canonical dotted form (e.g. 'travelers.1.country',
+   * brackets accepted: 'travelers[1].country'); n4s expands them against
+   * the schema relationship graph (dependents fan-out from run data), so
+   * callers pass raw names and never
+   * pre-expand. Null or undefined runs the full schema with focus
+   * narrowing only. An explicit empty array runs nothing (a single passing
+   * entry carrying the input data).
+   *
+   * Paths are dotted strings, so a record key containing a literal dot is
+   * unrepresentable ('a.b' always reads as nested path a → b). Numeric
+   * segments always denote array indices in dotted form ('travelers.1' is
+   * index 1, never record key '1'); an all-digit record key is
+   * indistinguishable from an index and resolves as one.
+   */
+  readonly affected?: readonly string[] | null;
+  /** @internal Pre-resolved by resolveAffectedPaths for Vest integration. */
+  readonly resolvedAffected?: readonly string[] | null;
+  /**
+   * Inclusion focus: top-level field names (dotted names select subtrees).
+   * Always intersects `affected` — `only` narrows execution, never widens
+   * it and is never silently dropped. An explicit empty list runs nothing.
+   */
+  readonly only?: string | readonly string[] | null;
+  /**
+   * Exclusion focus: field names, or `true` for skip-all (every synthesized
+   * failure is dropped, mirroring the suite runtime).
+   */
+  readonly skip?: string | readonly string[] | boolean | null;
+};
+
+/**
+ * Normalized focus for the selective engine: `only` is already a name list
+ * (null when no inclusion focus was given), `skip` keeps its raw form for
+ * `buildSkipFilter` (boolean skip-all) and `buildArrayProp` (name lists).
+ */
+type FocusModifiers = {
+  readonly only?: readonly string[] | null;
+  readonly skip?: string | readonly string[] | boolean | null;
+};
+
+/**
+ * The single contract for dependency-aware schema execution. The caller
+ * passes raw changed fields; n4s owns everything after that: changed→
+ * affected fan-out from the relationship graph (with array fan-out from
+ * run data), container-kind detection, fragment projection, short-circuit
+ * supplementation, chain-baseline checks, and failure narrowing. Returns
+ * one entry per distinct failure (plus the parsed type on the first entry),
+ * or a single passing entry carrying the parsed data. Throws
+ * EnforceSchemaError on a nullish schema — schemaless runs never silently
+ * pass here (the suite runner guards those before calling).
+ */
+// eslint-disable-next-line complexity -- this is the orchestration boundary for all selective-run modes
+export function runSchemaPaths(
+  schema: unknown,
+  data: unknown,
+  options: SelectiveRunOptions = {},
+): SelectiveSchemaResult[] {
+  if (isNullish(schema)) {
+    throw new EnforceSchemaError(
+      'EnforceSchemaError: runSchemaPaths requires a schema',
+    );
+  }
+  const focus = selectiveFocusOf({
+    ...options,
+    affected:
+      options.resolvedAffected === undefined
+        ? expandChangedToAffected(schema, options.affected, data)
+        : options.resolvedAffected,
+  });
+  const execute = (): SelectiveSchemaResult[] =>
+    runSchemaWithParse(
+      schema as SelectiveSchema,
+      data,
+      { only: focus.onlyList, skip: focus.skip },
+      focus.effectiveAffected,
+    );
+  const createsExecutionFragment =
+    focus.effectiveAffected !== null ||
+    focus.onlyList !== null ||
+    !isNullish(focus.skip);
+  return createsExecutionFragment
+    ? withSchemaExecutionProjection(execute)
+    : execute();
+}
+
+/**
+ * Normalizes entry-point options: `only` becomes a name list and the
+ * affected set becomes the only∫affected intersection.
+ */
+function selectiveFocusOf(options: SelectiveRunOptions): {
+  readonly effectiveAffected: readonly string[] | null;
+  readonly onlyList: string[] | null;
+  readonly skip: string | readonly string[] | boolean | null;
+} {
+  const { affected = null, only = null, skip = null } = options;
+  const onlyList = buildArrayProp(only);
+  return {
+    effectiveAffected: intersectAffectedWithOnly(affected, onlyList),
+    onlyList,
+    skip,
+  };
+}
+
+/**
+ * Attempts to parse the schema. Returns null on genuine validation
+ * failures, so the caller can fall back to schema.run.
+ *
+ * n4s rules expose the non-throwing StandardSchema `validate` entry, which
+ * reports genuine failures as `issues` without throwing: validator bugs
+ * (unexpected TypeErrors from user predicates or getters) propagate loudly
+ * instead of being misclassified as validation failures. The throwing
+ * `parse` entry — with the narrowed `isExpectedSchemaParseError` gate —
+ * remains only for foreign `{ run, parse }` schemas without it.
+ */
+function tryParseSchema(
+  executableSchema: SelectiveSchema,
+  data: unknown,
+): SelectiveSchemaResult[] | null {
+  const parse = executableSchema.parse;
+  if (!isFunction(parse)) return null;
+
+  const standardValidate = n4sStandardValidateOf(executableSchema);
+  if (standardValidate !== null) {
+    return runViaStandardValidate(executableSchema, standardValidate, data);
+  }
+  return runViaThrowingParse(executableSchema, parse, data);
+}
+
+/**
+ * n4s parse path: genuine failures arrive as `issues`, unexpected
+ * exceptions propagate untouched.
+ */
+function runViaStandardValidate(
+  executableSchema: SelectiveSchema,
+  standardValidate: (data: unknown) => unknown,
+  data: unknown,
+): SelectiveSchemaResult[] | null {
+  const result = standardValidate(data);
+  if (hasStandardIssues(result)) return null;
+  return runParsedValue(executableSchema, (result as { value: unknown }).value);
+}
+
+/**
+ * Foreign `{ run, parse }` path: only validation-marked parse failures
+ * fall back to `run`, programming errors stay loud.
+ */
+function runViaThrowingParse(
+  executableSchema: SelectiveSchema,
+  parse: (...args: unknown[]) => unknown,
+  data: unknown,
+): SelectiveSchemaResult[] | null {
+  try {
+    const parsedValue = parse(data);
+    return runParsedValue(executableSchema, parsedValue);
+  } catch (error) {
+    if (isExpectedSchemaParseError(error)) return null;
+    throw error;
+  }
+}
+
+/**
+ * The non-throwing StandardSchema validate entry of an n4s rule, or null
+ * for foreign schemas (which keep the throwing parse path).
+ */
+function n4sStandardValidateOf(
+  executableSchema: SelectiveSchema,
+): ((data: unknown) => unknown) | null {
+  if (!isN4sVendorSchema(executableSchema)) return null;
+  const validate = (
+    executableSchema as unknown as {
+      '~standard'?: { validate?: unknown };
+    }
+  )['~standard']?.validate;
+  return isFunction(validate) ? (validate as (data: unknown) => unknown) : null;
+}
+
+function hasStandardIssues(result: unknown): boolean {
+  return (
+    isObject(result) && Array.isArray((result as { issues?: unknown }).issues)
+  );
+}
+
+/**
+ * Runs a parsed value through the schema's run step when the schema opts
+ * into parse-then-run; otherwise the parsed value is the result.
+ */
+function runParsedValue(
+  executableSchema: SelectiveSchema,
+  parsedValue: unknown,
+): SelectiveSchemaResult[] {
+  const run = executableSchema.run;
+  if (shouldRunAfterParse(executableSchema) && isFunction(run)) {
+    return normalizeSelectiveSchemaResult(run(parsedValue), parsedValue);
+  }
+  return [{ pass: true, type: parsedValue }];
+}
+
+/**
+ * Runs schema parsing/validation in a safe order:
+ * 1) try parse
+ * 2) if parse succeeds, treat it as the authoritative validation output
+ * 3) on expected parse validation failures, fallback to run(raw)
+ *
+ * changed() with nested affected paths cannot use enforce.pick (it selects
+ * top-level keys only, silently dropping nested validation). Run a projected
+ * schema limited to the affected subtrees instead: n4s shape/loose reports
+ * only its first failure, so running everything and filtering afterward is
+ * order-dependent — an unrelated earlier field would hide the affected
+ * dependency. Failures are still narrowed to the affected paths afterward.
+ * Top-level-only focus keeps the existing pick/omit behavior identical.
+ */
+function runSchemaWithParse(
+  schema: SelectiveSchema,
+  data: unknown,
+  modifiers: FocusModifiers,
+  changedAffected?: readonly string[] | null,
+): SelectiveSchemaResult[] {
+  if (changedAffected == null) {
+    return runFlatSchema(schema, modifiers, data, changedAffected);
+  }
+  if (changedAffected.length === 0) return [{ pass: true, type: data }];
+  const divergentFallback = runExplicitUndefinedFallback(
+    schema,
+    modifiers,
+    changedAffected,
+    data,
+  );
+  if (divergentFallback !== null) return divergentFallback;
+  const { mainRun, supplement } = runProjectedMain(
+    schema,
+    modifiers,
+    [...changedAffected],
+    data,
+  );
+  return narrowProjectedResults({
+    data,
+    mainRun,
+    modifiers,
+    nestedAffected: changedAffected,
+    schema,
+    supplement,
+  });
+}
+
+type ProjectedOutcome = {
+  readonly data: unknown;
+  readonly mainRun: ProjectedMainRun;
+  readonly modifiers: FocusModifiers;
+  readonly nestedAffected: readonly string[];
+  readonly schema: SelectiveSchema;
+  readonly supplement: ArraySupplement;
+};
+
+/**
+ * Narrows projected results to the affected set. `nestedAffected` already
+ * carries the only∫affected intersection (see `intersectAffectedWithOnly`);
+ * `skip` must additionally narrow synthesized failures (the projected run
+ * does not take focused modifiers, unlike `applySchemaFocus`). A member
+ * that cannot run standalone (orphaned root edge) would be silently
+ * omitted — run everything with post-filtering instead.
+ */
+function narrowProjectedResults(
+  outcome: ProjectedOutcome,
+): SelectiveSchemaResult[] {
+  const skip = buildSkipFilter(outcome.modifiers.skip);
+  if (outcome.supplement.gap) {
+    return runFullWithAffectedFilter({
+      affected: outcome.nestedAffected,
+      data: outcome.data,
+      modifiers: outcome.modifiers,
+      schema: outcome.schema,
+      skip,
+    });
+  }
+  const merged = mergeSupplementalResults(
+    outcome.mainRun.results,
+    outcome.supplement.results,
+  );
+  return filterSchemaResultsToAffected(
+    merged,
+    outcome.nestedAffected,
+    outcome.data,
+    skip,
+  );
+}
+
+/**
+ * One projected main run plus its per-member supplement.
+ */
+function runProjectedMain(
+  schema: SelectiveSchema,
+  modifiers: FocusModifiers,
+  expanded: string[],
+  data: unknown,
+): { mainRun: ProjectedMainRun; supplement: ArraySupplement } {
+  const projectedSchema = buildProjectedSchema(schema, expanded);
+  const mainRun = runProjectedOrFull(projectedSchema, schema, modifiers, data);
+  const supplement = collectSupplementForMain(mainRun, schema, expanded, data);
+  return { mainRun, supplement };
+}
+
+type FullFilterRun = {
+  readonly affected: readonly string[];
+  readonly data: unknown;
+  readonly modifiers: FocusModifiers;
+  readonly schema: SelectiveSchema;
+  readonly skip: string[] | true | null;
+};
+
+/**
+ * Full-schema run with post-filtering to the affected set.
+ */
+function runFullWithAffectedFilter(
+  run: FullFilterRun,
+): SelectiveSchemaResult[] {
+  const full = runExecutableSchema(
+    changedFallbackSchema(run.schema, run.modifiers),
+    run.data,
+  );
+  return filterSchemaResultsToAffected(full, run.affected, run.data, run.skip);
+}
+
+/**
+ * Full-run fallback for the explicit-undefined unknown-key divergence (see
+ * `hasExplicitUndefinedUnknownKey`): the fragment would report clean where
+ * the full run fails, so run everything with post-filtering instead.
+ * Returns null when the fast projection path applies.
+ */
+function runExplicitUndefinedFallback(
+  schema: SelectiveSchema,
+  modifiers: FocusModifiers,
+  nestedAffected: readonly string[],
+  data: unknown,
+): SelectiveSchemaResult[] | null {
+  if (!hasExplicitUndefinedProjectionDivergence(schema, nestedAffected, data)) {
+    return null;
+  }
+  return runFlatSchema(schema, modifiers, data, nestedAffected);
+}
+
+/**
+ * Runs the top-level-only path (unchanged `pick`/`omit` focus). `changed()`
+ * runs additionally narrow synthesized failures by `skip()` — nested skip
+ * names are no-ops in `omit()`, so the post-filter covers them. Plain runs
+ * and empty changes pass through untouched.
+ */
+function runFlatSchema(
+  schema: SelectiveSchema,
+  modifiers: FocusModifiers,
+  data: unknown,
+  changedAffected?: readonly string[] | null,
+): SelectiveSchemaResult[] {
+  // Top-level changed() runs carry the only∫affected intersection like the
+  // nested path: a pick() would drop container validators chained after
+  // construction, so they take the parity-guarded fallback schema instead.
+  // Plain only()/skip() runs keep the legacy focus behavior identical.
+  const focused = changedAffected
+    ? changedFallbackSchema(schema, modifiers)
+    : applySchemaFocus(schema, modifiers);
+  const result = runExecutableSchema(focused, data);
+  // Narrowing applies to n4s schemas only: custom standard-schema results
+  // keep full-run parity (no affected/skip vocabulary exists for them).
+  // Root-container n4s schemas (array/record/tuple roots without __schema)
+  // cannot take pick/omit focus or projection, but their full-run failures
+  // still filter by affected path — returning them unfiltered would report
+  // failures changed() never asked about.
+  if (!shouldNarrowFlatResults(schema, changedAffected)) {
+    if (isEmptyAffectedFocus(schema, changedAffected)) {
+      // Explicit zero-field focus (e.g. a disjoint only∫affected): run
+      // nothing, mirroring the skip-all pass-through. Foreign schemas keep
+      // full-run parity (no affected vocabulary exists for them).
+      return passThroughResult(result, data);
+    }
+    return result;
+  }
+  const skip = buildSkipFilter(modifiers.skip);
+  const memberResults = collectFlatMemberSupplement(
+    schema,
+    changedAffected,
+    result,
+    data,
+    skip,
+  );
+  const merged = mergeSupplementalResults(result, memberResults);
+  return filterSchemaResultsToAffected(merged, changedAffected, data, skip);
+}
+
+/**
+ * Whether flat changed() results narrow by affected path: a real affected
+ * set on an n4s schema. Empty and foreign cases return early instead.
+ */
+function shouldNarrowFlatResults(
+  schema: SelectiveSchema,
+  changedAffected: readonly string[] | null | undefined,
+): changedAffected is readonly string[] {
+  return (
+    changedAffected != null &&
+    changedAffected.length > 0 &&
+    isN4sVendorSchema(schema)
+  );
+}
+
+function isEmptyAffectedFocus(
+  schema: SelectiveSchema,
+  changedAffected: readonly string[] | null | undefined,
+): boolean {
+  return changedAffected?.length === 0 && isN4sVendorSchema(schema);
+}
+
+/**
+ * Per-member execution for flat (top-level-only) changed() runs. The main
+ * run validates the full schema, which reports only its first failure — an
+ * affected member invalid behind an earlier failure would stay silent
+ * (W2). n4s containers iterate schema keys in Object.keys order (ownKeys)
+ * and short-circuit at the first failure, so members strictly after the
+ * single reported failure's top key never executed: run exactly those
+ * standalone and merge (W3 honors the merged only+affected set the same
+ * way). Any other main outcome — pass, root failure, extra-key failure,
+ * several failures — implies full member execution (or filter-kept roots),
+ * so it supplements nothing: a member the main run reached is never
+ * re-run, keeping stateful validators exactly-once.
+ */
+function collectFlatMemberSupplement(
+  schema: SelectiveSchema,
+  affected: readonly string[],
+  main: SelectiveSchemaResult[],
+  data: unknown,
+  skip: string[] | true | null,
+): SelectiveSchemaResult[] {
+  if (skip === true) return [];
+  const topSchema = schema.__schema;
+  if (topSchema === undefined) return [];
+  const afterKey = shadowedAfterKey(main, topSchema);
+  if (afterKey === null) return [];
+  // Absent-member knowledge comes from the declared top container's
+  // metadata: a partial-like top never evaluates missing keys, so an
+  // absent affected member past the boundary is valid-absent, not a
+  // shadowed failure. Unknown containers skip absent members too — the
+  // full-run verdict stands instead of inventing failures.
+  const skipAbsent = skipAbsentMembersOf(schema);
+  return runShadowedMembers(topSchema, afterKey, {
+    affected,
+    data,
+    skip,
+    skipAbsent,
+  });
+}
+
+type ShadowedRun = {
+  readonly skipAbsent: boolean;
+  readonly affected: readonly string[];
+  readonly skip: string[] | null;
+  readonly data: unknown;
+};
+
+function runShadowedMembers(
+  topSchema: Record<string, SelectiveSchema>,
+  afterKey: string,
+  run: ShadowedRun,
+): SelectiveSchemaResult[] {
+  const skipSet = skipSetOf(run.skip);
+  const affectedSet = new Set(run.affected);
+  const out: SelectiveSchemaResult[] = [];
+  let pastFailure = false;
+  for (const key of Object.keys(topSchema)) {
+    if (key === afterKey) {
+      pastFailure = true;
+    } else if (shouldRunShadowed(pastFailure, affectedSet, skipSet, key)) {
+      appendFlatMember(
+        topSchema[key],
+        { skipAbsent: run.skipAbsent, data: run.data, key },
+        out,
+      );
+    }
+  }
+  return out;
+}
+
+function shouldRunShadowed(
+  pastFailure: boolean,
+  affectedSet: Set<string>,
+  skipSet: Set<string>,
+  key: string,
+): boolean {
+  return pastFailure && affectedSet.has(key) && !skipSet.has(key);
+}
+
+/**
+ * The top-level key a single-failure main run failed at, when that failure
+ * proves later members never executed: exactly one failure, pathed under a
+ * declared member. Anything else (pass, root failure, extra-key failure,
+ * several failures) implies full member execution or filter-kept roots.
+ */
+function shadowedAfterKey(
+  main: readonly SelectiveSchemaResult[],
+  topSchema: Record<string, SelectiveSchema>,
+): string | null {
+  const failures = main.filter(result => !result.pass);
+  if (failures.length !== 1) return null;
+  return memberTopKey(failures, topSchema);
+}
+
+function memberTopKey(
+  failures: SelectiveSchemaResult[],
+  topSchema: Record<string, SelectiveSchema>,
+): string | null {
+  const [failure] = failures as [SelectiveSchemaResult];
+  const [top] = failure?.path ?? [];
+  if (typeof top !== 'string' || !hasOwnProperty(topSchema, top)) return null;
+  return top;
+}
+
+type FlatMemberRun = {
+  readonly skipAbsent: boolean;
+  readonly data: unknown;
+  readonly key: string;
+};
+
+function appendFlatMember(
+  rule: SelectiveSchema,
+  run: FlatMemberRun,
+  out: SelectiveSchemaResult[],
+): void {
+  // A member absent from a partial-like (or unknown) top was never
+  // evaluated by the main run: running it standalone would invent a
+  // failure the full run never reports. Absent members of required
+  // containers are genuinely invalid and run (failing correctly), as do
+  // present members — including explicit-undefined ones, which the full
+  // run evaluates.
+  if (skipAbsentMember(run)) return;
+  const child = childValue(run.data, run.key);
+  // This path is reached only when an earlier failure proved the member
+  // was never executed.
+  let outcome: SelectiveSchemaResult[];
+  try {
+    outcome = runExecutableSchema(rule, child);
+  } catch (error) {
+    // A member with external dependencies cannot run standalone (orphaned
+    // source): skip it — the main run's verdict stands, as before.
+    if (isBoundaryError(error)) return;
+    throw error;
+  }
+  for (const result of prefixFailureResults(outcome, [run.key])) {
+    out.push(result);
+  }
+}
+
+/**
+ * Partial containers iterate own enumerable keys. Explicit undefined is
+ * therefore provided only when its property participates in that iteration.
+ */
+function isPresentKey(data: unknown, key: string): boolean {
+  return (
+    isObject(data) && Object.prototype.propertyIsEnumerable.call(data, key)
+  );
+}
+
+function skipAbsentMember(run: FlatMemberRun): boolean {
+  return run.skipAbsent && !isPresentKey(run.data, run.key);
+}
+
+/**
+ * One projected main run. `full` reports whether the main run already
+ * executed the full schema instead of a fragment.
+ */
+type ProjectedMainRun = {
+  results: SelectiveSchemaResult[];
+  full: boolean;
+};
+
+/**
+ * Runs the projected fragment, falling back to the full schema run with
+ * post-filtering when the fragment cannot validate standalone (e.g. an
+ * exotic rooted edge the source expansion did not retain).
+ */
+function runProjectedOrFull(
+  projectedSchema: SelectiveSchema | null,
+  schema: SelectiveSchema,
+  modifiers: FocusModifiers,
+  data: unknown,
+): ProjectedMainRun {
+  if (!projectedSchema) {
+    return {
+      full: true,
+      results: runExecutableSchema(
+        changedFallbackSchema(schema, modifiers),
+        data,
+      ),
+    };
+  }
+  try {
+    return { full: false, results: runExecutableSchema(projectedSchema, data) };
+  } catch (error) {
+    if (!isBoundaryError(error)) throw error;
+    return {
+      full: true,
+      results: runExecutableSchema(
+        changedFallbackSchema(schema, modifiers),
+        data,
+      ),
+    };
+  }
+}
+
+/**
+ * Schema for the changed() fallback path. The caller post-filters to the
+ * only∫affected set, so `only` needs no further narrowing here (a pick()
+ * over dotted names would silently drop subtrees and container
+ * validators). Only top-level `skip` focus applies, and only when
+ * rebuilding preserves behavior: a partial-like top would gain
+ * requiredness and a moved chain would lose container validators, so those
+ * run unfocused (post-filter narrows).
+ */
+function changedFallbackSchema(
+  schema: SelectiveSchema,
+  modifiers: FocusModifiers,
+): SelectiveSchema {
+  if (!isN4sSchema(schema)) return schema;
+  if (isPartialLikeContainer(schema) || !chainBaselineMatches(schema)) {
+    return schema;
+  }
+  return omitSkippedTopKeys(schema, modifiers.skip);
+}
+
+function omitSkippedTopKeys(
+  schema: SelectiveSchema,
+  skipProp: string | readonly string[] | boolean | null | undefined,
+): SelectiveSchema {
+  const skip = buildArrayProp(skipProp);
+  if (!skip || schema.__schema === undefined) return schema;
+  // The interop view cannot name rule members; the values are the schema's
+  // own member rules, so they satisfy the member constraint by construction.
+  const members = schema.__schema as unknown as Record<
+    string,
+    SchemaMemberRule
+  >;
+  return preserveOptionality(
+    schema,
+    enforceLazy.omit(members, skip) as unknown as SelectiveSchema,
+  );
+}
+
+/**
+ * Runs a schema via parse-then-run, falling back to run(raw) when parse is
+ * unavailable or reports an expected validation failure.
+ */
+function runExecutableSchema(
+  executableSchema: SelectiveSchema,
+  data: unknown,
+): SelectiveSchemaResult[] {
+  const parseResult = tryParseSchema(executableSchema, data);
+  if (parseResult) {
+    return parseResult;
+  }
+  if (isFunction(executableSchema.run)) {
+    return normalizeSelectiveSchemaResult(executableSchema.run(data), data);
+  }
+  return [
+    {
+      pass: true,
+      type: data,
+    },
+  ];
+}
+
+/**
+ * Detects standalone-boundary rejections. instanceof-first for same-copy
+ * errors, with an error-name fallback: the error can originate from a
+ * second copy of the n4s classes when the executable schema was built
+ * through the packaged entry point (dual-copy interop). Anything else —
+ * including plain TypeErrors from buggy validators — is not a boundary.
+ */
+function isBoundaryError(error: unknown): boolean {
+  if (error instanceof EnforceSchemaError) return true;
+  return (
+    isObject(error) &&
+    (error as { name?: unknown }).name === 'EnforceSchemaError'
+  );
+}
+
+type AffectedSeg = string | number;
+
+/**
+ * Canonical affected-path parser: the single implementation behind every
+ * changed/affected field-name parse (n4s selective machinery and Vest's
+ * suite.changed(), which delegates to this function). Bracket and dotted
+ * spellings unify here ('travelers[1].country' and 'travelers.1.country'
+ * parse identically); all-numeric segments become item segments (array
+ * indices), everything else becomes a property segment. Shared limitation:
+ * a literal dotted record key is unrepresentable ('a.b' always reads as
+ * nested path a → b), and an all-digit record key is indistinguishable
+ * from an array index.
+ */
+export function parseAffectedFieldName(field: string): SchemaPath {
+  // Normalize brackets to dots: travelers[1].country -> travelers.1.country
+  const normalized = field.replace(/\[/g, '.').replace(/\]/g, '');
+  const parts = normalized.split('.').filter(Boolean);
+  return parts.map((part): SchemaPath[number] =>
+    // Numeric segments are item segments (array indices). A property
+    // literally named '123' is ambiguous but unrepresentable here.
+    /^\d+$/.test(part)
+      ? { type: 'item', binding: part }
+      : { type: 'property', key: part },
+  ) as SchemaPath;
+}
+
+/**
+ * Canonical dotted form of an affected field name ('travelers[1].country'
+ * -> 'travelers.1.country').
+ */
+function canonicalAffectedName(field: string): string {
+  return affectedPathToName(parseAffectedFieldName(field));
+}
+
+function affectedPathToName(path: SchemaPath): string {
+  return path
+    .map(seg => (seg.type === 'property' ? String(seg.key) : seg.binding))
+    .join('.');
+}
+
+/**
+ * Bracket-to-dot parsing with numeric coercion: the item-segment bindings
+ * of the canonical parser read back as numbers for index dispatch.
+ */
+function parseAffectedPath(field: string): AffectedSeg[] {
+  return parseAffectedFieldName(field).map(seg =>
+    seg.type === 'item' ? Number(seg.binding) : String(seg.key),
+  );
+}
+
+/**
+ * Whether projection would change explicit-undefined semantics. This occurs
+ * for unknown strict-shape keys (the value-only sentinel cannot distinguish
+ * absence) and declared partial members (the projected optional wrapper would
+ * skip a present undefined value that the full partial container evaluates).
+ * Callers take the full-run fallback so the selective verdict stays exact.
+ * Metadata-only: never executes user validators and never throws.
+ */
+function hasExplicitUndefinedProjectionDivergence(
+  schema: SelectiveSchema,
+  affected: readonly string[],
+  data: unknown,
+): boolean {
+  for (const field of affected) {
+    let path: AffectedSeg[];
+    try {
+      path = parseAffectedPath(field);
+    } catch {
+      continue;
+    }
+    if (checkAffectedSegments(schema, data, path, 0)) return true;
+  }
+  return false;
+}
+
+function checkAffectedSegments(
+  schemaNode: SelectiveSchema | undefined,
+  dataNode: unknown,
+  segs: AffectedSeg[],
+  index: number,
+): boolean {
+  if (index >= segs.length) return false;
+  const next = stepAffectedSegment(
+    schemaNode,
+    dataNode,
+    segs[index],
+    index === segs.length - 1,
+  );
+  if (next === null) return false;
+  if (next.diverged) return true;
+  return checkAffectedSegments(next.schemaNode, next.dataNode, segs, index + 1);
+}
+
+type AffectedStep = {
+  readonly diverged: boolean;
+  readonly schemaNode: SelectiveSchema | undefined;
+  readonly dataNode: unknown;
+};
+
+function stepAffectedSegment(
+  schemaNode: SelectiveSchema | undefined,
+  dataNode: unknown,
+  seg: AffectedSeg | undefined,
+  last: boolean,
+): AffectedStep | null {
+  if (typeof seg === 'number') {
+    return stepIndexSegment(schemaNode, dataNode, seg);
+  }
+  return stepKeySegment(schemaNode, dataNode, seg, last);
+}
+
+function stepIndexSegment(
+  schemaNode: SelectiveSchema | undefined,
+  dataNode: unknown,
+  index: number,
+): AffectedStep | null {
+  const member = itemMemberOf(schemaNode, index);
+  if (member === undefined) return null;
+  return {
+    diverged: false,
+    schemaNode: member,
+    dataNode: isArray(dataNode) ? dataNode[index] : undefined,
+  };
+}
+
+function stepKeySegment(
+  schemaNode: SelectiveSchema | undefined,
+  dataNode: unknown,
+  seg: AffectedSeg | undefined,
+  last: boolean,
+): AffectedStep | null {
+  if (typeof seg !== 'string' || schemaNode === undefined) return null;
+  const inner = shapeInnerOf(schemaNode);
+  if (inner === null) return null;
+  if (!last) {
+    return {
+      diverged: false,
+      schemaNode: inner[seg],
+      dataNode: readDataKey(dataNode, seg),
+    };
+  }
+  return finalKeyStep(schemaNode, inner, dataNode, seg);
+}
+
+function finalKeyStep(
+  schemaNode: SelectiveSchema,
+  inner: Record<string, SelectiveSchema>,
+  dataNode: unknown,
+  seg: string,
+): AffectedStep {
+  return {
+    diverged:
+      isDivergentUnknownKey(inner, dataNode, seg) ||
+      (hasOwnProperty(inner, seg) &&
+        isPartialLikeContainer(schemaNode) &&
+        isExplicitUndefined(dataNode, seg)),
+    schemaNode: undefined,
+    dataNode: undefined,
+  };
+}
+
+function isDivergentUnknownKey(
+  inner: Record<string, SelectiveSchema>,
+  dataNode: unknown,
+  seg: string,
+): boolean {
+  return (
+    !hasOwnProperty(inner, seg) &&
+    !isUnsafeKey(seg) &&
+    isExplicitUndefined(dataNode, seg)
+  );
+}
+
+/**
+ * The declared members of a shape-like container, or null when keys are
+ * never unknown (records accept any key) or not introspectable.
+ */
+function shapeInnerOf(
+  rule: SelectiveSchema,
+): Record<string, SelectiveSchema> | null {
+  // Records accept any key, so no key is ever unknown under one.
+  if (containerKindOf(rule) === 'record') return null;
+  const inner = rule.__schema;
+  return inner && typeof inner === 'object' ? inner : null;
+}
+
+/**
+ * Own-enumerable presence with an undefined value: exactly the case the
+ * full run's own-keys iteration reports but the sentinel misses.
+ * Non-enumerable keys are absent on both sides (ownKeys skips them).
+ */
+function isExplicitUndefined(dataNode: unknown, key: string): boolean {
+  return (
+    isObject(dataNode) &&
+    Object.prototype.propertyIsEnumerable.call(dataNode, key) &&
+    (dataNode as Record<string, unknown>)[key] === undefined
+  );
+}
+
+function readDataKey(dataNode: unknown, key: string): unknown {
+  if (!isObject(dataNode)) return undefined;
+  return (dataNode as Record<string, unknown>)[key];
+}
+
+function itemMemberOf(
+  rule: SelectiveSchema | undefined,
+  index: number,
+): SelectiveSchema | undefined {
+  if (rule === undefined) return undefined;
+  const slot = symbolSlotOf(rule, ITEM_SCHEMA);
+  if (isArray(slot)) {
+    const member = slot[index];
+    return isObject(member)
+      ? (member as unknown as SelectiveSchema)
+      : undefined;
+  }
+  return isObject(slot) ? (slot as unknown as SelectiveSchema) : undefined;
+}
+
+/**
+ * Invariant: no speculative execution of user validators in the changed()
+ * path. Every projection decision below reads construction-time metadata
+ * (PARTIAL_LIKE, OPTIONAL_RULE, chain baselines, container kinds). Rules
+ * without recognizable metadata are never behaviorally probed: they take
+ * the full-schema run + result filtering fallback instead.
+ */
+
+/**
+ * Whether a shape-like container skips missing keys (partial-style
+ * optionality). Metadata-only: partial() marks itself at construction, so
+ * an all-optional shape is never mistaken for partial-like. Rules with a
+ * chain baseline were built by known combinators — an absent marker means
+ * required semantics.
+ */
+function isPartialLikeContainer(rule: SelectiveSchema): boolean {
+  if (typeof rule !== 'object' || rule === null) return false;
+  return symbolSlotOf(rule, PARTIAL_LIKE) === true;
+}
+
+/**
+ * Whether absent members of a container must be skipped during
+ * supplementation (never executed standalone). True for partial-like
+ * containers (construction marker, above) and for unknown containers (no
+ * marker and no chain baseline): the full run never evaluated the absent
+ * member, and running it standalone could invent a failure the full run
+ * never reports — the full-run verdict stands instead. Metadata-only, like
+ * above: no user code executes to decide this.
+ */
+function skipAbsentMembersOf(rule: SelectiveSchema): boolean {
+  if (typeof rule !== 'object' || rule === null) return false;
+  if (symbolSlotOf(rule, PARTIAL_LIKE) === true) return true;
+  return !hasChainBaseline(rule);
+}
+
+type SymbolSlots = Record<symbol, unknown>;
+
+function symbolSlotOf(rule: unknown, slot: symbol): unknown {
+  return (rule as unknown as SymbolSlots)[slot];
+}
+
+/**
+ * Which container flavor owns the rule's item slot, if recorded.
+ * Suffixes alone cannot distinguish records with numeric keys from
+ * arrays — the kind travels with the slot from n4s instead.
+ */
+function containerKindOf(rule: SelectiveSchema): ItemContainerKind | null {
+  const kind = symbolSlotOf(rule, ITEM_CONTAINER);
+  if (kind === 'array' || kind === 'record') {
+    return kind;
+  }
+  return null;
+}
+
+/**
+ * Whether the runtime value has the container flavor the rule declares.
+ * Guards member dispatch when schema and data disagree on the container
+ * type (e.g. array schema, object data): inventing member failures there
+ * would attribute paths the full run never produced.
+ */
+function kindValueMatches(rule: SelectiveSchema, value: unknown): boolean {
+  const kind = containerKindOf(rule);
+  if (kind === 'array') {
+    return isArray(value);
+  }
+  if (kind === 'record') {
+    return isRecordValue(value);
+  }
+  return true;
+}
+
+/**
+ * Forward changed→affected fan-out over the relationship graph. This is
+ * the single expansion of the run path: `runSchemaPaths` takes raw changed
+ * fields and expands here, so no
+ * caller pre-expands (expanding twice would compose transitively and break
+ * the pinned non-transitive contract — changed(a) runs a and b, not c).
+ *
+ * Direct dependents only (non-transitive), deduplicated, same-item for
+ * arrays: a changed path matching a relationship source pulls the
+ * relationship's targets, concretized with the changed index when
+ * possible, fanned out from run data otherwise, falling back to the
+ * top-level key when expansion is impossible (never '$item' bindings).
+ * A parent-level changed path pulls targets the same way. Schemas without
+ * graph data keep the changed names as-is. Never throws.
+ */
+function expandChangedToAffected(
+  schema: unknown,
+  affected: readonly string[] | null | undefined,
+  data: unknown,
+): readonly string[] | null {
+  if (affected == null) return null;
+  return resolveAffectedPaths(schema, affected, data);
+}
+
+/** Resolves raw changed names to the canonical, direct affected set. */
+export function resolveAffectedPaths(
+  schema: unknown,
+  changedFields: string | readonly string[],
+  data?: unknown,
+): string[] {
+  const entries = Array.isArray(changedFields)
+    ? changedFields
+    : [changedFields];
+  const changedArray = stringEntriesOf(entries).map(canonicalAffectedName);
+  if (changedArray.length === 0) return [];
+  const relationships = getSchemaRelationships(schema);
+  if (relationships.length === 0) {
+    return [...new Set(changedArray)];
+  }
+  return collectForwardTargets(changedArray, relationships, data);
+}
+
+// Non-string entries (e.g. a runtime boolean) never reach field-name
+// parsing, which would throw on them — filtered gracefully instead.
+function stringEntriesOf(entries: readonly unknown[]): string[] {
+  return entries.filter((field): field is string => typeof field === 'string');
+}
+
+function collectForwardTargets(
+  changedArray: string[],
+  relationships: SchemaRelationship[],
+  data: unknown,
+): string[] {
+  const concreteChanged = changedArray.map(field => ({
+    field,
+    path: parseAffectedFieldName(field),
+  }));
+  // Always include the changed fields themselves.
+  const affectedSet = new Set<string>(changedArray);
+  for (const rel of relationships) {
+    addMatchingTargets(rel, concreteChanged, data, affectedSet);
+  }
+  return [...affectedSet];
+}
+
+function addMatchingTargets(
+  rel: SchemaRelationship,
+  concreteChanged: { field: string; path: SchemaPath }[],
+  data: unknown,
+  affectedSet: Set<string>,
+): void {
+  for (const { path: concretePath } of concreteChanged) {
+    if (
+      concreteMatchesPattern(rel.source, concretePath) ||
+      isStrictPrefixOfPattern(rel.source, concretePath)
+    ) {
+      addConcreteTargets(rel, concretePath, data, affectedSet);
+    }
+  }
+}
+
+function getSchemaRelationships(schema: unknown): SchemaRelationship[] {
+  const describe = describeFnOf(schema);
+  if (describe === null) return [];
+  try {
+    return describe().relationships ?? [];
+  } catch {
+    // Introspection must never break a run: schemas without readable
+    // relationships keep their changed set unexpanded.
+    return [];
+  }
+}
+
+function describeFnOf(
+  schema: unknown,
+): (() => { relationships: SchemaRelationship[] }) | null {
+  if (!isObject(schema)) return null;
+  const describe = (schema as SelectiveSchema).describe;
+  return typeof describe === 'function' ? describe : null;
+}
+
+/**
+ * Whether a concrete changed path matches a source pattern where item
+ * bindings are wildcards. A pattern item covers both array indices and
+ * dynamic record keys, so it matches a concrete item as well as a
+ * concrete property (record key) at the same position.
+ */
+function concreteMatchesPattern(
+  pattern: SchemaPath,
+  concrete: SchemaPath,
+): boolean {
+  if (pattern.length !== concrete.length) return false;
+  return pattern.every((seg, index) => patternSegMatches(seg, concrete[index]));
+}
+
+/**
+ * Whether a concrete changed path is a strict parent prefix of a
+ * relationship source pattern. Item segments in the pattern act as
+ * wildcards. A parent-level changed path (e.g. 'profile' vs source
+ * [profile, country]) must pull in the relationship's targets, otherwise
+ * nested failures under the parent are silently swallowed by exact-match
+ * focus.
+ */
+function isStrictPrefixOfPattern(
+  pattern: SchemaPath,
+  concrete: SchemaPath,
+): boolean {
+  if (concrete.length === 0 || concrete.length >= pattern.length) return false;
+  return concrete.every((seg, index) => patternSegMatches(pattern[index], seg));
+}
+
+function patternSegMatches(
+  patternSeg: PropertySegment | ItemSegment | undefined,
+  concreteSeg: PropertySegment | ItemSegment,
+): boolean {
+  if (patternSeg === undefined) return false;
+  // Pattern items cover array indices and dynamic record keys alike.
+  if (patternSeg.type === 'item') return true;
+  if (concreteSeg.type === 'item') return false;
+  return patternSeg.key === concreteSeg.key;
+}
+
+/**
+ * Adds a relationship's targets to the affected set, concretized with the
+ * concrete changed source when possible. Array targets without a usable
+ * concrete index expand from run data; when expansion is impossible (no
+ * data) they fall back to the top-level key — never '$item' bindings.
+ */
+function addConcreteTargets(
+  rel: SchemaRelationship,
+  concreteSource: SchemaPath,
+  data: unknown,
+  affectedSet: Set<string>,
+): void {
+  const target = rel.target;
+  if (!target.some(seg => seg.type === 'item')) {
+    affectedSet.add(affectedPathToName(target));
+    return;
+  }
+  addItemTargets(target, rel.source, concreteSource, data, affectedSet);
+}
+
+function addItemTargets(
+  target: SchemaPath,
+  patternSource: SchemaPath,
+  concreteSource: SchemaPath,
+  data: unknown,
+  affectedSet: Set<string>,
+): void {
+  const resolved = resolveConcreteTargetItems(
+    target,
+    patternSource,
+    concreteSource,
+  );
+  if (resolved) {
+    affectedSet.add(affectedPathToName(resolved));
+    return;
+  }
+  addUnresolvedItemTargets(target, data, affectedSet);
+}
+
+function addUnresolvedItemTargets(
+  target: SchemaPath,
+  data: unknown,
+  affectedSet: Set<string>,
+): void {
+  if (isNullish(data)) {
+    const top = topLevelKeyOfChanged(target);
+    if (top) affectedSet.add(top);
+    return;
+  }
+  for (const field of expandChangedArrayTargets(target, data)) {
+    affectedSet.add(field);
+  }
+}
+
+/**
+ * Returns the top-level key of a schema path (its first property segment).
+ * Binding-free fallback when an array target cannot be expanded to
+ * concrete indices: affected names must never leak internal '$item'
+ * bindings.
+ */
+function topLevelKeyOfChanged(path: SchemaPath): string | null {
+  const [first] = path as (PropertySegment | ItemSegment)[];
+  if (first !== undefined && first.type === 'property') {
+    return String(first.key);
+  }
+  return null;
+}
+
+/**
+ * Resolves a relationship target's item segments to concrete indices taken
+ * from the concrete changed source at the same positions (same-item).
+ * Returns null when some target item has no corresponding concrete index —
+ * callers then expand from run data or fall back to the top-level key
+ * instead of emitting internal '$item' bindings.
+ */
+function resolveConcreteTargetItems(
+  patternTarget: SchemaPath,
+  patternSource: SchemaPath,
+  concreteSource: SchemaPath,
+): SchemaPath | null {
+  const segs: (PropertySegment | ItemSegment)[] = [];
+  for (let i = 0; i < patternTarget.length; i++) {
+    const targetSeg = patternTarget[i];
+    if (targetSeg === undefined) return null;
+    if (targetSeg.type !== 'item') {
+      segs.push({ ...targetSeg });
+      continue;
+    }
+    // For same-item, the item binding at the same position is shared
+    // between source and target, so copy the concrete index.
+    const resolved = resolveChangedItemBinding(
+      patternSource[i],
+      concreteSource[i],
+    );
+    if (resolved === null) return null;
+    segs.push(resolved);
+  }
+  return segs as SchemaPath;
+}
+
+function resolveChangedItemBinding(
+  sourceSeg: PropertySegment | ItemSegment | undefined,
+  concreteSeg: PropertySegment | ItemSegment | undefined,
+): (PropertySegment | ItemSegment) | null {
+  if (sourceSeg === undefined || concreteSeg === undefined) return null;
+  if (sourceSeg.type !== 'item') return null;
+  // Array indices stay items; dynamic record keys resolve to the concrete
+  // property so targets read as 'dictionary.home.state', not '$item'.
+  if (concreteSeg.type === 'item') {
+    return { type: 'item', binding: concreteSeg.binding };
+  }
+  return { ...concreteSeg };
+}
+
+/**
+ * Expands an array-item target path to all concrete indices present in
+ * data, recursively expanding every nested $item segment. Without backing
+ * data the index cannot be concretized: the branch is skipped instead of
+ * leaking internal '$item' bindings, and callers fall back to the
+ * top-level key when nothing expands.
+ */
+function expandChangedArrayTargets(
+  targetPath: SchemaPath,
+  data: unknown,
+): string[] {
+  const results: string[] = [];
+  dfsChangedTarget(targetPath, 0, data, [] as unknown as SchemaPath, results);
+  return results;
+}
+
+function dfsChangedTarget(
+  targetPath: SchemaPath,
+  pathIdx: number,
+  dataNode: unknown,
+  built: SchemaPath,
+  results: string[],
+): void {
+  if (pathIdx >= targetPath.length) {
+    results.push(affectedPathToName(built));
+    return;
+  }
+  const seg = targetPath[pathIdx];
+  if (seg === undefined) return;
+  if (isPropertySegment(seg)) {
+    const child: unknown = isObject(dataNode)
+      ? (dataNode as Record<PropertyKey, unknown>)[seg.key]
+      : undefined;
+    dfsChangedTarget(
+      targetPath,
+      pathIdx + 1,
+      child,
+      [...built, seg] as SchemaPath,
+      results,
+    );
+    return;
+  }
+  dfsChangedItem(targetPath, pathIdx, dataNode, built, results);
+}
+
+function dfsChangedItem(
+  targetPath: SchemaPath,
+  pathIdx: number,
+  dataNode: unknown,
+  built: SchemaPath,
+  results: string[],
+): void {
+  if (isArray(dataNode)) {
+    for (let i = 0; i < dataNode.length; i++) {
+      dfsChangedTarget(
+        targetPath,
+        pathIdx + 1,
+        dataNode[i],
+        [...built, { type: 'item', binding: String(i) }] as SchemaPath,
+        results,
+      );
+    }
+  } else if (isObject(dataNode)) {
+    // Item segment over a record — expand every dynamic key as a
+    // concrete property so affected names never leak '$item' bindings.
+    for (const key of Object.keys(dataNode)) {
+      dfsChangedTarget(
+        targetPath,
+        pathIdx + 1,
+        (dataNode as Record<string, unknown>)[key],
+        [...built, { type: 'property', key }] as SchemaPath,
+        results,
+      );
+    }
+  }
+}
+
+/**
+ * Per-member supplement for projection. Index-selected containers leave the
+ * main fragment (which cannot express per-index selection), so the
+ * supplement is their only execution: single-rule members run narrowed,
+ * tuple members run positionally, union members resolve whole-member
+ * matching with the full run's generic element failure. Containers report
+ * only their first failure, so an unaffected member's failure can hide the
+ * affected one after post-filtering (order-dependent, P1-3) — running each
+ * affected member keeps every affected failure visible. Members the main
+ * run already reported are not executed again (exactly-once, P1-4). The
+ * main run stays authoritative for parsed data; these results only add
+ * failures. A member that cannot run standalone (orphaned root edge) sets
+ * the gap flag so the caller falls back to the full run instead of
+ * silently omitting it.
+ */
+type ArraySupplement = {
+  results: SelectiveSchemaResult[];
+  gap: boolean;
+};
+
+/**
+ * Resolves the per-member supplement for a projected or full main run.
+ * A full run can still stop at its first failing child, so selected members
+ * beyond that boundary need supplementation. Members at or before the
+ * boundary remain authoritative and are never executed again (F4).
+ */
+function collectSupplementForMain(
+  mainRun: ProjectedMainRun,
+  schema: SelectiveSchema,
+  expanded: string[],
+  data: unknown,
+): ArraySupplement {
+  return collectArraySupplement(schema, expanded, data, mainRun);
+}
+
+function collectArraySupplement(
+  schema: SelectiveSchema,
+  expanded: string[],
+  data: unknown,
+  mainRun: ProjectedMainRun,
+): ArraySupplement {
+  const gap = { found: false };
+  try {
+    return {
+      results: collectArraySupplementInner(schema, data, {
+        expanded,
+        fullMain: mainRun.full,
+        gap,
+        main: mainRun.results,
+      }),
+      gap: gap.found,
+    };
+  } catch (error) {
+    // Best-effort augmentation only: a member fragment that cannot even
+    // project (e.g. an orphaned rooted edge at composition) must not break
+    // the run — report the gap so the caller falls back to the full run.
+    // Anything that is not a schema boundary failure stays loud.
+    if (isBoundaryError(error)) return { results: [], gap: true };
+    throw error;
+  }
+}
+
+type ArraySupplementContext = {
+  readonly expanded: readonly string[];
+  readonly fullMain: boolean;
+  readonly gap: { found: boolean };
+  readonly main: readonly SelectiveSchemaResult[];
+};
+
+function collectArraySupplementInner(
+  schema: SelectiveSchema,
+  data: unknown,
+  context: ArraySupplementContext,
+): SelectiveSchemaResult[] {
+  const topSchema = schema.__schema;
+  if (topSchema === undefined || !isObject(data) || isArray(data)) return [];
+  const out: SelectiveSchemaResult[] = [];
+  appendShapeDescendants(schema, data, {
+    suffixes: context.expanded.map(parseAffectedPath),
+    sink: {
+      basePath: [],
+      fullMain: context.fullMain,
+      gap: context.gap,
+      out,
+    },
+    main: context.main,
+  });
+  return out;
+}
+
+function childValue(data: unknown, top: string): unknown {
+  if (!isObject(data)) return undefined;
+  const record: Record<string, unknown> = data;
+  if (!hasOwnProperty(record, top)) return undefined;
+  return record[top];
+}
+
+type IndexRunSink = {
+  readonly basePath: string[];
+  out: SelectiveSchemaResult[];
+  /** Boundary gaps hit while running members standalone (→ full fallback). */
+  readonly gap: { found: boolean };
+  /** Whether the authoritative main result came from the unprojected schema. */
+  readonly fullMain: boolean;
+};
+
+type IndexSelection = {
+  readonly suffixes: AffectedSeg[][];
+  readonly sink: IndexRunSink;
+  /** Main-run failures: covered members must not execute again (P1-4). */
+  readonly main: readonly SelectiveSchemaResult[];
+};
+
+function appendSupplementalFailures(
+  rule: SelectiveSchema,
+  value: unknown,
+  selection: IndexSelection,
+): void {
+  if (tryAppendMembers(rule, value, selection)) return;
+  if (isArray(value) || !isObject(value)) return;
+  const record: Record<string, unknown> = value;
+  appendShapeDescendants(rule, record, selection);
+}
+
+function tryAppendMembers(
+  rule: SelectiveSchema,
+  value: unknown,
+  selection: IndexSelection,
+): boolean {
+  const dispatch = memberDispatch(rule);
+  if (dispatch === null) return false;
+  // The container itself failed after either rejecting its input or running
+  // a chained predicate. Its main result is authoritative for this path.
+  if (mainFailedAtPath(selection.main, selection.sink.basePath)) return true;
+  if (dispatch.kind === 'tuple') {
+    return appendTupleMembers(rule, dispatch.members, value, selection);
+  }
+  if (dispatch.kind === 'union') {
+    return appendUnionMembers(rule, dispatch.members, value, selection);
+  }
+  return appendSingleDispatch(rule, dispatch.item, value, selection);
+}
+
+function appendSingleDispatch(
+  rule: SelectiveSchema,
+  item: SelectiveSchema,
+  value: unknown,
+  selection: IndexSelection,
+): boolean {
+  if (!kindValueMatches(rule, value)) {
+    // Schema/data container contradiction: the full run reports the
+    // container's own failure here, not member failures. Reproduce it
+    // exactly with a standalone container run (merge dedupes when the main
+    // run already reported it).
+    appendContainerFailure(rule, value, selection);
+    return true;
+  }
+  if (mainExecutedWholeContainer(rule, selection)) {
+    // The main run executed every member of this kept-whole container with
+    // no failure under it: re-running affected members here would
+    // double-execute stateful validators (F3). Members the main run never
+    // reached (short-circuit shadowing) still run below (P1-3).
+    return true;
+  }
+  if (isArray(value)) {
+    return appendEachIndex(item, value, selection);
+  }
+  if (isRecordValue(value)) {
+    return appendRecordKeys(rule, item, value, selection);
+  }
+  return false;
+}
+
+/**
+ * Reproduces a container-level failure exactly (length contracts,
+ * non-array data): runs the container rule itself and attributes failures
+ * to the container path, mirroring the full run.
+ */
+function appendContainerFailure(
+  rule: SelectiveSchema,
+  value: unknown,
+  selection: IndexSelection,
+): void {
+  for (const result of prefixFailureResults(
+    safeRunItem(rule, value, selection.sink),
+    selection.sink.basePath,
+  )) {
+    selection.sink.out.push(result);
+  }
+}
+
+/**
+ * Whether the main run already reports a failure at or under the member
+ * path. Covered members must not execute again: rerunning stateful
+ * validators would change results (P1-4). The main outcome is authoritative.
+ */
+function isCoveredByMain(
+  main: readonly SelectiveSchemaResult[],
+  memberPath: string[],
+): boolean {
+  return main.some(result => {
+    if (result.pass) return false;
+    const path = result.path ?? [];
+    if (path.length < memberPath.length) return false;
+    return memberPath.every((seg, i) => String(path[i]) === seg);
+  });
+}
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return isObject(value) && !isArray(value);
+}
+
+/**
+ * Whether the main run already executed every member of this container:
+ * the projection kept it whole and reported no failure at or under its
+ * path. A kept-whole run short-circuits at the first failure, so any
+ * failure under the container means later members may never have run —
+ * those still need their supplement run (P1-3 shadowing).
+ */
+function mainExecutedWholeContainer(
+  rule: SelectiveSchema,
+  selection: IndexSelection,
+): boolean {
+  if (isCoveredByMain(selection.main, selection.sink.basePath)) return false;
+  return projectionKeptWhole(rule, selection.suffixes);
+}
+
+/**
+ * Mirrors the projection's fragment fate for one container: kept-whole
+ * (the same rule back, or null which callers also keep) means the main run
+ * executed it. Never throws — an undecidable container keeps the
+ * established per-member behavior.
+ */
+function projectionKeptWhole(
+  rule: SelectiveSchema,
+  suffixes: AffectedSeg[][],
+): boolean {
+  try {
+    const outcome = projectRule(rule, suffixes);
+    return outcome === null || outcome === rule;
+  } catch {
+    return false;
+  }
+}
+
+function appendEachIndex(
+  item: SelectiveSchema,
+  value: readonly unknown[],
+  selection: IndexSelection,
+): boolean {
+  const indices = indexHeads(selection.suffixes);
+  for (const index of indices) {
+    if (mainVisitedArrayIndex(index, selection)) continue;
+    appendSingleIndex(item, value, index, selection);
+  }
+  return indices.length > 0;
+}
+
+function appendRecordKeys(
+  rule: SelectiveSchema,
+  item: SelectiveSchema,
+  value: Record<string, unknown>,
+  selection: IndexSelection,
+): boolean {
+  const keys = keyHeads(selection.suffixes);
+  for (const key of keys) {
+    if (mainVisitedRecordKey(value, key, selection)) continue;
+    appendRecordKey({ item, key, rule, value }, selection);
+  }
+  return keys.length > 0;
+}
+
+type RecordKeyRun = {
+  readonly rule: SelectiveSchema;
+  readonly item: SelectiveSchema;
+  readonly value: Record<string, unknown>;
+  readonly key: string;
+};
+
+function appendRecordKey(entry: RecordKeyRun, selection: IndexSelection): void {
+  if (shouldRunRecordEntry(entry, selection)) {
+    runRecordKeyEntry(entry, selection);
+    return;
+  }
+  appendSingleKey(entry.item, entry.value, entry.key, selection);
+}
+
+/**
+ * Whether an affected record key runs as a single-entry whole-record run
+ * instead of the value-only flow. Only genuine records qualify (the
+ * closed-over rule carries the two-arg key rule no slot exposes), only
+ * safe keys (a computed `{[__proto__]: …}` entry would set a prototype
+ * instead of an own key), and only exact-key selections (deeper paths keep
+ * the narrowed value flow, which the entry run cannot reproduce).
+ */
+function shouldRunRecordEntry(
+  entry: RecordKeyRun,
+  selection: IndexSelection,
+): boolean {
+  return (
+    containerKindOf(entry.rule) === 'record' &&
+    !isUnsafeKey(entry.key) &&
+    isExactKeySelection(selection.suffixes, entry.key)
+  );
+}
+
+function isExactKeySelection(suffixes: AffectedSeg[][], key: string): boolean {
+  const rests = suffixesForMember(suffixes, key);
+  return rests.length > 0 && rests.every(rest => rest.length === 0);
+}
+
+/**
+ * Evaluates one affected record key with the record's own rule against a
+ * single-entry object, so a two-arg key rule violation on the affected key
+ * surfaces instead of hiding behind first-failure ordering (the supplement
+ * otherwise runs only the value rule). Entry evaluation is independent per
+ * key in n4s, and attribution matches the value flow: the record prefixes
+ * the key, the merger prefixes the container path. Replaces (never adds
+ * to) the value-only run, so stateful validators still fire exactly once.
+ */
+function runRecordKeyEntry(
+  entry: RecordKeyRun,
+  selection: IndexSelection,
+): void {
+  if (!hasOwnProperty(entry.value, entry.key)) return;
+  const child = entry.value[entry.key];
+  const memberPath = [...selection.sink.basePath, entry.key];
+  // Exactly-once like the value flow: a main-run failure here is already
+  // reported — rerunning would double-execute stateful validators.
+  if (isCoveredByMain(selection.main, memberPath)) return;
+  const outcome = safeRunItem(
+    entry.rule,
+    { [entry.key]: child },
+    selection.sink,
+  );
+  pushRecordEntryResults(outcome, entry.key, selection.sink);
+}
+
+function pushRecordEntryResults(
+  outcome: SelectiveSchemaResult[],
+  key: string,
+  sink: IndexRunSink,
+): void {
+  for (const result of prefixFailureResults(outcome, sink.basePath)) {
+    if (!result.pass) {
+      sink.out.push(result);
+      continue;
+    }
+    pushRecordEntryPass(result, key, sink);
+  }
+}
+
+/**
+ * Unwraps a passing single-entry result to its entry value so the F5
+ * coercion fold places the coerced value (not the single-entry object) at
+ * the member path. Entries the key rule renamed have no affected-path
+ * home, so they contribute no patch — the fragment keeps its raw value.
+ */
+function pushRecordEntryPass(
+  result: SelectiveSchemaResult,
+  key: string,
+  sink: IndexRunSink,
+): void {
+  const entryValue = recordEntryValue(result.type, key);
+  if (entryValue === undefined) {
+    sink.out.push({ pass: result.pass, path: result.path });
+    return;
+  }
+  sink.out.push({ ...result, type: entryValue });
+}
+
+function recordEntryValue(type: unknown, key: string): unknown {
+  if (!isObject(type)) return undefined;
+  const parsed = type as Record<string, unknown>;
+  if (!hasOwnProperty(parsed, key)) return undefined;
+  return parsed[key];
+}
+
+function appendShapeDescendants(
+  rule: SelectiveSchema,
+  value: Record<string, unknown>,
+  selection: IndexSelection,
+): void {
+  const context = shapeDescendantContext(rule, selection);
+  if (context === null) return;
+  const keys = Object.keys(context.inner);
+  const failedIndex =
+    context.failedKey === null ? -1 : keys.indexOf(context.failedKey);
+  for (let index = 0; index < keys.length; index += 1) {
+    appendSelectedShapeDescendant({
+      context,
+      failedIndex,
+      index,
+      key: keys[index],
+      selection,
+      value,
+    });
+  }
+}
+
+type ShapeDescendantContext = {
+  readonly skipAbsent: boolean;
+  readonly byKey: Map<string, AffectedSeg[][]>;
+  readonly failedKey: string | null;
+  readonly inner: Record<string, SelectiveSchema>;
+};
+
+function shapeDescendantContext(
+  rule: SelectiveSchema,
+  selection: IndexSelection,
+): ShapeDescendantContext | null {
+  const inner = rule.__schema;
+  if (inner === undefined) return null;
+  const byKey = groupAffectedByChildKey(inner, selection.suffixes);
+  if (byKey === null) return null;
+  // An object-container failure at this exact path comes from a predicate
+  // chained after the shape evaluator; every child already ran successfully.
+  if (mainFailedAtPath(selection.main, selection.sink.basePath)) return null;
+  const failedKey = failedChildKey(inner, selection);
+  // A full main run already executed every reachable member. Supplement it
+  // only when its single failure identifies a short-circuit boundary.
+  if (fullMainWithoutFailureBoundary(selection, failedKey)) return null;
+  // Absent-member knowledge for shadowed members from the parent's
+  // metadata: a partial-like parent never evaluates missing keys, so an
+  // absent member past the boundary is valid-absent, not a shadowed
+  // failure. Unknown parents skip absent members too — the full-run
+  // verdict stands instead of inventing failures.
+  return { byKey, failedKey, inner, skipAbsent: skipAbsentMembersOf(rule) };
+}
+
+function fullMainWithoutFailureBoundary(
+  selection: IndexSelection,
+  failedKey: string | null,
+): boolean {
+  return selection.sink.fullMain && failedKey === null;
+}
+
+type ShapeDescendantRun = {
+  readonly context: ShapeDescendantContext;
+  readonly failedIndex: number;
+  readonly index: number;
+  readonly key: string;
+  readonly selection: IndexSelection;
+  readonly value: Record<string, unknown>;
+};
+
+function appendSelectedShapeDescendant(run: ShapeDescendantRun): void {
+  const { context, failedIndex, index, key, selection, value } = run;
+  const rests = context.byKey.get(key);
+  if (rests === undefined) return;
+  if (memberPrecedesFailure(index, failedIndex)) return;
+  const childSelection: IndexSelection = {
+    suffixes: rests,
+    sink: {
+      basePath: [...selection.sink.basePath, key],
+      fullMain: selection.sink.fullMain,
+      gap: selection.sink.gap,
+      out: selection.sink.out,
+    },
+    main: selection.main,
+  };
+  if (memberFollowsFailure(index, failedIndex)) {
+    if (isAbsentPartialMember(context, value, key)) return;
+    appendShadowedShapeMember(context.inner[key], value, key, childSelection);
+    return;
+  }
+  appendSupplementalFailures(context.inner[key], value[key], childSelection);
+}
+
+/**
+ * A member absent from a partial-like (or unknown) parent was never
+ * evaluated by the main run: running it standalone would invent a failure
+ * the full run never reports. Present members — including
+ * explicit-undefined ones, which container iteration evaluates — always
+ * run, as do absent members of required containers (genuinely invalid).
+ */
+function isAbsentPartialMember(
+  context: ShapeDescendantContext,
+  value: Record<string, unknown>,
+  key: string,
+): boolean {
+  return context.skipAbsent && !isPresentKey(value, key);
+}
+
+function memberPrecedesFailure(index: number, failedIndex: number): boolean {
+  return failedIndex >= 0 && index < failedIndex;
+}
+
+function memberFollowsFailure(index: number, failedIndex: number): boolean {
+  return failedIndex >= 0 && index > failedIndex;
+}
+
+function mainFailedAtPath(
+  main: readonly SelectiveSchemaResult[],
+  path: readonly string[],
+): boolean {
+  const failures = main.filter(result => !result.pass);
+  if (failures.length !== 1) return false;
+  const failurePath = failures[0].path ?? [];
+  return (
+    failurePath.length === path.length &&
+    path.every((segment, index) => String(failurePath[index]) === segment)
+  );
+}
+
+/**
+ * Returns the immediate child whose failure stopped this shape, when the
+ * main run proves that later siblings were never executed. Failure paths are
+ * already rebased to the root, so the current sink path locates the relevant
+ * segment at any nesting depth.
+ */
+function failedChildKey(
+  inner: Record<string, SelectiveSchema>,
+  selection: IndexSelection,
+): string | null {
+  const key = failedDescendantHead(selection);
+  if (key === null) return null;
+  return hasOwnProperty(inner, key) ? key : null;
+}
+
+function failedDescendantHead(selection: IndexSelection): string | null {
+  const failures = selection.main.filter(result => !result.pass);
+  if (failures.length !== 1) return null;
+  const path = failures[0].path ?? [];
+  const base = selection.sink.basePath;
+  if (path.length <= base.length) return null;
+  if (!base.every((segment, index) => String(path[index]) === segment)) {
+    return null;
+  }
+  return String(path[base.length]);
+}
+
+/** Members through the failing array position were already visited. */
+function mainVisitedArrayIndex(
+  index: number,
+  selection: IndexSelection,
+): boolean {
+  const head = failedDescendantHead(selection);
+  if (head === null || !/^(0|[1-9]\d*)$/.test(head)) return false;
+  const failedIndex = Number(head);
+  return Number.isSafeInteger(failedIndex) && index <= failedIndex;
+}
+
+/** Record iteration follows own-key order and stops at its failing entry. */
+function mainVisitedRecordKey(
+  value: Record<string, unknown>,
+  key: string,
+  selection: IndexSelection,
+): boolean {
+  const failedKey = failedDescendantHead(selection);
+  if (failedKey === null) return false;
+  const keys = Object.keys(value);
+  const failedIndex = keys.indexOf(failedKey);
+  const selectedIndex = keys.indexOf(key);
+  return failedIndex >= 0 && selectedIndex >= 0 && selectedIndex <= failedIndex;
+}
+
+/**
+ * Runs one selected shape member that lies strictly after the main run's
+ * first failing sibling. This is not a duplicate: n4s shape containers stop
+ * at that sibling. Nested projected containers and coercions use the same
+ * member path as array supplementation.
+ */
+function appendShadowedShapeMember(
+  rule: SelectiveSchema,
+  value: Record<string, unknown>,
+  key: string,
+  selection: IndexSelection,
+): void {
+  const child = hasOwnProperty(value, key) ? value[key] : undefined;
+  const narrowed = projectRule(rule, selection.suffixes);
+  // This member is now its own projected run. Descendant supplementation
+  // must reason from that local outcome, not the earlier full-root failure.
+  const sink: IndexRunSink = { ...selection.sink, fullMain: false };
+  if (narrowed === FRAGMENT_EXCLUDED) {
+    tryAppendMembers(rule, child, { ...selection, sink });
+    return;
+  }
+  runProjectedMember(narrowed ?? rule, child, selection.suffixes, sink);
+}
+
+type MemberDispatch =
+  | { kind: 'single'; item: SelectiveSchema }
+  | { kind: 'tuple'; members: SelectiveSchema[] }
+  | { kind: 'union'; members: SelectiveSchema[] };
+
+/**
+ * Classifies a rule's item slot for per-member execution. Tuples carry a
+ * positional member list under a kindless slot; unions carry their member
+ * list under kind 'array'; records and single-rule arrays carry one member.
+ */
+function memberDispatch(rule: SelectiveSchema): MemberDispatch | null {
+  const slot = symbolSlotOf(rule, ITEM_SCHEMA);
+  if (isArray(slot)) {
+    const members = asMemberRules(slot);
+    if (members.length === 0) return null;
+    if (containerKindOf(rule) === 'array') {
+      return { kind: 'union', members };
+    }
+    return { kind: 'tuple', members };
+  }
+  if (!isObject(slot)) return null;
+  return { kind: 'single', item: slot as unknown as SelectiveSchema };
+}
+
+function asMemberRules(slot: readonly unknown[]): SelectiveSchema[] {
+  const members: SelectiveSchema[] = [];
+  for (const entry of slot) {
+    if (isObject(entry)) {
+      members.push(entry as unknown as SelectiveSchema);
+    }
+  }
+  return members;
+}
+
+/**
+ * Tuple members run positionally: member i validates element i with the
+ * same index-prefixed attribution the full run produces, so an affected
+ * member's failure surfaces even when an earlier member failed first
+ * (P1-3). Length mismatches reproduce the full run's container-level
+ * failure instead — positions are meaningless without a valid length.
+ */
+function appendTupleMembers(
+  rule: SelectiveSchema,
+  members: SelectiveSchema[],
+  value: unknown,
+  selection: IndexSelection,
+): boolean {
+  if (!isArray(value)) {
+    appendContainerFailure(rule, value, selection);
+    return true;
+  }
+  if (!tupleLengthOk(members, value)) {
+    appendContainerFailure(rule, value, selection);
+    return true;
+  }
+  return appendTupleIndices(rule, members, value, selection);
+}
+
+function appendTupleIndices(
+  rule: SelectiveSchema,
+  members: SelectiveSchema[],
+  value: readonly unknown[],
+  selection: IndexSelection,
+): boolean {
+  const indices = indexHeads(selection.suffixes);
+  for (const index of indices) {
+    if (mainVisitedArrayIndex(index, selection)) continue;
+    if (index >= value.length) continue;
+    const member = members[index];
+    if (member === undefined) {
+      // Unknown flavor (a union read as positional): reproduce the
+      // container's own verdict exactly instead of inventing attribution.
+      appendContainerFailure(rule, value, selection);
+      break;
+    }
+    appendSingleIndex(member, value, index, selection);
+  }
+  return indices.length > 0;
+}
+
+/**
+ * The tuple length contract holds exactly when no required position is
+ * missing: every position past the value end must be optional-marked.
+ * Markers (not behavioral probes) decide — introspection executes nothing.
+ */
+function tupleLengthOk(
+  members: readonly SelectiveSchema[],
+  value: readonly unknown[],
+): boolean {
+  if (value.length > members.length) return false;
+  for (let i = value.length; i < members.length; i += 1) {
+    if (symbolSlotOf(members[i], OPTIONAL_RULE) !== true) return false;
+  }
+  return true;
+}
+
+/**
+ * Union members resolve whole-member matching: narrowing a member for the
+ * verdict would admit elements the full run rejects. An element matching
+ * no member reproduces the full run's generic element failure (P1-3).
+ */
+function appendUnionMembers(
+  rule: SelectiveSchema,
+  members: SelectiveSchema[],
+  value: unknown,
+  selection: IndexSelection,
+): boolean {
+  if (!isArray(value)) {
+    appendContainerFailure(rule, value, selection);
+    return true;
+  }
+  const indices = indexHeads(selection.suffixes);
+  for (const index of indices) {
+    if (mainVisitedArrayIndex(index, selection)) continue;
+    appendUnionElement(members, value, index, selection);
+  }
+  return indices.length > 0;
+}
+
+function appendUnionElement(
+  members: SelectiveSchema[],
+  value: readonly unknown[],
+  index: number,
+  selection: IndexSelection,
+): void {
+  if (index >= value.length) return;
+  const child = value[index];
+  const memberPath = [...selection.sink.basePath, String(index)];
+  if (isCoveredByMain(selection.main, memberPath)) return;
+  // Union membership is whole-member by semantics: narrowing a member for
+  // the verdict would admit elements the full run rejects. An element
+  // matching no member reproduces the full run's generic element failure.
+  if (unionElementRejected(members, child, selection.sink)) {
+    selection.sink.out.push({ pass: false, type: child, path: memberPath });
+  }
+}
+
+function unionElementRejected(
+  members: SelectiveSchema[],
+  child: unknown,
+  sink: IndexRunSink,
+): boolean {
+  for (const member of members) {
+    const results = safeRunItem(member, child, sink);
+    if (results.every(result => result.pass)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function indexHeads(suffixes: AffectedSeg[][]): number[] {
+  const indices = new Set<number>();
+  for (const suffix of suffixes) {
+    const head = suffix[0];
+    if (typeof head === 'number') indices.add(head);
+  }
+  return [...indices];
+}
+
+function keyHeads(suffixes: AffectedSeg[][]): string[] {
+  const keys = new Set<string>();
+  for (const suffix of suffixes) {
+    addKeyHead(suffix[0], keys);
+  }
+  return [...keys];
+}
+
+/**
+ * Record keys are strings at runtime, but affected paths coerce numeric
+ * segments to numbers (`parseAffectedPath`). Accept both spellings so
+ * numeric record keys ('0', '1') dispatch to their member like other keys.
+ */
+function addKeyHead(head: AffectedSeg, keys: Set<string>): void {
+  if (typeof head === 'string') {
+    keys.add(head);
+    return;
+  }
+  if (typeof head === 'number') {
+    keys.add(String(head));
+  }
+}
+
+function appendSingleIndex(
+  item: SelectiveSchema,
+  value: readonly unknown[],
+  index: number,
+  selection: IndexSelection,
+): void {
+  // isArrayOf/tuple validate every position below length, including sparse
+  // holes and explicit undefined values. Only an index beyond the runtime
+  // array is absent and must be ignored.
+  if (index >= value.length) return;
+  appendSingleMember(item, value[index], selection, index);
+}
+
+function appendSingleKey(
+  item: SelectiveSchema,
+  value: Record<string, unknown>,
+  key: string,
+  selection: IndexSelection,
+): void {
+  // Records validate own entries only. Preserve explicit undefined values;
+  // unlike an absent key, record() would run its value rule for them.
+  if (!hasOwnProperty(value, key)) return;
+  appendSingleMember(item, value[key], selection, key);
+}
+
+function appendSingleMember(
+  item: SelectiveSchema,
+  child: unknown,
+  selection: IndexSelection,
+  head: string | number,
+): void {
+  const memberPath = [...selection.sink.basePath, String(head)];
+  // Exactly-once: the main run's outcome for this member is authoritative —
+  // rerunning it would double-execute stateful validators (P1-4).
+  if (isCoveredByMain(selection.main, memberPath)) return;
+  const itemSuffixes = suffixesForMember(selection.suffixes, head);
+  const narrowed = projectRule(item, itemSuffixes);
+  const sink: IndexRunSink = {
+    basePath: memberPath,
+    fullMain: false,
+    gap: selection.sink.gap,
+    out: selection.sink.out,
+  };
+  if (narrowed === FRAGMENT_EXCLUDED) {
+    // Nested index-selected container: descend into its own members instead
+    // of running it whole (same selective-execution rule, one level down).
+    tryAppendMembers(item, child, {
+      suffixes: itemSuffixes,
+      sink,
+      main: selection.main,
+    });
+    return;
+  }
+  runProjectedMember(narrowed ?? item, child, itemSuffixes, sink);
+}
+
+function runProjectedMember(
+  projected: SelectiveSchema,
+  child: unknown,
+  itemSuffixes: AffectedSeg[][],
+  sink: IndexRunSink,
+): void {
+  // No container-kind guard here: the member rule runs against the same
+  // element the full run would reach (isArrayOf prefixes the member index
+  // onto inner failures, so attribution already matches), and shadowed
+  // members the full run never reaches are exactly what the supplement is
+  // for. Contradicting container-vs-data dispatch is guarded one level up
+  // in tryAppendMembers instead.
+  const localResults = prefixFailureResults(
+    safeRunItem(projected, child, sink),
+    sink.basePath,
+  );
+  for (const result of localResults) {
+    sink.out.push(result);
+  }
+  appendSupplementalFailures(projected, child, {
+    suffixes: itemSuffixes,
+    sink,
+    main: localResults,
+  });
+}
+
+function suffixesForMember(
+  suffixes: AffectedSeg[][],
+  head: string | number,
+): AffectedSeg[][] {
+  const out: AffectedSeg[][] = [];
+  for (const suffix of suffixes) {
+    if (headMatches(suffix[0], head)) out.push(suffix.slice(1));
+  }
+  return out;
+}
+
+/**
+ * Matches a suffix head against a member key across the numeric coercion:
+ * affected paths spell record key '1' as number 1, runtime data keeps '1'.
+ */
+function headMatches(suffixHead: AffectedSeg, head: string | number): boolean {
+  if (suffixHead === head) return true;
+  return (
+    typeof head === 'string' &&
+    typeof suffixHead === 'number' &&
+    String(suffixHead) === head
+  );
+}
+
+function safeRunItem(
+  rule: SelectiveSchema,
+  value: unknown,
+  sink: IndexRunSink,
+): SelectiveSchemaResult[] {
+  try {
+    return runExecutableSchema(rule, value);
+  } catch (error) {
+    // A standalone member run can orphan a $.root edge that only composes
+    // in the full schema. Record the gap so the caller falls back to the
+    // full run instead of silently omitting the affected member.
+    if (isBoundaryError(error)) {
+      sink.gap.found = true;
+      return [];
+    }
+    throw error;
+  }
+}
+
+/**
+ * Re-bases supplement results to their member path. Failures carry the
+ * verdict signal; passing entries are kept for their coerced `type` so the
+ * merger can fold excluded-member coercions into the fragment's parsed
+ * output (F5). Passing entries never become standalone results — the merger
+ * folds their types into the main parsed value and drops them.
+ */
+function prefixFailureResults(
+  results: SelectiveSchemaResult[],
+  path: string[],
+): SelectiveSchemaResult[] {
+  const out: SelectiveSchemaResult[] = [];
+  for (const result of results) {
+    out.push({ ...result, path: [...path, ...(result.path ?? [])] });
+  }
+  return out;
+}
+
+/**
+ * Merges per-member supplement failures into the main run results,
+ * skipping entries that duplicate a main-run failure. Keys stay
+ * structured (path segments, never re-joined) so dotted record keys
+ * cannot collide with nested paths during deduplication. Passing
+ * supplement entries are not appended: their coerced types are folded
+ * into the main parsed value instead (F5), so excluded members keep
+ * full-run coercion parity on passing runs.
+ */
+export function mergeSupplementalResults(
+  main: SelectiveSchemaResult[],
+  extra: SelectiveSchemaResult[],
+): SelectiveSchemaResult[] {
+  if (extra.length === 0) return main;
+  const base = withSupplementCoercions(main, extra);
+  const seen = new Set(base.map(resultKey));
+  const out = [...base];
+  appendUniqueFailures(out, seen, extra);
+  return out;
+}
+
+function appendUniqueFailures(
+  out: SelectiveSchemaResult[],
+  seen: Set<string>,
+  extra: SelectiveSchemaResult[],
+): void {
+  for (const result of extra) {
+    if (result.pass) {
+      continue;
+    }
+    const key = resultKey(result);
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(result);
+    }
+  }
+}
+
+type CoercionPatch = {
+  readonly path: readonly string[];
+  readonly value: unknown;
+};
+
+/**
+ * Folds passing supplement member types (coerced values) into the main
+ * parsed value. The fragment's pass-through output is a raw shallow copy,
+ * so without this the excluded members would read uncoerced. Returns the
+ * input untouched when no passing member carries a type.
+ */
+function withSupplementCoercions(
+  main: SelectiveSchemaResult[],
+  extra: SelectiveSchemaResult[],
+): SelectiveSchemaResult[] {
+  const patches = coercionPatchesOf(extra);
+  if (patches.length === 0) return main;
+  const [first, ...rest] = main;
+  if (isNullish(first)) return main;
+  return [
+    { ...first, type: applyCoercionPatches(first.type, patches) },
+    ...rest,
+  ];
+}
+
+function coercionPatchesOf(extra: SelectiveSchemaResult[]): CoercionPatch[] {
+  const patches: CoercionPatch[] = [];
+  for (const result of extra) {
+    if (isCoercionPatch(result)) {
+      patches.push({ path: result.path, value: result.type });
+    }
+  }
+  return patches;
+}
+
+/**
+ * A passing member result placed at a concrete path, carrying its own
+ * coerced type. Failing runs ignore parsed output (raw input fallback),
+ * so only placement and type ownership matter here.
+ */
+function isCoercionPatch(
+  result: SelectiveSchemaResult,
+): result is SelectiveSchemaResult & { path: readonly string[] } {
+  return (
+    result.pass &&
+    hasOwnProperty(result, 'type') &&
+    !isNullish(result.path) &&
+    result.path.length > 0
+  );
+}
+
+function applyCoercionPatches(
+  base: unknown,
+  patches: CoercionPatch[],
+): unknown {
+  let out = base;
+  for (const patch of patches) {
+    out = setPathValue(out, patch.path, patch.value);
+  }
+  return out;
+}
+
+function setPathValue(
+  base: unknown,
+  path: readonly string[],
+  value: unknown,
+): unknown {
+  const [head, ...tail] = path;
+  if (isNullish(head)) return value;
+  if (tail.length === 0) return setChildValue(base, head, value);
+  return setChildValue(
+    base,
+    head,
+    setPathValue(readChildValue(base, head), tail, value),
+  );
+}
+
+function setChildValue(base: unknown, head: string, value: unknown): unknown {
+  if (isArray(base)) {
+    return isArrayIndex(head) ? setArrayChild(base, head, value) : base;
+  }
+  return setRecordChild(base, head, value);
+}
+
+function setArrayChild(
+  base: unknown[],
+  head: string,
+  value: unknown,
+): unknown[] {
+  const out = [...base];
+  out[Number(head)] = value;
+  return out;
+}
+
+function setRecordChild(
+  base: unknown,
+  head: string,
+  value: unknown,
+): Record<string, unknown> {
+  if (isObject(base)) {
+    const record: Record<string, unknown> = base;
+    return { ...record, [head]: value };
+  }
+  return { [head]: value };
+}
+
+function readChildValue(base: unknown, head: string): unknown {
+  if (isArray(base) && isArrayIndex(head)) {
+    return base[Number(head)];
+  }
+  if (!isObject(base)) {
+    return undefined;
+  }
+  const record: Record<string, unknown> = base;
+  if (!hasOwnProperty(record, head)) {
+    return undefined;
+  }
+  return record[head];
+}
+
+function isArrayIndex(head: string): boolean {
+  return /^\d+$/.test(head);
+}
+
+function resultKey(result: SelectiveSchemaResult): string {
+  // Paths stay structured (never re-joined) so dotted record keys cannot
+  // collide with nested paths when deduplicating merged results.
+  return `${result.pass}|${JSON.stringify(result.path ?? [])}|${result.message ?? ''}`;
+}
+
+/**
+ * Builds a schema limited to the affected subtrees so unrelated validators
+ * never execute during a nested changed() run. Top-level keys outside the
+ * affected set are dropped; nested shape containers are rebuilt with only
+ * the affected child keys; index-selected array/tuple/union containers
+ * leave the fragment for the per-member supplement (which executes each
+ * affected member exactly once), and a pass-through fragment is returned
+ * when every affected subtree runs there. Returns null when nothing is
+ * projectable, in which case the caller falls back to the full schema run
+ * with post-filter.
+ */
+export function buildProjectedSchema(
+  schema: SelectiveSchema,
+  affected: readonly string[],
+): SelectiveSchema | null {
+  try {
+    return buildProjectedSchemaInner(schema, affected);
+  } catch {
+    // A fragment that cannot compose (e.g. a nested array rebuild orphaning
+    // a source) is unprojectable — the caller falls back to the full run.
+    return null;
+  }
+}
+
+function buildProjectedSchemaInner(
+  schema: SelectiveSchema,
+  affected: readonly string[],
+): SelectiveSchema | null {
+  const topSchema = introspectableTopSchema(schema);
+  if (topSchema === null) return null;
+
+  const byTop = groupAffectedByTopKey(topSchema, affected);
+  if (byTop.size === 0) return null;
+
+  const { projectedTop, excluded } = projectTopSchema(topSchema, byTop);
+  if (Object.keys(projectedTop).length > 0) {
+    const projected = projectedTopRule(schema, projectedTop);
+    if (!projected) return null;
+    return preserveOptionality(schema, projected);
+  }
+  return passThroughFragment(schema, excluded);
+}
+
+/**
+ * The introspectable top-level shape, or null when the top container cannot
+ * be rebuilt. Partial containers are representable as a loose shape whose
+ * selected members are optional; a moved chain is not, because rebuilding
+ * would lose its container validators.
+ */
+function introspectableTopSchema(
+  schema: SelectiveSchema,
+): Record<string, SelectiveSchema> | null {
+  const topSchema = schema?.__schema;
+  if (!topSchema || typeof topSchema !== 'object') return null;
+  if (!topContainerRebuildable(schema)) return null;
+  return topSchema;
+}
+
+function topContainerRebuildable(schema: SelectiveSchema): boolean {
+  return chainBaselineMatches(schema);
+}
+
+/**
+ * Pass-through fragment for when every affected subtree runs in the
+ * supplement: executes nothing but parses data through, so the main run
+ * stays authoritative for parsed data without executing unaffected
+ * validators (P1-4).
+ */
+function passThroughFragment(
+  schema: SelectiveSchema,
+  excluded: number,
+): SelectiveSchema | null {
+  if (excluded === 0) return null;
+  try {
+    return preserveOptionality(schema, looseRule({}));
+  } catch {
+    return null;
+  }
+}
+
+function projectedTopRule(
+  original: SelectiveSchema,
+  projectedTop: Record<string, SelectiveSchema>,
+): SelectiveSchema | null {
+  if (Object.keys(projectedTop).length === 0) return null;
+  try {
+    return rebuildShapeContainer(original, projectedTop);
+  } catch {
+    // Unprojectable fragment (e.g. an orphaned dependsOn source at the top
+    // level): fall back to the full schema run with post-filter.
+    return null;
+  }
+}
+
+function groupAffectedByTopKey(
+  topSchema: Record<string, SelectiveSchema>,
+  affected: readonly string[],
+): Map<string, AffectedSeg[][]> {
+  const byTop = new Map<string, AffectedSeg[][]>();
+  for (const field of affected) {
+    appendTopGroup(byTop, topSchema, parseAffectedPath(field));
+  }
+  return byTop;
+}
+
+function appendTopGroup(
+  byTop: Map<string, AffectedSeg[][]>,
+  topSchema: Record<string, SelectiveSchema>,
+  segs: AffectedSeg[],
+): void {
+  if (segs.length === 0) return;
+  const [top, ...rest] = segs as [AffectedSeg, ...AffectedSeg[]];
+  if (typeof top !== 'string') return;
+  // Unknown keys stay grouped: the fragment retains them as extra-key
+  // sentinels so a strict shape() failure the full run reports is not lost.
+  // Unsafe unknown keys are still dropped: a sentinel cannot sit in a
+  // plain-object fragment (prototype setter instead of an own key).
+  if (isUnsafeUnknownKey(topSchema, top)) return;
+  const list = byTop.get(top) ?? [];
+  list.push(rest);
+  byTop.set(top, list);
+}
+
+function isUnsafeUnknownKey(
+  topSchema: Record<string, SelectiveSchema>,
+  key: string,
+): boolean {
+  return !hasOwnProperty(topSchema, key) && isUnsafeKey(key);
+}
+
+/**
+ * projectRule outcome for containers the per-member supplement executes
+ * instead of the fragment (arrays/tuples/unions with index selections):
+ * executing them in the main run would run unaffected members and run
+ * affected members twice (P1-4). Callers drop the key; the supplement
+ * covers exactly the selected members.
+ */
+const FRAGMENT_EXCLUDED: unique symbol = Symbol('vest:fragmentExcluded');
+
+function projectTopSchema(
+  topSchema: Record<string, SelectiveSchema>,
+  byTop: Map<string, AffectedSeg[][]>,
+): {
+  projectedTop: Record<string, SelectiveSchema>;
+  excluded: number;
+} {
+  const projectedTop: Record<string, SelectiveSchema> = {};
+  let excluded = 0;
+  for (const top of Object.keys(topSchema)) {
+    const outcome = projectTopKey(topSchema[top], byTop.get(top));
+    if (outcome === FRAGMENT_EXCLUDED) {
+      excluded += 1;
+    } else if (outcome !== undefined) {
+      projectedTop[top] = outcome;
+    }
+  }
+  appendUnknownTopKeys(topSchema, byTop, projectedTop);
+  return { projectedTop, excluded };
+}
+
+function appendUnknownTopKeys(
+  topSchema: Record<string, SelectiveSchema>,
+  byTop: Map<string, AffectedSeg[][]>,
+  projectedTop: Record<string, SelectiveSchema>,
+): void {
+  for (const top of byTop.keys()) {
+    if (!hasOwnProperty(topSchema, top)) {
+      projectedTop[top] = unknownExtraKeyRule();
+    }
+  }
+}
+
+/**
+ * Sentinel for an affected key the schema does not declare. It fails exactly
+ * when the key is present with a value (mirroring a strict shape()
+ * extra-key failure, whose path is the key itself) and passes when the key
+ * is absent, so the post-filter — not the fragment — keeps deciding
+ * affectedness. Value-only rules cannot distinguish absent from
+ * explicitly-undefined, so that remaining case never reaches the fragment:
+ * `hasExplicitUndefinedUnknownKey` diverts it to the full-run fallback.
+ */
+function unknownExtraKeyRule(): SelectiveSchema {
+  return enforceLazy.condition((value: unknown) => value === undefined);
+}
+
+/**
+ * One top-level key's fragment fate: undefined drops an unrelated key,
+ * the rule keeps an exact-selected or un-narrowed subtree, and
+ * FRAGMENT_EXCLUDED leaves supplement-covered containers out.
+ */
+function projectTopKey(
+  rule: SelectiveSchema,
+  rests: AffectedSeg[][] | undefined,
+): SelectiveSchema | undefined | typeof FRAGMENT_EXCLUDED {
+  // Unrelated top-level subtree: dropped so it cannot hide failures.
+  if (rests === undefined) return undefined;
+  // Exact-selected (e.g. parent changed path itself): keep whole subtree.
+  if (rests.some(rest => rest.length === 0)) return rule;
+  const projected = projectRule(rule, rests);
+  return projected ?? rule;
+}
+
+/**
+ * Narrows a nested rule to the given child suffixes. Returns the original
+ * rule when nothing can (or needs to) be narrowed, null only when the shape
+ * is not introspectable — both tell the caller to keep the original rule.
+ * Returns FRAGMENT_EXCLUDED for containers the supplement executes instead
+ * of the fragment — callers drop the key.
+ */
+function projectRule(
+  rule: SelectiveSchema,
+  suffixes: AffectedSeg[][],
+): SelectiveSchema | null | typeof FRAGMENT_EXCLUDED {
+  const inner = rule?.__schema;
+  if (inner && typeof inner === 'object') {
+    return projectShapeRule(rule, inner, suffixes);
+  }
+  return projectItemRule(rule, suffixes);
+}
+
+function projectItemRule(
+  rule: SelectiveSchema,
+  suffixes: AffectedSeg[][],
+): SelectiveSchema | null | typeof FRAGMENT_EXCLUDED {
+  // A moved chain means container-level validators a rebuild would drop —
+  // retain the whole rule (full-run parity).
+  if (!chainBaselineMatches(rule)) return rule;
+  const itemSchema = symbolSlotOf(rule, ITEM_SCHEMA);
+  if (isArray(itemSchema)) {
+    // Tuple (positional members, kindless slot) and union (kind 'array')
+    // members run per-index in the supplement with exact attribution
+    // (P1-3). Index selections leave the fragment so unaffected members
+    // never execute and affected members execute exactly once (P1-4);
+    // anything else keeps the whole rule.
+    return indexSelectionsOnly(suffixes) ? FRAGMENT_EXCLUDED : rule;
+  }
+  if (!isObject(itemSchema)) return null;
+  return projectArrayRule(rule, suffixes);
+}
+
+/**
+ * Whether every affected suffix selects specific members by index. Whole
+ * selections (empty suffix) and non-index heads keep the container whole.
+ */
+function indexSelectionsOnly(suffixes: AffectedSeg[][]): boolean {
+  return (
+    suffixes.length > 0 &&
+    suffixes.every(suffix => suffix.length > 0 && typeof suffix[0] === 'number')
+  );
+}
+
+function projectShapeRule(
+  rule: SelectiveSchema,
+  inner: Record<string, SelectiveSchema>,
+  suffixes: AffectedSeg[][],
+): SelectiveSchema | null {
+  const byKey = groupAffectedByChildKey(inner, suffixes);
+  if (!byKey || byKey.size === 0) return null;
+
+  const filtered = projectShapeChildren(inner, byKey);
+  if (isUnchangedShape(inner, filtered)) return rule;
+  return rebuildShapeRule(rule, filtered);
+}
+
+/**
+ * Rebuilds a narrowed shape fragment. Partial semantics are represented by
+ * optionalizing each retained member inside a loose container: missing
+ * selected keys pass while unrelated original keys remain accepted. A moved
+ * chain still cannot be rebuilt because its container validators are private
+ * to the original rule.
+ */
+function rebuildShapeRule(
+  rule: SelectiveSchema,
+  filtered: Record<string, SelectiveSchema>,
+): SelectiveSchema | null {
+  if (!chainBaselineMatches(rule)) return rule;
+  try {
+    return preserveOptionality(rule, rebuildShapeContainer(rule, filtered));
+  } catch {
+    // A narrowed fragment can orphan a dependsOn source (e.g. taxId needs
+    // its sibling country): rebuilding then throws. Keep the whole subtree —
+    // today's full-run behavior — instead of breaking the run.
+    return rule;
+  }
+}
+
+function projectShapeChildren(
+  inner: Record<string, SelectiveSchema>,
+  byKey: Map<string, AffectedSeg[][]>,
+): Record<string, SelectiveSchema> {
+  const filtered: Record<string, SelectiveSchema> = {};
+  for (const key of Object.keys(inner)) {
+    const outcome = projectTopKey(inner[key], byKey.get(key));
+    // Supplement-covered containers leave the fragment (P1-4). An emptied
+    // shape still rebuilds as loose({}) below, keeping the key present so
+    // parsed data keeps its structure.
+    if (outcome === FRAGMENT_EXCLUDED) continue;
+    if (outcome !== undefined) filtered[key] = outcome;
+  }
+  appendUnknownChildKeys(inner, byKey, filtered);
+  return filtered;
+}
+
+function appendUnknownChildKeys(
+  inner: Record<string, SelectiveSchema>,
+  byKey: Map<string, AffectedSeg[][]>,
+  filtered: Record<string, SelectiveSchema>,
+): void {
+  for (const key of byKey.keys()) {
+    if (!hasOwnProperty(inner, key)) {
+      filtered[key] = unknownExtraKeyRule();
+    }
+  }
+}
+
+function isUnchangedShape(
+  inner: Record<string, SelectiveSchema>,
+  filtered: Record<string, SelectiveSchema>,
+): boolean {
+  const filteredKeys = Object.keys(filtered);
+  return (
+    filteredKeys.length === Object.keys(inner).length &&
+    filteredKeys.every(key => filtered[key] === inner[key])
+  );
+}
+
+function groupAffectedByChildKey(
+  inner: Record<string, SelectiveSchema>,
+  suffixes: AffectedSeg[][],
+): Map<string, AffectedSeg[][]> | null {
+  const byKey = new Map<string, AffectedSeg[][]>();
+  for (const suffix of suffixes) {
+    if (!appendChildGroup(byKey, inner, suffix)) return null;
+  }
+  return byKey;
+}
+
+function appendChildGroup(
+  byKey: Map<string, AffectedSeg[][]>,
+  inner: Record<string, SelectiveSchema>,
+  suffix: AffectedSeg[],
+): boolean {
+  const [head, ...rest] = suffix as [AffectedSeg, ...AffectedSeg[]];
+  if (typeof head !== 'string') return false;
+  // Unknown keys stay grouped so nested fragments retain their extra-key
+  // sentinels. Unsafe ones keep the whole rule instead: a sentinel cannot
+  // sit in a plain-object fragment (prototype setter, not an own key).
+  if (!hasOwnProperty(inner, head) && isUnsafeKey(head)) return false;
+  const list = byKey.get(head) ?? [];
+  list.push(rest);
+  byKey.set(head, list);
+  return true;
+}
+
+/**
+ * Decides an array rule's fragment fate. Per-index selections leave the
+ * fragment (FRAGMENT_EXCLUDED): isArrayOf validates every member with one
+ * rule, so keeping it would execute unaffected members, and the per-member
+ * supplement already executes each affected member exactly once (P1-4).
+ * Records always keep the full rule: narrowing through record() would drop
+ * a two-arg record's key rule (n4s exposes only the value rule in the item
+ * slot), breaking parity with the full run. Whole-item and non-index
+ * selections keep the container whole. Member failures still surface via
+ * the per-member supplement.
+ */
+type LooseCombinator = (
+  schema: Record<string, SelectiveSchema>,
+) => SelectiveSchema;
+
+const looseRule = enforceLazy.loose as unknown as LooseCombinator;
+
+type OptionalCombinator = (inner: SelectiveSchema) => SelectiveSchema;
+
+const optionalRule = enforceLazy.optional as unknown as OptionalCombinator;
+
+function rebuildShapeContainer(
+  original: SelectiveSchema,
+  filtered: Record<string, SelectiveSchema>,
+): SelectiveSchema {
+  return looseRule(
+    isPartialLikeContainer(original) ? optionalizeMembers(filtered) : filtered,
+  );
+}
+
+function optionalizeMembers(
+  members: Record<string, SelectiveSchema>,
+): Record<string, SelectiveSchema> {
+  const optionalized: Record<string, SelectiveSchema> = {};
+  for (const key of Object.keys(members)) {
+    optionalized[key] = optionalRule(members[key]);
+  }
+  return optionalized;
+}
+
+function projectArrayRule(
+  rule: SelectiveSchema,
+  suffixes: AffectedSeg[][],
+): SelectiveSchema | null | typeof FRAGMENT_EXCLUDED {
+  if (containerKindOf(rule) === 'record') return rule;
+  if (!indexSelectionsOnly(suffixes)) return rule;
+  return FRAGMENT_EXCLUDED;
+}
+
+/**
+ * Preserves optional-wrapped containers across projection: a rebuilt loose
+ * rule would fail on nullish values that the original optional rule passes.
+ */
+function preserveOptionality(
+  original: SelectiveSchema,
+  rebuilt: SelectiveSchema,
+): SelectiveSchema {
+  if (!isNullishPassing(original)) return rebuilt;
+  return optionalRule(rebuilt);
+}
+
+/**
+ * Whether a rule passes nullish values (optional-style). Metadata-only:
+ * optional() marks itself at construction; every other known combinator
+ * carries a chain baseline with no marker (required semantics), and
+ * unknown rules without a marker are treated as required so a rebuilt
+ * fragment never gains nullish acceptance the original lacks. No user
+ * code executes to decide this.
+ */
+function isNullishPassing(rule: SelectiveSchema): boolean {
+  return symbolSlotOf(rule, OPTIONAL_RULE) === true;
+}
+
+/**
+ * Narrows full-schema run results to failures under the affected changed paths.
+ * Passing entries are preserved; root failures (no path) are kept since they
+ * affect every field. A failure is kept on exact match or when either side is
+ * a parent path of the other (affected 'profile' keeps failures at
+ * 'profile.state', and a failure at 'profile' is relevant to 'profile.state').
+ */
+export function filterSchemaResultsToAffected(
+  results: SelectiveSchemaResult[],
+  affected: readonly string[],
+  data: unknown,
+  skip: string[] | true | null = null,
+): SelectiveSchemaResult[] {
+  if (skip === true) {
+    // Boolean skip-all (skip(true)): every synthesized failure is skipped,
+    // mirroring the runtime which skips all tests — including the
+    // schema-failure tests. Same pass-through as the empty-kept path.
+    return passThroughResult(results, data);
+  }
+  const affectedSet = new Set(affected.map(canonicalAffectedName));
+  const skipSet = skipSetOf(skip);
+  const kept = results.filter(result =>
+    keepSchemaResult(result, affectedSet, skipSet),
+  );
+  return keptOrPassThrough(kept, results, data);
+}
+
+function keptOrPassThrough(
+  kept: SelectiveSchemaResult[],
+  results: SelectiveSchemaResult[],
+  data: unknown,
+): SelectiveSchemaResult[] {
+  if (kept.length > 0) {
+    return kept;
+  }
+  return passThroughResult(results, data);
+}
+
+function passThroughResult(
+  results: SelectiveSchemaResult[],
+  data: unknown,
+): SelectiveSchemaResult[] {
+  // A fabricated pass carries the surviving parsed output — the first
+  // passing entry's type — or the raw input when nothing passed. Reading
+  // results[0] unconditionally would leak a filtered-out failure's
+  // partially-coerced type as if it were parsed output.
+  return [
+    { pass: true, type: results.find(result => result.pass)?.type ?? data },
+  ];
+}
+
+function skipSetOf(skip: string[] | null): Set<string> {
+  // Raw entries only: the runtime matches skip() against user-test names
+  // exactly (no normalization), so normalizing here would drop synthesized
+  // failures the full run still reports (nested skips are no-ops in
+  // omit()). Canonicalization stays on the affected-matching side only.
+  return new Set(skip ?? []);
+}
+
+function keepSchemaResult(
+  result: SelectiveSchemaResult,
+  affectedSet: Set<string>,
+  skipSet: Set<string>,
+): boolean {
+  return !isSkippedName(result, skipSet) && isAffectedName(result, affectedSet);
+}
+
+/**
+ * Skip matching mirrors the runtime exactly: suite `skip()` applies to
+ * user tests by exact field name, so synthesized failures drop only on
+ * exact raw match — `skip('items[0]')` does not suppress a dotted
+ * 'items.0' synthesis, exactly as it would not skip a test named
+ * 'items.0'. Pathless failures are never skipped (they read as global).
+ */
+function isSkippedName(
+  result: SelectiveSchemaResult,
+  skipSet: Set<string>,
+): boolean {
+  if (result.pass || skipSet.size === 0) {
+    return false;
+  }
+  const failureName = (result.path ?? []).map(String).join('.');
+  if (!failureName) {
+    return false;
+  }
+  return skipSet.has(failureName);
+}
+
+/**
+ * Affected matching keeps string semantics (exact or parent either way):
+ * both sides already speak dotted strings, so numeric coercions compare
+ * equal and dotted record keys keep the historical keep-behavior rather
+ * than going silently clean. Dedupe collisions for dotted keys are handled
+ * separately via structured result keys.
+ */
+function isAffectedName(
+  result: SelectiveSchemaResult,
+  affectedSet: Set<string>,
+): boolean {
+  if (result.pass) {
+    return true;
+  }
+  const failureName = (result.path ?? []).map(String).join('.');
+  if (!failureName) {
+    return true;
+  }
+  return affectedSetHas(affectedSet, failureName);
+}
+
+function affectedSetHas(
+  affectedSet: Set<string>,
+  failureName: string,
+): boolean {
+  for (const name of affectedSet) {
+    if (name === failureName || isEitherPrefix(name, failureName)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isEitherPrefix(first: string, second: string): boolean {
+  return first.startsWith(`${second}.`) || second.startsWith(`${first}.`);
+}
+
+const N4S_VENDOR = 'n4s';
+
+/**
+ * Any n4s-produced rule (shape-rooted or a root container): failure paths
+ * from these runs speak the affected-path vocabulary, so post-filtering by
+ * affected/skip applies. Custom standard-schema results do not.
+ */
+function isN4sVendorSchema(schema: unknown): boolean {
+  if (!isObject(schema)) return false;
+  return schema['~standard']?.vendor === N4S_VENDOR;
+}
+
+/**
+ * Shape-rooted n4s schemas only. pick/omit focus and fragment projection
+ * both traverse __schema top-level keys, so root containers (array/record
+ * roots) run unfocused and filter afterward instead.
+ */
+function isN4sSchema(schema: unknown): boolean {
+  return (
+    isN4sVendorSchema(schema) &&
+    (schema as SelectiveSchema)?.__schema !== undefined
+  );
+}
+
+/**
+ * Intersects the caller-computed affected set with the `only` inclusion
+ * focus: `only` narrows execution and is never silently dropped. A nullish
+ * `only` leaves the affected set untouched (plain changed() runs); an
+ * explicit empty `only` runs nothing. Matching is parent-either-way on
+ * canonical dotted names, mirroring result filtering: `only: 'profile'`
+ * keeps `profile.state`, and `only: 'profile.state'` keeps `profile`.
+ */
+function intersectAffectedWithOnly(
+  affected: readonly string[] | null | undefined,
+  only: readonly string[] | null,
+): readonly string[] | null {
+  if (affected == null || only == null) return affected ?? null;
+  if (only.length === 0) return [];
+  const onlyNames = only.map(canonicalAffectedName);
+  return affected.filter(field =>
+    onlyNames.some(name =>
+      focusSelectsName(name, canonicalAffectedName(field)),
+    ),
+  );
+}
+
+function focusSelectsName(onlyName: string, field: string): boolean {
+  return (
+    onlyName === field ||
+    onlyName.startsWith(`${field}.`) ||
+    field.startsWith(`${onlyName}.`)
+  );
+}
+
+function applySchemaFocus(
+  schema: SelectiveSchema,
+  modifiers: FocusModifiers,
+): SelectiveSchema {
+  // Root-container n4s schemas run unfocused here (pick/omit need __schema
+  // keys); runFlatSchema still narrows their failures by affected path.
+  if (!isN4sSchema(schema)) {
+    return schema;
+  }
+
+  const only = buildArrayProp(modifiers.only);
+  const skip = buildArrayProp(modifiers.skip);
+
+  return buildFocusedSchemaInstance(schema, only, skip);
+}
+
+function buildArrayProp(
+  prop: string | readonly string[] | boolean | null | undefined,
+): string[] | null {
+  if (!prop) return null;
+  // An explicitly empty array is a zero-field focus (e.g. changed([])):
+  // keep it so the schema resolves to an empty pick instead of no focus.
+  // Non-string entries never reach name matching: asArray(true) is [true]
+  // and name normalization would throw on it (boolean skip-all is a legal
+  // modifier, handled as match-all by buildSkipFilter instead).
+  // Copy readonly arrays: asArray only accepts mutable element lists.
+  const list = Array.isArray(prop) ? [...prop] : prop;
+  return asArray(list).filter(
+    (entry): entry is string => typeof entry === 'string',
+  );
+}
+
+/**
+ * Skip filter for synthesized failures. Boolean skip-all (skip(true))
+ * drops every failure, mirroring the runtime which skips all tests;
+ * name lists narrow by exact field name via buildArrayProp.
+ */
+function buildSkipFilter(
+  skipProp: string | readonly string[] | boolean | null | undefined,
+): string[] | true | null {
+  if (skipProp === true) return true;
+  return buildArrayProp(skipProp);
+}
+
+function buildIntersectedSchemaInstance(
+  schema: SelectiveSchema,
+  only: string[],
+  skip: string[],
+): SelectiveSchema {
+  const skipSet = new Set(skip);
+  const members = (schema.__schema ?? {}) as unknown as Record<
+    string,
+    SchemaMemberRule
+  >;
+  const picked = enforceLazy.pick(
+    members,
+    only.filter(f => !skipSet.has(f)),
+  );
+  return picked as unknown as SelectiveSchema;
+}
+
+function buildFocusedSchemaInstance(
+  schema: SelectiveSchema,
+  only: string[] | null,
+  skip: string[] | null,
+): SelectiveSchema {
+  const members = (schema.__schema ?? {}) as unknown as Record<
+    string,
+    SchemaMemberRule
+  >;
+  if (only) {
+    return skip
+      ? buildIntersectedSchemaInstance(schema, only, skip)
+      : (enforceLazy.pick(members, only) as unknown as SelectiveSchema);
+  }
+
+  return skip
+    ? (enforceLazy.omit(members, skip) as unknown as SelectiveSchema)
+    : schema;
+}
+
+/**
+ * Converts unknown schema.run return value into a stable internal representation.
+ */
+function normalizeSelectiveSchemaResult(
+  candidate: unknown,
+  fallbackType: unknown,
+): SelectiveSchemaResult[] {
+  if (isArray(candidate)) {
+    return candidate.map(entry =>
+      normalizeSingleSelectiveSchemaResult(entry, fallbackType),
+    );
+  }
+
+  return [normalizeSingleSelectiveSchemaResult(candidate, fallbackType)];
+}
+
+/**
+ * Converts a single unknown run payload into a safe result shape.
+ */
+function normalizeSingleSelectiveSchemaResult(
+  candidate: unknown,
+  fallbackType: unknown,
+): SelectiveSchemaResult {
+  if (!isSelectiveSchemaResult(candidate)) {
+    return {
+      pass: false,
+      type: fallbackType,
+    };
+  }
+
+  return {
+    message: candidate.message,
+    pass: candidate.pass,
+    path: candidate.path,
+    type: candidate.type ?? fallbackType,
+  };
+}
+
+/**
+ * Runtime type guard for schema run payloads.
+ */
+function isSelectiveSchemaResult(
+  candidate: unknown,
+): candidate is SelectiveSchemaResult {
+  if (!isObject(candidate)) {
+    return false;
+  }
+
+  const value = candidate as Partial<SelectiveSchemaResult>;
+
+  const hasPass = typeof value.pass === 'boolean';
+  const hasPath =
+    value.path === undefined ||
+    (isArray(value.path) && value.path.every(item => typeof item === 'string'));
+
+  return hasPass && hasPath;
+}
+
+/**
+ * Detects parse errors that represent genuine validation failures (the
+ * foreign-parse fallback path only — n4s rules report failures via
+ * `validate` issues and never reach here). Only validation-marked errors
+ * take the fallback: a bare TypeError is a programming error (buggy
+ * validator, broken getter) and stays loud instead of being hidden behind
+ * a run-again pass.
+ */
+function isExpectedSchemaParseError(error: unknown): boolean {
+  if (error instanceof EnforceSchemaError) return true;
+  if (!isObject(error)) return false;
+  const typedError = error as { isValidation?: unknown; name?: unknown };
+  return (
+    typedError.isValidation === true || typedError.name === 'EnforceSchemaError'
+  );
+}
+
+/**
+ * Determines whether schema.run should execute after a successful parse call.
+ *
+ * For n4s StandardSchema-backed rules, parse already performs full validation.
+ * Re-running run(parsed) can break coercion chains where post-parse types differ
+ * from pre-parse input expectations.
+ */
+function shouldRunAfterParse(schema: SelectiveSchema): boolean {
+  if (!isFunction(schema.run)) {
+    return false;
+  }
+
+  const standard = schema as unknown as {
+    '~standard'?: { vendor?: unknown };
+  };
+  return standard['~standard']?.vendor !== N4S_VENDOR;
+}

--- a/packages/n4s/src/utils/RuleInstance.ts
+++ b/packages/n4s/src/utils/RuleInstance.ts
@@ -1,6 +1,61 @@
 import { StandardSchemaV1 } from 'vest-utils/standardSchemaSpec';
 
+import type { FIELD } from '../schema/scopeProxy';
+import type { SchemaPath } from '../schema/SchemaPath';
+import { RESOLVED_RELATIONSHIPS, UNRESOLVED_DEPS } from '../schema/schemaSlots';
+import type {
+  InternalRelationship,
+  SchemaDependency,
+  SchemaRelationship,
+} from '../schema/SchemaRelationship';
+
 import { RuleRunReturn } from './RuleRunReturn';
+
+export interface ScopeHandle {
+  readonly root: ScopeHandle;
+  [FIELD]: (fieldName: string) => ScopeHandle;
+  [key: string]: ScopeHandle;
+  [key: symbol]: unknown;
+}
+
+export type DescribeResult = {
+  dependencies: SchemaDependency[];
+  relationships: SchemaRelationship[];
+};
+
+export function clonePath(path: SchemaPath): SchemaPath {
+  return path.map(seg => ({ ...seg }));
+}
+
+export function cloneRelationship(
+  rel: InternalRelationship,
+): SchemaRelationship {
+  return {
+    ...(rel.metadata ? { metadata: { ...rel.metadata } } : {}),
+    effect: rel.effect,
+    source: clonePath(rel.source),
+    target: clonePath(rel.target),
+  };
+}
+
+export function groupDependencies(
+  resolved: SchemaRelationship[],
+): SchemaDependency[] {
+  const depMap = new Map<
+    string,
+    { target: SchemaPath; sources: SchemaPath[] }
+  >();
+  for (const rel of resolved) {
+    const key = JSON.stringify(rel.target);
+    let dep = depMap.get(key);
+    if (!dep) {
+      dep = { target: clonePath(rel.target), sources: [] };
+      depMap.set(key, dep);
+    }
+    dep.sources.push(clonePath(rel.source));
+  }
+  return Array.from(depMap.values());
+}
 
 /**
  * Represents a lazy validation rule that can be executed with a value.
@@ -56,6 +111,9 @@ export class RuleInstance<T, Args extends any[] = any[]> {
     readonly types: StandardSchemaV1.Types<Args[0], T>;
   };
 
+  dependsOn!: (resolver: (scope: ScopeHandle) => unknown) => this;
+  describe!: () => DescribeResult;
+
   private constructor() {}
 
   /**
@@ -69,11 +127,12 @@ export class RuleInstance<T, Args extends any[] = any[]> {
   static create<R extends RuleInstance<T, Args>, T, Args extends any[]>(
     rule: (...args: Args) => RuleRunReturn<T>,
   ): R {
+    const unresolvedDeps: Array<{
+      resolver: (scope: ScopeHandle) => unknown;
+    }> = [];
     const validate = (...args: Args): StandardSchemaV1.Result<T> => {
       const result = rule(...args);
-      if (result.pass) {
-        return { value: result.type };
-      }
+      if (result.pass) return { value: result.type };
       return {
         issues: [
           {
@@ -84,22 +143,16 @@ export class RuleInstance<T, Args extends any[] = any[]> {
       };
     };
 
-    // Internal compatibility method - wraps validate and converts result back
-    const run = (...args: Args): RuleRunReturn<T> => {
-      return rule(...args);
-    };
+    const run = (...args: Args): RuleRunReturn<T> => rule(...args);
 
     const parse = (...args: Args): T => {
       const result = validate(...args);
-      if (!result.issues) {
-        return result.value;
-      }
-
+      if (!result.issues) return result.value;
       const [firstIssue] = result.issues;
       throw new TypeError(firstIssue?.message || 'Validation failed');
     };
 
-    return {
+    const instance = {
       '~standard': {
         types: {
           input: undefined as unknown as Args[0],
@@ -117,6 +170,35 @@ export class RuleInstance<T, Args extends any[] = any[]> {
         return !result.issues;
       },
       validate,
-    } as unknown as R;
+    } as unknown as R & {
+      dependsOn: (resolver: (scope: ScopeHandle) => unknown) => R;
+      describe: () => DescribeResult;
+    };
+
+    const dependsOn = (resolver: (scope: ScopeHandle) => unknown): R => {
+      unresolvedDeps.push({ resolver });
+      (instance as unknown as Record<symbol, unknown>)[UNRESOLVED_DEPS] =
+        unresolvedDeps;
+      return instance as unknown as R;
+    };
+
+    const describe = (): DescribeResult => {
+      const raw =
+        ((instance as unknown as Record<symbol, unknown>)[
+          RESOLVED_RELATIONSHIPS
+        ] as InternalRelationship[]) || [];
+      const resolved: SchemaRelationship[] = raw.map(cloneRelationship);
+      return {
+        dependencies: groupDependencies(resolved),
+        relationships: resolved,
+      };
+    };
+
+    (instance as unknown as Record<string, unknown>).dependsOn = dependsOn;
+    (instance as unknown as Record<string, unknown>).describe = describe;
+    (instance as unknown as Record<symbol, unknown>)[UNRESOLVED_DEPS] =
+      unresolvedDeps;
+
+    return instance as unknown as R;
   }
 }

--- a/packages/vest/bench/SCHEMA_RELATIONSHIPS_DESIGN.md
+++ b/packages/vest/bench/SCHEMA_RELATIONSHIPS_DESIGN.md
@@ -1,0 +1,494 @@
+# Benchmark Design — Schema Relationships (`dependsOn` + `suite.changed()`)
+
+> **Status:** Implemented — `packages/vest/bench/schema-relationships.bench.ts` and `packages/vest/bench/granular/schema-relationships-changed.bench.ts` (49 rows) shipped with RFC rev2 V1.
+> **Author:** Benchmark Designer (workflow child parallel-4)
+> **Date:** 2026-09-02
+> **Scope:** Proposal for `packages/vest/bench/` (primary) + optional `packages/n4s/bench/` leaf
+
+---
+
+## 1 — Discovery — What Exists Today
+
+### 1.1 No top-level `benchmarks/` folder
+
+```
+ls /Users/ealush/Code/vest/benchmarks  →  No such file or directory
+ls /Users/ealush/Code/vest/packages/*/benchmark*  →  only packages/vest/bench
+```
+
+All benchmarks live in **`packages/vest/bench/`** (17 files + `granular/` subfolder with 7 more). `packages/n4s` has no bench folder at all.
+
+### 1.2 Runner = `vitest bench` (tinybench under the hood)
+
+| Layer      | Detail                                                                                                                                                                                                                                                          |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Engine     | `vitest@4.0.18` `bench()` / `describe()` — wraps `tinybench@2.9.0` (found in `node_modules/tinybench` + `.yarn/cache/tinybench-…zip`)                                                                                                                           |
+| Config     | Root `vitest.config.ts` + per-package `packages/vest/vitest.config.ts` (`include: packages/**/__tests__/*.test.ts`) — bench discovery is via CLI flag, not include glob                                                                                         |
+| CLI        | `yarn vitest bench --run --config packages/vest/vitest.config.ts --passWithNoTests --no-color "<file>"` (see `vx/scripts/benchmark-reporter.ts:runBenchmarkFile`)                                                                                               |
+| npm script | `packages/vest/package.json → "bench": "vitest bench --run --config ./vitest.config.ts"` and root `package.json → "bench": "npx tsx vx/scripts/benchmark-reporter.ts --update"`                                                                                 |
+| CI         | `.github/workflows/benchmark.yml` — PR-triggered interlaced run: builds `latest` baseline vs PR, runs `npx tsx vx/scripts/benchmark-reporter.ts --interlace .benchmark-baseline`, posts diff table to `benchmark-results.md` (current file: 74 lines, 60+ rows) |
+| Parser     | `benchmark-reporter.ts:parseOutput` regex `· <name> <hz> … <p99> ±<rme>% <samples>` — extracts `hz` (ops/sec), `p99` (ms), `rme` (margin of error)                                                                                                              |
+| Diff logic | `calculateDiffs` — suppresses diff if `\|Δ%\| < max(5, rme%)`                                                                                                                                                                                                   |
+
+No `benchmark.js`, no `vitest bench --reporter=json` customisation, no separate `bench.config.ts`. Adding one is out of scope — reuse existing harness.
+
+### 1.3 Existing bench pattern (what to copy)
+
+```ts
+// packages/vest/bench/suite-focus.bench.ts — canonical shape
+import { bench, describe } from 'vitest';
+import { create, enforce, group, test } from '../src/vest';
+
+// Suite created ONCE at module scope, pre-warmed with .run() if stateful
+const focusSuite = create(() => {
+  group('g', () => {
+    test('f', () => enforce(1).equals(1));
+  });
+});
+
+describe('suite.focus modifiers', () => {
+  bench(
+    'no focus modifiers',
+    () => {
+      focusSuite.run();
+    },
+    { time: 150, iterations: 15 },
+  );
+  bench(
+    'onlyGroup: limit to one group',
+    () => {
+      focusSuite.focus({ onlyGroup: 'g' }).run();
+    },
+    { time: 150, iterations: 15 },
+  );
+});
+```
+
+Granular benches live in `bench/granular/*.bench.ts` and import from `../../src/vest` with same API.
+
+Common timing knobs observed:
+
+| Knob                              | Typical value                                                    | When used                                                     |
+| --------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------- |
+| `time`                            | `150` (fast focus), `250` (matrix), `1000` (field-volume stress) | total bench budget ms                                         |
+| `iterations`                      | `15` (focus), `5`/`3`/`2` (heavy nesting)                        | samples                                                       |
+| `warmupTime` / `warmupIterations` | `50` / `1`                                                       | only for very heavy nesting (`nesting-fields-hooks.bench.ts`) |
+| `runSuiteTimes(suite, N)` helper  | loop `N` runs per `bench()` iteration                            | amortise tiny suites                                          |
+
+Suites pre-populate state outside `bench()` (e.g. `suite.run(list100)` before describe) so reordering/retain/error-survival semantics are realistic.
+
+### 1.4 Domain to benchmark — where it came from
+
+The new functionality spans two packages:
+
+- **n4s** — `enforce.shape({ field: enforce.isString().dependsOn($ => $.other) })` + `describe()` metadata + rebasing (nested reuse, `isArrayOf($item)`, `$.root`, 3-level nesting, cyclic, bracket keys, `loose`/`partial` notes). Evidence: `packages/n4s/src/__tests__/schemaRelationships*.test.ts` (4 files, ~218 + composition + interaction + acceptance-10), `packages/n4s/src/schema/{SchemaRelationship,SchemaPath,dependencyResolver,rebase,scopeProxy}.ts`.
+- **vest** — `suite.changed('field')` incremental re-run (merge gate, deduped affected set = changed + direct dependents, non-transitive, same-item array scoping, reusable-nested isolation, async, `skipWhen`/`only` authority). Evidence: `packages/vest/src/suite/changed.ts`, `packages/vest/src/suite/__tests__/changed.integration.test.ts` (13 cases), `schemaRelationships.suite.test.ts` (V1 `only()` does NOT auto-expand).
+
+The prompt's "23-list" has no single canonical file; it is the union of: 10 acceptance cases (RFC rev2) + 13 changed-integration cases = 23. Composition/interaction files add variants but collapse to the same 23. This design maps every bench row back to that 23.
+
+---
+
+## 2 — Goals & Non-Goals
+
+**Prove (must):**
+
+1. `changed('field')` is **minimal** — runs only changed + direct dependents, not the whole suite. Not a rebrand of `run()`. Needs side-by-side rate comparison vs `run()` and `only()`.
+2. **No regression** — `describe()` and schema creation with relationships is not materially slower than without them (`describe()` is a cold metadata read, creation is one-time).
+3. **Scale** — nested (3-level), reusable (billing+shipping shared schema), array same-item (100 travelers), multi-dependent fan-out, 10→1000-field volume, all stay proportionate.
+
+**Not doing:**
+
+- Correctness assertions inside bench (count of ran fields) beyond a smoke guard — correctness is the test files' job. Bench proves throughput; a tiny `if (log.length !== expected) throw` is okay as a guard but not as the primary check.
+- `benchmark.js` / `tinybench` direct import — stay on `vitest bench` so CI parser works unchanged.
+- Copying baseline output files by hand — reporter generates `benchmark-results.md`; we just add rows.
+
+---
+
+## 3 — Proposed File Structure
+
+### 3.1 One new top-level bench file + one granular file (preferred)
+
+```
+packages/vest/bench/
+├── SCHEMA_RELATIONSHIPS_DESIGN.md        ← this file
+├── schema-relationships.bench.ts         ← NEW — primary (n4s + suite)
+└── granular/
+    └── schema-relationships-changed.bench.ts  ← NEW — deep changed() matrix (optional split)
+```
+
+Rationale:
+
+- Single top-level file keeps discovery trivial for `benchmark-reporter.ts:getBenchFiles` (recursive readdir of `packages/vest/bench` picks up both). Splitting is for ergonomics if the file exceeds ~500 lines.
+- `packages/n4s/bench/` is **not** needed — n4s schema creation is exercised via vest suites (the real cost is in suite integration, not n4s alone). A lone n4s micro-bench (schema creation + `describe()`) lives as the first `describe` in the same file and imports from `n4s` directly, avoiding a second bench harness.
+- If n4s later wants standalone bench, add `packages/n4s/bench/schema-relationships.bench.ts` with `vitest --config packages/n4s/vitest.config.ts` — no duplication needed now.
+
+### 3.2 Alternative considered and rejected
+
+| Alternative                                                                  | Why rejected                                                                                                  |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `benchmarks/` at repo root                                                   | Repo convention is package-scoped bench; root would need new vitest workspace entry + reporter patch          |
+| One bench file per topology (flat.bench.ts, nested.bench.ts, array.bench.ts) | 4 files for 23 cases fragments CI table and duplicates helpers — one file with 4 `describe` groups is clearer |
+| Doing it in `feature-matrix.bench.ts`                                        | That file is at capacity (4131 bytes, approve-matrix + flow suites); relationships deserve isolated reporting |
+
+### 3.3 File imports & scope setup
+
+```ts
+// packages/vest/bench/schema-relationships.bench.ts
+import { bench, describe } from 'vitest';
+import {
+  create,
+  test,
+  enforce,
+  group,
+  skipWhen,
+  only,
+  skip,
+} from '../src/vest';
+import { enforce as n4sEnforce } from '../../n4s/src/n4s'; // for pure schema-creation benches
+import { each } from '../src/isolates/each';
+import { TFieldName, TGroupName } from '../src/suiteResult/SuiteResultTypes';
+```
+
+Create shared helpers once:
+
+```ts
+function makeLog() {
+  const a: string[] = [];
+  return {
+    push(s: string) {
+      a.push(s);
+    },
+    reset() {
+      a.length = 0;
+    },
+    snap() {
+      return [...a];
+    },
+  };
+}
+const travelers = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    country: 'US',
+    passportNumber: `P${i}`,
+  }));
+```
+
+---
+
+## 4 — Metric Contract — What to Measure and How
+
+### 4.1 Primary metrics (what reporter already captures)
+
+| Metric                             | Source                                             | Unit          | Why                                                                                              |
+| ---------------------------------- | -------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------ |
+| **ops/sec (Hz)**                   | `tinybench` `hz` — parsed by `resultRegex` group 2 | higher=better | Main comparison vs baseline; PR diff table uses this for `Diff (Abs)` / `Diff (%)`               |
+| **rme (relative margin of error)** | `±X%` group 4                                      | lower=better  | Gate: if `\|Δ%\| < max(5, rme)` diff is masked to 0 — so keep `rme` low or accept 5% noise floor |
+| **p99 (ms)**                       | column 3 → `p99`                                   | lower=better  | Tail latency; important for 1000-field stress                                                    |
+| **samples**                        | trailing number in bench line                      | —             | Diagnostics only; reporter drops it                                                              |
+
+We do **not** need to invent throughput-counting; `tinybench` already counts inner `bench()` iterations per `time` budget. Ensure each `bench()` body is non-trivial (≥1 `suite.run()`) so `hz` is meaningful.
+
+### 4.2 vitest bench knobs to use
+
+| Scenario                                                            | `time` | `iterations` | `warmup*`                           | Notes                                                              |
+| ------------------------------------------------------------------- | ------ | ------------ | ----------------------------------- | ------------------------------------------------------------------ |
+| Fast path (flat, nested shallow, describe)                          | `150`  | `15`         | default                             | Matches `suite-focus.bench.ts` / `focus-filters.bench.ts`          |
+| Medium (reusable 2×, array 10, fan-out)                             | `250`  | `10`         | default                             | Matches `feature-matrix.bench.ts`                                  |
+| Heavy (array 100, 3-level nesting, 500–1000 fields, realistic flow) | `1000` | `3`          | `warmupTime:50, warmupIterations:1` | Matches `stress-fields.bench.ts` / `nesting-fields-hooks.bench.ts` |
+| Micro (schema creation, describe serialisation)                     | `200`  | `20`         | default                             | Creation is cheap — more iterations needed for stable hz           |
+
+### 4.3 Assertions inside bench (light)
+
+- A `beforeAll` smoke-run checks `log` length (minimality) once; bench bodies **do not** assert per-iteration (would pollute timing). Example:
+
+```ts
+// one-time guard, not inside bench()
+{
+  const g = makeLog();
+  const s = makeSuite(g);
+  await s.run(baseData);
+  g.reset();
+  await s.changed('password').run(nextData);
+  if (g.snap().length !== 2)
+    throw new Error('changed() minimality broken — bench would be meaningless');
+}
+```
+
+---
+
+## 5 — Scenario Matrix — Every Required Bench Row
+
+Rows are ordered to tell a story: (A) schema cost → (B) describe cost → (C) suite run modes comparison → (D) full 23-list integration. Each row maps to its source case.
+
+### 5.1 Group A — Schema creation with relationships (n4s isolated)
+
+`describe 'Schema creation — with vs without relationships'`
+
+| #   | Bench name                                     | What it does                                                                                                                | Knob        | Maps to                                 |
+| --- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------- | --------------------------------------- |
+| A1  | `create flat (no rel)`                         | `enforce.shape({ a: isString(), b: isString() })`                                                                           | micro       | baseline                                |
+| A2  | `create flat with dependsOn`                   | same + `b: isString().dependsOn($=>$.a)`                                                                                    | micro       | acceptance-1, flat-scenarios            |
+| A3  | _(removed — `revalidates` deferred out of V1)_ | —                                                                                                                           | —           | —                                       |
+| A4  | `create flat with multi-source`                | `total: isNumber().dependsOn($=>[%.quantity, %.unitPrice, %.currency])`                                                     | micro       | dependsOn multi-source test             |
+| A5  | `create nested (3 levels) with rebase`         | `outer{ middle{ inner{ zip dependsOn city }}}` — 3-level rebase cost                                                        | micro       | composition three-level                 |
+| A6  | `create reusable (shared address ×2)`          | `address={country,state dependsOn country}; checkout={billing:address,shipping:address}` — purity check (child not mutated) | micro       | composition reusable, acceptance-3      |
+| A7  | `create array same-item (one traveler)`        | `travelers: isArrayOf(traveler{ passportNumber dependsOn passportCountry })` — single $item binding                         | micro       | composition array item, acceptance-4    |
+| A8  | `create $.root escape`                         | `company.taxId dependsOn [$.country, $.root.accountType]`                                                                   | micro       | composition $.root, acceptance-5/8      |
+| A9  | `create nested arrays (orders→items)`          | `orders: isArrayOf(order{ items: isArrayOf(item{ discount dependsOn name }) })` — 2× $item bindings                         | micro       | composition nested arrays, acceptance-6 |
+| A10 | `create cyclic (2-node)`                       | `start dependsOn end, end dependsOn start` — legal                                                                          | micro       | acceptance-7                            |
+| A11 | `create fan-out (1→2)`                         | `a, b dependsOn a, c dependsOn a` — 1 source, 2 targets                                                                     | micro       | changed-integration-7 dedupe            |
+| A12 | `create large (100-field chain Pain)`          | 100 keys, every 10th with dependsOn predecessor                                                                             | heavy-micro | stress — ensures creation scales        |
+
+Expectation: A2 ≈ A1 within 5% (metadata-only V1). If A2 regresses >10% this is a release-blocker. A5–A9 measure rebase overhead, not validation.
+
+### 5.2 Group B — `describe()` with and without relationships
+
+`describe 'describe() — metadata read'`
+
+| #   | Bench name                             | What it does                                                                                     | Knob  | Maps to                               |
+| --- | -------------------------------------- | ------------------------------------------------------------------------------------------------ | ----- | ------------------------------------- |
+| B1  | `describe flat no rel`                 | `enforce.shape({a,b}).describe()` baseline                                                       | micro | —                                     |
+| B2  | `describe flat with one edge`          | same as A2 then `.describe()`                                                                    | micro | schemaRelationships.test flat         |
+| B3  | `describe nested rebased (2×)`         | A6 checkout `.describe()` — expect 2 edges                                                       | micro | composition reusable                  |
+| B4  | `describe array same-item`             | A7 booking `.describe()` — check binding identity                                                | micro | composition array binding             |
+| B5  | `describe serialize (JSON round-trip)` | `JSON.parse(JSON.stringify(schema.describe()))` — tests requirement "describe is serializable"   | micro | schemaRelationships.test serializable |
+| B6  | `describe repeated (cache hit?)`       | `describe(); describe(); describe()` ×3 — measures idempotency cost (stable after repeated runs) | micro | vest suite repeated-runs test         |
+
+Expectation: `describe()` is cold read; all B rows within same order of magnitude. JSON round-trip (B5) is expected to be ~2× B2 but still microsecond-range.
+
+### 5.3 Group C — `suite.changed()` vs `suite.only()` vs `suite.run()` — Head-to-Head
+
+This is the **core proof** that `changed()` is minimal. Each topology gets a triplet (and where meaningful a `run()`-only traffic).
+
+`describe 'changed() vs only() vs run() — minimality proof'`
+
+| #   | Bench name                                                              | Body                                                                                                                                       | Knob   | Proves                                                                    |
+| --- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------ | ------------------------------------------------------------------------- |
+| C1  | `flat: run() full (3 fields)`                                           | `suite.run(data)` — baseline (runs 3)                                                                                                      | fast   | denominator                                                               |
+| C2  | `flat: only(password) — 1 field`                                        | `suite.only('password').run(data)` — 1 field                                                                                               | fast   | only is explicit (does NOT expand)                                        |
+| C3  | `flat: changed(password) — 2 fields`                                    | `suite.changed('password').run(data)` — 2 fields (password + confirm)                                                                      | fast   | minimal: `C2 < C3 < C1` in _work_ but `hz(C3) > hz(C1)` since fewer tests |
+| C4  | `flat: changed(confirmPassword) — 1 field`                              | directionality — should equal C2 in work                                                                                                   | fast   | integration-2                                                             |
+| C5  | `flat: changed(email) — 1 field (retains errors)`                       | unrelated field; changed must retain prior errors                                                                                          | fast   | integration-3                                                             |
+| C6  | `nested: run() (profile.country + profile.state + email)`               | full run                                                                                                                                   | fast   | —                                                                         |
+| C7  | `nested: changed(profile.country) — 2 fields`                           | `changed('profile.country')` → country+state                                                                                               | fast   | integration-4                                                             |
+| C8  | `reusable: run() (billing×2 + shipping×2 =4)`                           | full 4-field run                                                                                                                           | medium | —                                                                         |
+| C9  | `reusable: changed(billing.country) — 2 fields, isolated`               | should NOT touch shipping                                                                                                                  | medium | integration-5                                                             |
+| C10 | `array(3): run() — 6 fields (3×country+passport)`                       | full array run                                                                                                                             | medium | —                                                                         |
+| C11 | `array(3): changed(travelers.1.country) — 2 fields same-item`           | only index 1 affected                                                                                                                      | medium | integration-6                                                             |
+| C12 | `array(100): run() — 200 fields`                                        | full 100-traveler run                                                                                                                      | heavy  | scale                                                                     |
+| C13 | `array(100): changed(travelers.50.country) — 2 fields`                  | **key regression gate** — `hz(C13) / hz(C12)` should be >> `10×` (200 vs 2). If ratio < 5×, flags that `changed()` is looping whole array. | heavy  | minimality at scale                                                       |
+| C14 | `fan-out: run() (password + 2 dependents + email =4)`                   | full                                                                                                                                       | medium | —                                                                         |
+| C15 | `fan-out: changed(password) — 3 fields deduped`                         | 1→2 fan-out                                                                                                                                | medium | integration-7                                                             |
+| C16 | `chain: changed(a) where a→b→c non-transitive — 2 fields not 3`         | ensures no cascade                                                                                                                         | fast   | integration-8                                                             |
+| C17 | `skipWhen: changed(country) where country≠US→US flips state visibility` | candidate set vs Vest skip authority                                                                                                       | fast   | integration-10                                                            |
+| C18 | `async: changed(organizationId) — reruns username (pending)`            | async dependent                                                                                                                            | medium | integration-11                                                            |
+
+Interpretation of C3 vs C1: `changed()` must have **higher hz** than full `run()` (less work → more ops/sec). Absolute hz is not the claim — _ratio_ is. Report both raw hz and log length in bench name comment (e.g. `changed(password) [2/3 fields]`). The grant of "proving changed() is minimal" is satisfied by the **side-by-side hz ratio**, not by in-bench asserts.
+
+### 5.4 Group D — Integration Matrix (`changed()` under Vest features) & Realistic Flow
+
+`describe 'Integration matrix — changed() meets Vest features'`
+
+| #   | Bench name                                                                 | Scenario (all from changed.integration + acceptance)                                                         | Knob   | Maps to                                        |
+| --- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------ | ---------------------------------------------- |
+| D1  | `skipWhen: state skipped when country≠US — changed touches but Vest skips` | state `skipWhen(country!=='US')`, changed(country CA→US)                                                     | fast   | integration-10 variant                         |
+| D2  | `omitWhen: field omitted — changed still candidate but omitted`            | —                                                                                                            | fast   | composition omitWhen                           |
+| D3  | `optional (suite): password optional — changed keeps graph`                | `optional('password')`                                                                                       | fast   | interaction optional                           |
+| D4  | `optional (n4s): b: optional(isString().dependsOn($.a))`                   | does not throw, graph intact                                                                                 | micro  | interaction n4s optional                       |
+| D5  | `warn: changed triggers warn+optional intersection`                        | —                                                                                                            | fast   | interaction warn                               |
+| D6  | `group: changed inside group + each combination`                           | `group → each → test` mix                                                                                    | medium | advanced control flow                          |
+| D7  | `each + group: 10 items each with group wrapper`                           | —                                                                                                            | medium | expert Each+Group                              |
+| D8  | `mode: ALL vs ONE under changed`                                           | ensure semantics unchanged                                                                                   | fast   | feature-matrix flow control                    |
+| D9  | `async waterfall: 2 async tests under changed`                             | pending semantics                                                                                            | medium | advanced Async & Concurrency                   |
+| D10 | `serialize large after changed — retain + serialize cost`                  | `suite.changed(...).run(); SuiteSerializer.serialize(res)`                                                   | medium | advanced State Management                      |
+| D11 | `realistic registration flow — 6 scenarios in sequence`                    | email→password→confirm→org→country — single suite, sequential `changed()` steps (mirrors integration-13)     | heavy  | **acceptance big picture** (the 23rd scenario) |
+| D12 | `realistic checkout flow — billing+shipping+travelers interleaved`         | checkout(A7) + vest `group/each` — stresses reusable+array together                                          | heavy  | cross of acceptance 3+4                        |
+| D13 | `volatility stress: 100 fields only 1 changed — changed ratio`             | 100 flat fields, 1 dependsOn, `changed(source)` → 2 vs `run()` → 100. Ratio gate `hz(changed)/hz(run) > 20×` | heavy  | stress-fields 100 + relationships              |
+
+D11 is the single most valuable bench for stakeholders — run the full registration sequence (initial submit invalid email → fix email via changed → change password → fix confirmation → CA→US flips state) inside one `bench()` iteration so steady-state throughput is measured, not one-shot latency.
+
+### 5.5 Summary counts
+
+| Group          | Count  | File                                               |
+| -------------- | ------ | -------------------------------------------------- |
+| A creation     | 12     | top-level                                          |
+| B describe     | 6      | top-level                                          |
+| C head-to-head | 18     | top-level (split to granular if too long)          |
+| D integration  | 13     | granular (`schema-relationships-changed.bench.ts`) |
+| **Total**      | **49** |                                                    |
+
+49 rows covers all 23 scenarios with multi-angle depth. Reporter currently emits ~60 rows total — so this adds ~80% more rows, doubling CI time. Mitigation: mark heavy rows (`array 100`, `flow`, `volatility`) with `time: 1000` so tinybench converges quickly; fast rows dominate 150 ms each → estimated **extra CI wall-time ~25–35 s** (acceptable).
+
+---
+
+## 6 — File Skeleton (copy-paste ready)
+
+```ts
+// packages/vest/bench/schema-relationships.bench.ts
+import { bench, describe } from 'vitest';
+import { create, test, enforce, group, skipWhen } from '../src/vest';
+import { enforce as n4sEnforce } from '../../n4s/src/n4s';
+import { each } from '../src/isolates/each';
+import { TFieldName, TGroupName } from '../src/suiteResult/SuiteResultTypes';
+
+// ── shared fixtures ──────────────────────────────────────────────
+const addressSchema = n4sEnforce.shape({
+  country: n4sEnforce.isString(),
+  state: n4sEnforce.isString().dependsOn($ => $.country),
+});
+const travelerSchema = n4sEnforce.shape({
+  country: n4sEnforce.isString(),
+  passportNumber: n4sEnforce.isString().dependsOn($ => $.country),
+});
+
+// Suite helpers (create once, reuse)
+function makeFlatSuite(log: string[]) {
+  /* ... */
+}
+function makeNestedSuite(log: string[]) {
+  /* ... */
+}
+// ...
+
+// ── smoke guard (outside bench, once) ───────────────────────────
+// void (async () => { /* assert changed() log lengths once */ })();
+
+// ── Group A — schema creation ───────────────────────────────────
+describe('Schema creation — with vs without relationships', () => {
+  bench(
+    'create flat (no rel)',
+    () => {
+      /* A1 */
+    },
+    { time: 200, iterations: 20 },
+  );
+  bench(
+    'create flat with dependsOn',
+    () => {
+      /* A2 */
+    },
+    { time: 200, iterations: 20 },
+  );
+  // ... A3–A12
+});
+
+// ── Group B — describe() ────────────────────────────────────────
+describe('describe() — metadata read', () => {
+  const flatWith = n4sEnforce.shape({
+    password: n4sEnforce.isString(),
+    confirmPassword: n4sEnforce.isString().dependsOn($ => $.password),
+  });
+  bench(
+    'describe flat no rel',
+    () => {
+      n4sEnforce
+        .shape({ a: n4sEnforce.isString(), b: n4sEnforce.isString() })
+        .describe();
+    },
+    { time: 200, iterations: 20 },
+  );
+  bench(
+    'describe flat with one edge',
+    () => {
+      (flatWith as any).describe();
+    },
+    { time: 200, iterations: 20 },
+  );
+  // ... B3–B6
+});
+
+// ── Group C — changed vs only vs run ────────────────────────────
+describe('changed() vs only() vs run() — minimality proof', () => {
+  // C1–C18, each bench body runs exactly one suite mode on pre-warmed suite
+});
+
+// packages/vest/bench/granular/schema-relationships-changed.bench.ts
+// ... Group D only — imports from '../../../src/vest' (granular depth)
+```
+
+Benchmark creation pattern to keep naming CI-friendly: append field-count hint in bench name, e.g. `'array(100): changed(travelers.50.country) [2/200 fields]'`. Reporter concatenates `suite :: name`, so `describe` + bench name are both visible in `benchmark-results.md`.
+
+---
+
+## 7 — Regression Gates & How to Read Results
+
+### 7.1 Gates that would fail CI (human-checked, not auto-fail)
+
+These are not encoded in reporter yet — they are review-time rules. If violated, the PR should be blocked:
+
+| Gate                                   | Check                                | Threshold                                           |
+| -------------------------------------- | ------------------------------------ | --------------------------------------------------- |
+| **G1 — creation not regressed**        | `hz(A2) / hz(A1) > 0.90`             | dependsOn creation within 10% of baseline           |
+| **G2 — describe not regressed**        | `hz(B2) / hz(B1) > 0.85`             | metadata read within 15% (JSON round-trip excluded) |
+| **G3 — changed beats run (flat)**      | `hz(C3) / hz(C1) > 1.2`              | changed does less work so faster                    |
+| **G4 — changed beats run (array 100)** | `hz(C13) / hz(C12) > 10`             | strong minimality signal at scale                   |
+| **G5 — isolation**                     | `hz(C9)` ≈ `hz(C7)` floor            | reusable not slower than flat                       |
+| **G6 — volatility**                    | `hz(D13 changed) / hz(D13 run) > 20` | 100-field suite, only 2 run                         |
+| **G7 — stability**                     | `rme` for all C rows < `10%`         | else increase `iterations` or `time`                |
+
+Gate thresholds use `max(5, rme)` masking in reporter — so a 7% diff tagged `0.00%` is still visible in raw log. Always check CI log raw output, not only masked table.
+
+### 7.2 How to prove "not regressing" historically
+
+Keep rows **additive** — never rename existing bench names. Baseline checkout (`latest` branch) will have no rows for these names; reporter shows them as new (Diff=0). On second run, diffs appear — evolutions are comparable. Pin heavy suites to `time:1000` so tinybench confidence stays high even on noisy CI.
+
+---
+
+## 8 — Risk & Mitigations
+
+| Risk                                                                        | Mitigation                                                                                                                                           |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench flakiness from `Math.random()` ids (seen in `suiteKeyThrash`)         | Use deterministic `travelers(n)` array, not random keys                                                                                              |
+| `changed()` body mutates shared suite state across iterations → orders leak | Call `suite.reset()` before suite creation per bench group, or create fresh suite inside bench for heavy cases (cost is negligible vs 200-field run) |
+| `only()` vs `changed()` semantics leak across benches in same file          | Give each `describe` its own suite instances — don't share `log` array                                                                               |
+| CI duration blow-out (49 benches)                                           | Group D marked `heavy` with few iterations; total extra ≈30 s                                                                                        |
+| n4s import path differs (`n4s` vs `../../n4s/src/n4s`)                      | Use `../../n4s/src/n4s` for consistency with tests; verify with `tsc --noEmit` before merge                                                          |
+
+---
+
+## 9 — Next Steps (not executed in this design task)
+
+1. **Author `schema-relationships.bench.ts`** per skeleton §6, Groups A–C.
+2. **Author `granular/schema-relationships-changed.bench.ts`** for Group D.
+3. Run `yarn vitest bench --run packages/vest/bench/schema-relationships.bench.ts --no-color` locally, sanity-check `rme < 10%`.
+4. Run full `npx tsx vx/scripts/benchmark-reporter.ts` and confirm ~49 new rows in local `benchmark-results-local.md`.
+5. Open PR — confirm `.github/workflows/benchmark.yml` posts table with `Diff (Abs) | Diff (%)` columns.
+6. Optional: add `packages/n4s/bench/` if n4s team wants creation/describe benches isolated from vest suite noise.
+
+---
+
+## 10 — Appendix — Existing Bench Inventory & Conventions
+
+For reference when authoring:
+
+```
+packages/vest/bench/
+  advanced.bench.ts            — control flow + enforce + serialization + selectors + async + hooks (8 describes)
+  complex-flows.bench.ts       — deep nesting with optional/warn/skip
+  conditional-isolates.bench.ts— skip/omit even indices
+  debounce-coverage.bench.ts   — debounce
+  dynamic-each-group.bench.ts  — longer list
+  enforce-advanced.bench.ts    — enforce chain
+  expert.bench.ts              — mix of everything (largest file)
+  feature-matrix.bench.ts      — ALL/EAGER mode matrix
+  focus-filters.bench.ts       — only/skip/include
+  library.bench.ts             — reordering, reset, message handling
+  nesting-fields-hooks.bench.ts— depth 3–5
+  optional-warn-mode.bench.ts  — optional/warn
+  result-selectors.bench.ts    — hasErrors / getErrors
+  stress-fields.bench.ts       — 10/500/1000 fields
+  stress-nesting.bench.ts      — depth 10/50/100
+  suite-focus.bench.ts         — focus modifiers (skipGroup/onlyGroup)
+  granular/
+    complex.bench.ts           — async group + skip + deep async
+    conditional.bench.ts       — skipWhen/omitWhen/include
+    control-flow.bench.ts      — group sync/async, each, only/skip
+    core.bench.ts              — sync pass/fail/warn, memo, async, high-volume (1000)
+    enforce.bench.ts           — simple/long chain
+    optional.bench.ts
+    state.bench.ts
+```
+
+Naming convention: `describe('<Human Area>', () => { bench('<specific case>', fn, opts) })`. No setup files for bench; uses `vitest bench` globals. Tinybench options per bench: `{ time, iterations, warmupTime, warmupIterations }`.
+
+Reporter output columns (post-run): `| Suite | Benchmark | Ops/sec (Hz) | P99 (ms) | Margin of Error | Diff (Abs) | Diff (%) |`

--- a/packages/vest/bench/granular/schema-relationships-changed.bench.ts
+++ b/packages/vest/bench/granular/schema-relationships-changed.bench.ts
@@ -1,0 +1,432 @@
+/* eslint-disable sort-keys -- bench fixture order intentionally groups password deps */
+import { bench, describe } from 'vitest';
+import { create, test, enforce, group, skipWhen } from '../../src/vest';
+import { each } from '../../src/isolates/each';
+import { TFieldName, TGroupName } from '../../src/suiteResult/SuiteResultTypes';
+
+// ──────────────────────────────────────────────────────────────
+// Shared helpers
+// ──────────────────────────────────────────────────────────────
+const travelersData = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    country: 'US',
+    passportNumber: `P${i}`,
+  }));
+
+// ──────────────────────────────────────────────────────────────
+// Group C — changed() vs only() vs run() — minimality proof (18)
+// ──────────────────────────────────────────────────────────────
+describe('changed() vs only() vs run() — minimality proof', () => {
+  // ── Flat suite (C1–C5) ─────────────────────────────────────
+  const flatSchema = enforce.shape({
+    password: enforce.isString(),
+    confirmPassword: enforce.isString().dependsOn($ => $.password),
+    email: enforce.isString(),
+  });
+
+  const flatData = {
+    password: 'abcdefgh',
+    confirmPassword: 'abcdefgh',
+    email: 'a@b.com',
+  };
+
+  const makeFlatSuite = () =>
+    create(data => {
+      test('password', () => {
+        enforce(data.password).isString();
+      });
+      test('confirmPassword', () => {
+        enforce(data.confirmPassword).equals(data.password);
+      });
+      test('email', () => {
+        enforce(data.email).isString();
+      });
+    }, flatSchema);
+
+  // Pre-warmed reused suites — bench measures steady-state throughput,
+  // not creation+warmup. Each bench reuses its own suite to avoid cross-bench focus leakage.
+  const flatSuiteRun = makeFlatSuite();
+  flatSuiteRun.run(flatData);
+  const flatSuiteOnly = makeFlatSuite();
+  flatSuiteOnly.run(flatData);
+  const flatSuiteChangedPw = makeFlatSuite();
+  flatSuiteChangedPw.run(flatData);
+  const flatSuiteChangedConfirm = makeFlatSuite();
+  flatSuiteChangedConfirm.run(flatData);
+  const flatSuiteChangedEmail = makeFlatSuite();
+  flatSuiteChangedEmail.run({ ...flatData, email: '' });
+
+  bench(
+    'C1 flat run() full [3/3 fields]',
+    () => {
+      flatSuiteRun.run(flatData);
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  bench(
+    'C2 flat only(password) [1/3 fields]',
+    () => {
+      flatSuiteOnly.only('password').run(flatData);
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  bench(
+    'C3 flat changed(password) [2/3 fields] password→confirm',
+    () => {
+      flatSuiteChangedPw
+        .changed('password')
+        .run({ ...flatData, password: 'newpass1' });
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  bench(
+    'C4 flat changed(confirmPassword) [1/3 fields] directionality',
+    () => {
+      flatSuiteChangedConfirm
+        .changed('confirmPassword')
+        .run({ ...flatData, confirmPassword: 'xyz' });
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  bench(
+    'C5 flat changed(email) [1/3 fields] unrelated, retains errors',
+    () => {
+      flatSuiteChangedEmail.changed('email').run(flatData);
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  // ── Nested suite (C6–C7) ───────────────────────────────────
+  const nestedSchema = enforce.shape({
+    profile: enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    }),
+    email: enforce.isString(),
+  });
+
+  const nestedData = {
+    profile: { country: 'CA', state: '' },
+    email: 'a@b.com',
+  };
+
+  const makeNestedSuite = () =>
+    create(data => {
+      test('profile.country', () => {
+        enforce(data.profile.country).isString();
+      });
+      test('profile.state', () => {
+        enforce(data.profile.state).isString();
+      });
+      test('email', () => {
+        enforce(data.email).isString();
+      });
+    }, nestedSchema);
+
+  const nestedSuiteRun = makeNestedSuite();
+  nestedSuiteRun.run(nestedData);
+  const nestedSuiteChanged = makeNestedSuite();
+  nestedSuiteChanged.run(nestedData);
+
+  bench(
+    'C6 nested run() full [3/3 fields] profile.country+state+email',
+    () => {
+      nestedSuiteRun.run(nestedData);
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  bench(
+    'C7 nested changed(profile.country) [2/3 fields] country→state',
+    () => {
+      nestedSuiteChanged
+        .changed('profile.country')
+        .run({ profile: { country: 'US', state: '' }, email: 'a@b.com' });
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  // ── Reusable suite (C8–C9) ─────────────────────────────────
+  const reuseAddress = enforce.shape({
+    country: enforce.isString(),
+    state: enforce.isString().dependsOn($ => $.country),
+  });
+  const reuseSchema = enforce.shape({
+    billing: reuseAddress,
+    shipping: reuseAddress,
+  });
+
+  const reuseData = {
+    billing: { country: 'US', state: 'CA' },
+    shipping: { country: 'US', state: 'NY' },
+  };
+
+  const makeReuseSuite = () =>
+    create(data => {
+      group('billing' as TGroupName, () => {
+        test('billing.country' as TFieldName, () => {
+          enforce(data.billing.country).isString();
+        });
+        test('billing.state' as TFieldName, () => {
+          enforce(data.billing.state).isString();
+        });
+      });
+      group('shipping' as TGroupName, () => {
+        test('shipping.country' as TFieldName, () => {
+          enforce(data.shipping.country).isString();
+        });
+        test('shipping.state' as TFieldName, () => {
+          enforce(data.shipping.state).isString();
+        });
+      });
+    }, reuseSchema);
+
+  const reuseSuiteRun = makeReuseSuite();
+  reuseSuiteRun.run(reuseData);
+  const reuseSuiteChanged = makeReuseSuite();
+  reuseSuiteChanged.run(reuseData);
+
+  bench(
+    'C8 reusable run() full [4/4 fields] billing×2+shipping×2',
+    () => {
+      reuseSuiteRun.run(reuseData);
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  bench(
+    'C9 reusable changed(billing.country) [2/4 fields] isolated, not shipping',
+    () => {
+      reuseSuiteChanged.changed('billing.country').run({
+        billing: { country: 'CA', state: 'CA' },
+        shipping: { country: 'US', state: 'NY' },
+      });
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  // ── Array suites (C10–C13) ─────────────────────────────────
+  const travelerSchema = enforce.shape({
+    country: enforce.isString(),
+    passportNumber: enforce.isString().dependsOn($ => $.country),
+  });
+  const arraySchema = enforce.shape({
+    travelers: enforce.isArrayOf(travelerSchema),
+  });
+
+  const makeArraySuite = (n: number) => {
+    const data = { travelers: travelersData(n) };
+    const suite = create(d => {
+      each(d.travelers, (t, i) => {
+        test(`travelers.${i}.country` as TFieldName, () => {
+          enforce(t.country).isString();
+        });
+        test(`travelers.${i}.passportNumber` as TFieldName, () => {
+          enforce(t.passportNumber).isString();
+        });
+      });
+    }, arraySchema);
+    suite.run(data);
+    return { suite, data };
+  };
+
+  const arr3 = makeArraySuite(3);
+  const arr100 = makeArraySuite(100);
+
+  // Pre-create dedicated array suites for C10/C12 run baselines (reused, not recreated per iteration)
+  const arr3Run = makeArraySuite(3);
+  const arr100Run = makeArraySuite(100);
+  // Pre-create changed fixtures to make run vs changed costs symmetric (no one-sided O(n) alloc)
+  const arr100ChangedData = { travelers: travelersData(100) };
+  arr100ChangedData.travelers[50] = { country: 'CA', passportNumber: 'P50' };
+
+  bench(
+    'C10 array(3) run() [6/6 fields] 3×country+passport',
+    () => {
+      arr3Run.suite.run(arr3Run.data);
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  bench(
+    'C11 array(3) changed(travelers.1.country) [2/6 fields] same-item isolated',
+    () => {
+      arr3.suite.changed('travelers.1.country').run({
+        travelers: [
+          { country: 'US', passportNumber: 'P0' },
+          { country: 'CA', passportNumber: 'P1' },
+          { country: 'FR', passportNumber: 'P2' },
+        ],
+      });
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  bench(
+    'C12 array(100) run() [200/200 fields] 100×traveler',
+    () => {
+      arr100Run.suite.run(arr100Run.data);
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  bench(
+    'C13 array(100) changed(travelers.50.country) [2/200 fields] ratio gate >10×',
+    () => {
+      arr100.suite.changed('travelers.50.country').run(arr100ChangedData);
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  // ── Fan-out (C14–C15) ──────────────────────────────────────
+  const fanoutSchema = enforce.shape({
+    password: enforce.isString(),
+    confirmPassword: enforce.isString().dependsOn($ => $.password),
+    hint: enforce.isString().dependsOn($ => $.password),
+    email: enforce.isString(),
+  });
+
+  const fanoutData = {
+    password: 'abcdefgh',
+    confirmPassword: 'abcdefgh',
+    hint: 'ok',
+    email: 'a@b.com',
+  };
+
+  const makeFanoutSuite = () =>
+    create(data => {
+      test('password', () => {
+        enforce(data.password).isString();
+      });
+      test('confirmPassword', () => {
+        enforce(data.confirmPassword).equals(data.password);
+      });
+      test('hint', () => {
+        enforce(data.hint).isString();
+      });
+      test('email', () => {
+        enforce(data.email).isString();
+      });
+    }, fanoutSchema);
+
+  const fanoutSuiteRun = makeFanoutSuite();
+  fanoutSuiteRun.run(fanoutData);
+  const fanoutSuiteChanged = makeFanoutSuite();
+  fanoutSuiteChanged.run(fanoutData);
+
+  bench(
+    'C14 fan-out run() [4/4 fields] password+2deps+email',
+    () => {
+      fanoutSuiteRun.run(fanoutData);
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  bench(
+    'C15 fan-out changed(password) [3/4 fields] deduped 1→2',
+    () => {
+      fanoutSuiteChanged
+        .changed('password')
+        .run({ ...fanoutData, password: 'newpass1' });
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  // ── Chain non-transitive (C16) ─────────────────────────────
+  const chainSchema = enforce.shape({
+    a: enforce.isString(),
+    b: enforce.isString().dependsOn($ => $.a),
+    c: enforce.isString().dependsOn($ => $.b),
+  });
+
+  const chainData = { a: '1', b: '2', c: '3' };
+
+  const makeChainSuite = () =>
+    create(data => {
+      test('a', () => {
+        enforce(data.a).isString();
+      });
+      test('b', () => {
+        enforce(data.b).isString();
+      });
+      test('c', () => {
+        enforce(data.c).isString();
+      });
+    }, chainSchema);
+
+  const chainSuiteRun = makeChainSuite();
+  chainSuiteRun.run(chainData);
+  const chainSuiteChanged = makeChainSuite();
+  chainSuiteChanged.run(chainData);
+
+  bench(
+    'C16 chain changed(a) a→b→c non-transitive [2/3 fields] not c',
+    () => {
+      chainSuiteChanged.changed('a').run({ a: 'x', b: '2', c: '3' });
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  // ── skipWhen (C17) ─────────────────────────────────────────
+  const skipWhenSchema = enforce.shape({
+    country: enforce.isString(),
+    state: enforce.isString().dependsOn($ => $.country),
+  });
+
+  const makeSkipWhenSuite = () =>
+    create(data => {
+      test('country', () => {
+        enforce(data.country).isString();
+      });
+      skipWhen(data.country !== 'US', () => {
+        test('state', () => {
+          enforce(data.state).isString();
+        });
+      });
+    }, skipWhenSchema);
+
+  const skipWhenSuiteChanged = makeSkipWhenSuite();
+  skipWhenSuiteChanged.run({ country: 'CA', state: '' });
+
+  bench(
+    'C17 skipWhen changed(country) CA→US flips state visibility [2 fields]',
+    () => {
+      skipWhenSuiteChanged.changed('country').run({ country: 'US', state: '' });
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+
+  // ── Async dependent (C18) ──────────────────────────────────
+  const asyncSchema = enforce.shape({
+    organizationId: enforce.isString(),
+    username: enforce.isString().dependsOn($ => $.organizationId),
+  });
+
+  const makeAsyncSuite = () =>
+    create(data => {
+      test('organizationId', () => {
+        enforce(data.organizationId).isString();
+      });
+      test('username', async () => {
+        const available = await Promise.resolve(data.username !== 'taken');
+        enforce(available).isTruthy();
+      });
+    }, asyncSchema);
+
+  const asyncSuiteChanged = makeAsyncSuite();
+  asyncSuiteChanged.run({ organizationId: 'A', username: 'free' });
+
+  bench(
+    'C18 async changed(organizationId) reruns username [pending] [2/2 fields]',
+    () => {
+      asyncSuiteChanged
+        .changed('organizationId')
+        .run({ organizationId: 'B', username: 'free' });
+    },
+    { time: 1000, warmupTime: 500 },
+  );
+});

--- a/packages/vest/bench/schema-relationships.bench.ts
+++ b/packages/vest/bench/schema-relationships.bench.ts
@@ -1,0 +1,831 @@
+import { bench, describe } from 'vitest';
+import {
+  create,
+  test,
+  enforce,
+  group,
+  skipWhen,
+  omitWhen,
+  optional,
+  warn,
+  mode,
+  Modes,
+  each,
+} from '../src/vest';
+import { SuiteSerializer } from '../src/exports/SuiteSerializer';
+import type { InferSchemaData } from '../src/suiteResult/SuiteResultTypes';
+import { TFieldName, TGroupName } from '../src/suiteResult/SuiteResultTypes';
+
+// ──────────────────────────────────────────────────────────────
+// Shared helpers
+// ──────────────────────────────────────────────────────────────
+const travelersData = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    country: 'US',
+    passportNumber: `P${i}`,
+  }));
+
+type StringRule = ReturnType<typeof enforce.isString>;
+
+// ──────────────────────────────────────────────────────────────
+// Group A — Schema creation with relationships (12 benches)
+// ──────────────────────────────────────────────────────────────
+describe('Schema creation — with vs without relationships', () => {
+  bench(
+    'A1 create flat (no rel) [2 fields]',
+    () => {
+      enforce.shape({
+        a: enforce.isString(),
+        b: enforce.isString(),
+      });
+    },
+    { time: 250 },
+  );
+
+  bench(
+    'A2 create flat with dependsOn [2 fields, 1 edge]',
+    () => {
+      enforce.shape({
+        a: enforce.isString(),
+        b: enforce.isString().dependsOn($ => $.a),
+      });
+    },
+    { time: 250 },
+  );
+
+  bench(
+    'A4 create flat multi-source [4 fields, total→3]',
+    () => {
+      enforce.shape({
+        quantity: enforce.isNumber(),
+        unitPrice: enforce.isNumber(),
+        currency: enforce.isString(),
+        total: enforce
+          .isNumber()
+          .dependsOn($ => [$.quantity, $.unitPrice, $.currency]),
+      });
+    },
+    { time: 250 },
+  );
+
+  bench(
+    'A5 create nested 3-level with rebase [outer→middle→inner]',
+    () => {
+      const inner = enforce.shape({
+        city: enforce.isString(),
+        zip: enforce.isString().dependsOn($ => $.city),
+      });
+      const middle = enforce.shape({ address: inner });
+      enforce.shape({ user: middle });
+    },
+    { time: 250 },
+  );
+
+  bench(
+    'A6 create reusable shared address ×2 [2×2 fields]',
+    () => {
+      const address = enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      });
+      enforce.shape({
+        billing: address,
+        shipping: address,
+      });
+    },
+    { time: 250 },
+  );
+
+  bench(
+    'A7 create array same-item one traveler [travelers.$item]',
+    () => {
+      const traveler = enforce.shape({
+        country: enforce.isString(),
+        passportNumber: enforce.isString().dependsOn($ => $.country),
+      });
+      enforce.shape({ travelers: enforce.isArrayOf(traveler) });
+    },
+    { time: 250 },
+  );
+
+  bench(
+    'A8 create $.root escape [company.taxId→root]',
+    () => {
+      enforce.shape({
+        accountType: enforce.isString(),
+        company: enforce.shape({
+          country: enforce.isString(),
+          taxId: enforce
+            .isString()
+            .dependsOn($ => [$.country, $.root.accountType]),
+        }),
+      });
+    },
+    { time: 250 },
+  );
+
+  bench(
+    'A9 create nested arrays orders→items [2× $item bindings]',
+    () => {
+      const item = enforce.shape({
+        name: enforce.isString(),
+        discount: enforce.isString().dependsOn($ => $.name),
+      });
+      const order = enforce.shape({
+        items: enforce.isArrayOf(item),
+      });
+      enforce.shape({ orders: enforce.isArrayOf(order) });
+    },
+    { time: 250 },
+  );
+
+  bench(
+    'A10 create cyclic 2-node [start↔end]',
+    () => {
+      enforce.shape({
+        start: enforce.isString().dependsOn($ => $.end),
+        end: enforce.isString().dependsOn($ => $.start),
+      });
+    },
+    { time: 250 },
+  );
+
+  bench(
+    'A11 create fan-out 1→2 [password→2 dependents]',
+    () => {
+      enforce.shape({
+        password: enforce.isString(),
+        confirmPassword: enforce.isString().dependsOn($ => $.password),
+        hint: enforce.isString().dependsOn($ => $.password),
+      });
+    },
+    { time: 250 },
+  );
+
+  bench(
+    'A12 create large 100-field chain [100 fields, 10 edges]',
+    () => {
+      const fields: Record<string, StringRule> = {};
+      for (let i = 0; i < 100; i++) {
+        if (i % 10 === 0 && i > 0) {
+          const prevKey = `field_${i - 10}`;
+          fields[`field_${i}`] = enforce.isString().dependsOn($ => $[prevKey]);
+        } else {
+          fields[`field_${i}`] = enforce.isString();
+        }
+      }
+      enforce.shape(fields);
+    },
+    { time: 250 },
+  );
+});
+
+// ──────────────────────────────────────────────────────────────
+// Group B — describe() metadata read (6 benches)
+// ──────────────────────────────────────────────────────────────
+describe('describe() — metadata read', () => {
+  const flatWith = enforce.shape({
+    password: enforce.isString(),
+    confirmPassword: enforce.isString().dependsOn($ => $.password),
+  });
+  const flatNoRel = enforce.shape({
+    a: enforce.isString(),
+    b: enforce.isString(),
+  });
+
+  const addressReuse = enforce.shape({
+    country: enforce.isString(),
+    state: enforce.isString().dependsOn($ => $.country),
+  });
+  const checkoutReuse = enforce.shape({
+    billing: addressReuse,
+    shipping: addressReuse,
+  });
+
+  const travelerForB = enforce.shape({
+    country: enforce.isString(),
+    passportNumber: enforce.isString().dependsOn($ => $.country),
+  });
+  const bookingForB = enforce.shape({
+    travelers: enforce.isArrayOf(travelerForB),
+  });
+
+  bench(
+    'B1 describe flat no rel',
+    () => {
+      flatNoRel.describe();
+    },
+    { time: 150 },
+  );
+
+  bench(
+    'B2 describe flat with one edge',
+    () => {
+      flatWith.describe();
+    },
+    { time: 150 },
+  );
+
+  bench(
+    'B3 describe nested reusable 2× [checkout billing+shipping]',
+    () => {
+      checkoutReuse.describe();
+    },
+    { time: 150 },
+  );
+
+  bench(
+    'B4 describe array same-item [booking travelers]',
+    () => {
+      bookingForB.describe();
+    },
+    { time: 150 },
+  );
+
+  bench(
+    'B5 describe JSON round-trip [flat with edge]',
+    () => {
+      JSON.parse(JSON.stringify(flatWith.describe()));
+    },
+    { time: 150 },
+  );
+
+  bench(
+    'B6 describe repeated ×3 [idempotency / cache]',
+    () => {
+      flatWith.describe();
+      flatWith.describe();
+      flatWith.describe();
+    },
+    { time: 150 },
+  );
+});
+
+// ──────────────────────────────────────────────────────────────
+// Group D — Integration matrix + realistic flows (13 benches)
+// ──────────────────────────────────────────────────────────────
+
+// Shared fixtures for D
+const dSkipWhenSchema = enforce.shape({
+  country: enforce.isString(),
+  state: enforce.isString().dependsOn($ => $.country),
+});
+
+const dOmitWhenSchema = enforce.shape({
+  country: enforce.isString(),
+  nickname: enforce.isString().dependsOn($ => $.country),
+});
+
+const dOptionalSchema = enforce.shape({
+  password: enforce.isString(),
+  confirmPassword: enforce.isString().dependsOn($ => $.password),
+});
+
+describe('Integration matrix — changed() meets Vest features', () => {
+  // D1 skipWhen
+  {
+    const d1Suite = create(data => {
+      test('country', () => {
+        enforce(data.country).isString();
+      });
+      skipWhen(data.country !== 'US', () => {
+        test('state', () => {
+          enforce(data.state).isString();
+        });
+      });
+    }, dSkipWhenSchema);
+    d1Suite.run({ country: 'CA', state: '' });
+    bench(
+      'D1 skipWhen changed(country) CA→US [candidate but Vest skips]',
+      () => {
+        d1Suite.changed('country').run({ country: 'US', state: '' });
+      },
+      { time: 250 },
+    );
+  }
+
+  // D2 omitWhen
+  {
+    type D2Data = {
+      country: string;
+      nickname: string;
+      omitNickname?: boolean;
+    };
+    const d2Suite = create((data: D2Data) => {
+      test('country', () => {
+        enforce(data.country).isString();
+      });
+      omitWhen(data.omitNickname ?? false, () => {
+        test('nickname', () => {
+          enforce(data.nickname).isString();
+        });
+      });
+    }, dOmitWhenSchema);
+    const d2Initial: D2Data = {
+      country: 'US',
+      nickname: 'x',
+      omitNickname: false,
+    };
+    d2Suite.run(d2Initial);
+    const d2Changed: D2Data = {
+      country: 'CA',
+      nickname: 'x',
+      omitNickname: true,
+    };
+    bench(
+      'D2 omitWhen changed(country) with omit guard [omitted branch]',
+      () => {
+        d2Suite.changed('country').run(d2Changed);
+      },
+      { time: 250 },
+    );
+  }
+
+  // D3 optional (suite-level)
+  {
+    const d3Schema = enforce.shape({
+      email: enforce.isString(),
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const d3Suite = create(data => {
+      optional('password');
+      optional('confirmPassword');
+      test('password', () => {
+        enforce(data.password).isString();
+      });
+      test('confirmPassword', () => {
+        enforce(data.confirmPassword).equals(data.password);
+      });
+      test('email', () => {
+        enforce(data.email).isString();
+      });
+    }, d3Schema);
+    d3Suite.run({ email: 'a@b.com', password: '', confirmPassword: '' });
+    bench(
+      'D3 optional suite changed(password) [optional field + dependent]',
+      () => {
+        d3Suite.changed('password').run({
+          email: 'a@b.com',
+          password: 'secret123',
+          confirmPassword: '',
+        });
+      },
+      { time: 250 },
+    );
+  }
+
+  // D4 optional (n4s-level via enforce.isString() — suite just validates)
+  {
+    // Use a shape where n4s optional field has dependsOn; suite passes through
+    const d4Suite = create(
+      data => {
+        test('a', () => {
+          enforce(data.a).isString();
+        });
+        test('b', () => {
+          enforce(data.b).isString();
+        });
+      },
+      enforce.shape({
+        a: enforce.isString(),
+        b: enforce.optional(enforce.isString().dependsOn($ => $.a)),
+      }),
+    );
+    d4Suite.run({ a: 'x', b: 'y' });
+    bench(
+      'D4 n4s optional shape changed(a) [b dependsOn a, optional at n4s]',
+      () => {
+        d4Suite.changed('a').run({ a: 'new', b: 'y' });
+      },
+      { time: 250 },
+    );
+  }
+
+  // D5 warn + optional intersection
+  {
+    const d5Suite = create(data => {
+      optional('confirmPassword');
+      test('password', () => {
+        enforce(data.password).isString();
+      });
+      test('confirmPassword', () => {
+        warn();
+        enforce(data.confirmPassword).equals(data.password);
+      });
+    }, dOptionalSchema);
+    d5Suite.run({ password: 'abcdefgh', confirmPassword: 'abcdefgh' });
+    bench(
+      'D5 warn intersection changed(password) [warn field rerun]',
+      () => {
+        d5Suite
+          .changed('password')
+          .run({ password: 'xyz', confirmPassword: 'abcdefgh' });
+      },
+      { time: 250 },
+    );
+  }
+
+  // D6 group + each combination
+  {
+    const d6Traveler = enforce.shape({
+      country: enforce.isString(),
+      passport: enforce.isString().dependsOn($ => $.country),
+    });
+    const d6Schema = enforce.shape({
+      travelers: enforce.isArrayOf(d6Traveler),
+    });
+    const d6Suite = create(data => {
+      group('travelers' as TGroupName, () => {
+        each(data.travelers, (t, i) => {
+          test(`travelers.${i}.country` as TFieldName, () => {
+            enforce(t.country).isString();
+          });
+          test(`travelers.${i}.passport` as TFieldName, () => {
+            enforce(t.passport).isString();
+          });
+        });
+      });
+    }, d6Schema);
+    const d6Data = { travelers: travelersData(5) };
+    // The bench intentionally runs schema-discordant data (travelers carry
+    // `passportNumber`, the schema declares `passport`, so the passport tests
+    // fail at runtime). The precise cast keeps that behavior while satisfying
+    // the schema-typed run signature.
+    type D6Input = InferSchemaData<typeof d6Schema>;
+    d6Suite.run(d6Data as unknown as D6Input);
+    bench(
+      'D6 group+each changed(travelers.1.country) [5 travelers, 10 tests]',
+      () => {
+        d6Suite
+          .changed('travelers.1.country')
+          .run(d6Data as unknown as D6Input);
+      },
+      { time: 250 },
+    );
+  }
+
+  // D7 each + group ×10
+  {
+    const d7Schema = enforce.shape({
+      items: enforce.isArrayOf(
+        enforce.shape({
+          label: enforce.isString(),
+          value: enforce.isString().dependsOn($ => $.label),
+        }),
+      ),
+    });
+    const d7Suite = create(data => {
+      each(data.items, (item, index) => {
+        group(`item_${index}` as TGroupName, () => {
+          test(`items.${index}.label` as TFieldName, () => {
+            enforce(item.label).isString();
+          });
+          test(`items.${index}.value` as TFieldName, () => {
+            enforce(item.value).isString();
+          });
+        });
+      });
+    }, d7Schema);
+    const d7Data = {
+      items: Array.from({ length: 10 }, (_, i) => ({
+        label: `l${i}`,
+        value: `v${i}`,
+      })),
+    };
+    d7Suite.run(d7Data);
+    bench(
+      'D7 each×group(10) changed(items.3.label) [20 tests, 10 groups]',
+      () => {
+        d7Suite.changed('items.3.label').run(d7Data);
+      },
+      { time: 250 },
+    );
+  }
+
+  // D8 mode ALL vs ONE under changed
+  {
+    const d8SuiteAll = create(
+      data => {
+        mode(Modes.ALL);
+        test('a', () => {
+          enforce(data.a).isString();
+        });
+        test('b', () => {
+          enforce(data.b).isString();
+        });
+      },
+      enforce.shape({
+        a: enforce.isString(),
+        b: enforce.isString().dependsOn($ => $.a),
+      }),
+    );
+    d8SuiteAll.run({ a: 'x', b: 'y' });
+    const d8SuiteOne = create(
+      data => {
+        mode(Modes.ONE);
+        test('a', () => {
+          enforce(data.a).isString();
+        });
+        test('b', () => {
+          enforce(data.b).isString();
+        });
+      },
+      enforce.shape({
+        a: enforce.isString(),
+        b: enforce.isString().dependsOn($ => $.a),
+      }),
+    );
+    d8SuiteOne.run({ a: 'x', b: 'y' });
+    bench(
+      'D8 mode ALL changed(a) [a→b, EAGER-like]',
+      () => {
+        d8SuiteAll.changed('a').run({ a: 'new', b: 'y' });
+      },
+      { time: 250 },
+    );
+    bench(
+      'D8 mode ONE changed(a) [single-error mode]',
+      () => {
+        d8SuiteOne.changed('a').run({ a: 'new', b: 'y' });
+      },
+      { time: 250 },
+    );
+  }
+
+  // D9 async waterfall
+  {
+    const d9Schema = enforce.shape({
+      organizationId: enforce.isString(),
+      username: enforce.isString().dependsOn($ => $.organizationId),
+      email: enforce.isString(),
+    });
+    const d9Suite = create(data => {
+      test('organizationId', () => {
+        enforce(data.organizationId).isString();
+      });
+      test('username', async () => {
+        const available = await Promise.resolve(data.username !== 'taken');
+        enforce(available).isTruthy();
+      });
+      test('email', async () => {
+        await Promise.resolve();
+        enforce(data.email).isString();
+      });
+    }, d9Schema);
+    d9Suite.run({ organizationId: 'A', username: 'free', email: 'a@b.com' });
+    bench(
+      'D9 async waterfall changed(organizationId) [2 async dependents]',
+      () => {
+        d9Suite
+          .changed('organizationId')
+          .run({ organizationId: 'B', username: 'free', email: 'a@b.com' });
+      },
+      { time: 250 },
+    );
+  }
+
+  // D10 serialize large after changed — retain + serialize cost
+  {
+    const d10Count = 100;
+    const d10Fields: Record<string, StringRule> = {};
+    for (let i = 0; i < d10Count; i++)
+      d10Fields[`field_${i}`] = enforce.isString();
+    // one dependency to give changed() something to do
+    d10Fields['dependent'] = enforce.isString().dependsOn($ => $.field_0);
+    const d10Schema = enforce.shape(d10Fields);
+    const d10Data: Record<string, string> = {};
+    for (let i = 0; i < d10Count; i++) d10Data[`field_${i}`] = `v${i}`;
+    d10Data['dependent'] = 'x';
+
+    const d10Suite = create((data: Record<string, string>) => {
+      for (let i = 0; i < d10Count; i++) {
+        test(`field_${i}` as TFieldName, () => {
+          enforce(data[`field_${i}`]).isString();
+        });
+      }
+      test('dependent' as TFieldName, () => {
+        enforce(data.dependent).isString();
+      });
+    }, d10Schema);
+    d10Suite.run(d10Data);
+    bench(
+      'D10 serialize large(100) after changed(field_0) [retain+serialize]',
+      () => {
+        const res = d10Suite
+          .changed('field_0')
+          .run({ ...d10Data, field_0: 'new' });
+        SuiteSerializer.serialize(res);
+      },
+      { time: 250 },
+    );
+  }
+
+  // D11 realistic registration flow — sequential changed steps in one iteration
+  {
+    const regSchema = enforce.shape({
+      email: enforce.isString(),
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+      organizationId: enforce.isString(),
+      username: enforce.isString().dependsOn($ => $.organizationId),
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+    });
+    const regSuite = create(data => {
+      test('email', () => {
+        enforce(data.email).isNotBlank();
+      });
+      test('password', () => {
+        enforce(data.password).longerThanOrEquals(8);
+      });
+      test('confirmPassword', () => {
+        enforce(data.confirmPassword).equals(data.password);
+      });
+      test('username', async () => {
+        const available = await Promise.resolve(data.username !== 'taken');
+        enforce(available).isTruthy();
+      });
+      test('profile.country', () => {
+        enforce(data.profile.country).isNotBlank();
+      });
+      test('profile.state', () => {
+        if (data.profile.country === 'US')
+          enforce(data.profile.state).isNotBlank();
+      });
+    }, regSchema);
+    // initial warm run
+    regSuite.run({
+      email: '',
+      password: 'abcdefgh',
+      confirmPassword: 'abcdefgh',
+      organizationId: 'A',
+      username: 'free',
+      profile: { country: 'CA', state: '' },
+    });
+
+    bench(
+      'D11 realistic registration flow — 6-step sequence [email→password→org→country]',
+      () => {
+        // Single iteration does the whole realistic sequence (steady-state)
+        regSuite.changed('email').run({
+          email: 'a@b.com',
+          password: 'abcdefgh',
+          confirmPassword: 'abcdefgh',
+          organizationId: 'A',
+          username: 'free',
+          profile: { country: 'CA', state: '' },
+        });
+        regSuite.changed('password').run({
+          email: 'a@b.com',
+          password: 'abcdefgh2',
+          confirmPassword: 'abcdefgh',
+          organizationId: 'A',
+          username: 'free',
+          profile: { country: 'CA', state: '' },
+        });
+        regSuite.changed('confirmPassword').run({
+          email: 'a@b.com',
+          password: 'abcdefgh2',
+          confirmPassword: 'abcdefgh2',
+          organizationId: 'A',
+          username: 'free',
+          profile: { country: 'CA', state: '' },
+        });
+        regSuite.changed('organizationId').run({
+          email: 'a@b.com',
+          password: 'abcdefgh2',
+          confirmPassword: 'abcdefgh2',
+          organizationId: 'B',
+          username: 'free',
+          profile: { country: 'CA', state: '' },
+        });
+        regSuite.changed('profile.country').run({
+          email: 'a@b.com',
+          password: 'abcdefgh2',
+          confirmPassword: 'abcdefgh2',
+          organizationId: 'B',
+          username: 'free',
+          profile: { country: 'US', state: '' },
+        });
+      },
+      { time: 250 },
+    );
+  }
+
+  // D12 realistic checkout flow — billing+shipping+travelers interleaved
+  {
+    const checkoutAddress = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+    const checkoutTraveler = enforce.shape({
+      country: enforce.isString(),
+      passportNumber: enforce.isString().dependsOn($ => $.country),
+    });
+    const checkoutSchema = enforce.shape({
+      billing: checkoutAddress,
+      shipping: checkoutAddress,
+      travelers: enforce.isArrayOf(checkoutTraveler),
+    });
+    const checkoutSuite = create(data => {
+      group('billing' as TGroupName, () => {
+        test('billing.country' as TFieldName, () => {
+          enforce(data.billing.country).isString();
+        });
+        test('billing.state' as TFieldName, () => {
+          enforce(data.billing.state).isString();
+        });
+      });
+      group('shipping' as TGroupName, () => {
+        test('shipping.country' as TFieldName, () => {
+          enforce(data.shipping.country).isString();
+        });
+        test('shipping.state' as TFieldName, () => {
+          enforce(data.shipping.state).isString();
+        });
+      });
+      each(data.travelers, (t, i) => {
+        test(`travelers.${i}.country` as TFieldName, () => {
+          enforce(t.country).isString();
+        });
+        test(`travelers.${i}.passportNumber` as TFieldName, () => {
+          enforce(t.passportNumber).isString();
+        });
+      });
+    }, checkoutSchema);
+    const checkoutData = {
+      billing: { country: 'US', state: 'CA' },
+      shipping: { country: 'US', state: 'NY' },
+      travelers: travelersData(5),
+    };
+    checkoutSuite.run(checkoutData);
+    bench(
+      'D12 realistic checkout flow — billing+shipping+travelers [9 travelers total]',
+      () => {
+        checkoutSuite
+          .changed('billing.country')
+          .run({ ...checkoutData, billing: { country: 'CA', state: 'CA' } });
+        checkoutSuite.changed('travelers.2.country').run(checkoutData);
+        checkoutSuite
+          .changed('shipping.country')
+          .run({ ...checkoutData, shipping: { country: 'CA', state: '' } });
+      },
+      { time: 250 },
+    );
+  }
+
+  // D13 volatility stress: 100 fields only 1 changed
+  {
+    const volFields: Record<string, StringRule> = {};
+    for (let i = 0; i < 100; i++) volFields[`field_${i}`] = enforce.isString();
+    volFields['consumer'] = enforce.isString().dependsOn($ => $.field_0);
+    const volSchema = enforce.shape(volFields);
+    const volData: Record<string, string> = {};
+    for (let i = 0; i < 100; i++) volData[`field_${i}`] = `v${i}`;
+    volData['consumer'] = 'x';
+
+    const volSuiteRun = create((data: Record<string, string>) => {
+      for (let i = 0; i < 100; i++) {
+        test(`field_${i}` as TFieldName, () => {
+          enforce(data[`field_${i}`]).isString();
+        });
+      }
+      test('consumer' as TFieldName, () => {
+        enforce(data.consumer).isString();
+      });
+    }, volSchema);
+
+    const volSuiteChanged = create((data: Record<string, string>) => {
+      for (let i = 0; i < 100; i++) {
+        test(`field_${i}` as TFieldName, () => {
+          enforce(data[`field_${i}`]).isString();
+        });
+      }
+      test('consumer' as TFieldName, () => {
+        enforce(data.consumer).isString();
+      });
+    }, volSchema);
+
+    volSuiteRun.run(volData);
+    volSuiteChanged.run(volData);
+    const volChangedData = { ...volData, field_0: 'changed' };
+
+    bench(
+      'D13 volatility run() full 101 fields [baseline]',
+      () => {
+        volSuiteRun.run(volData);
+      },
+      { time: 250 },
+    );
+    bench(
+      'D13 volatility changed(field_0) [2/101 fields] — ratio gate',
+      () => {
+        volSuiteChanged.changed('field_0').run(volChangedData);
+      },
+      { time: 250 },
+    );
+  }
+});

--- a/packages/vest/docs/focus.md
+++ b/packages/vest/docs/focus.md
@@ -65,6 +65,12 @@ If a group fails these checks, `skip(true)` pushes a transient `Focused` isolate
 
 A fundamental implication of using `onlyGroup` is the isolation of execution solely to targeted groups. Therefore, all "top-level" tests (tests declared without a parent group) must be reliably excluded.
 
+Schema-generated failures are emitted as top-level Vest tests because schemas
+do not declare Vest group membership. Consequently, `onlyGroup` excludes those
+failures, while `skipGroup` affects only tests inside the skipped group. Combine
+group focus with field-level `only` or `skip` when schema validation also needs
+to be narrowed.
+
 Inside `useIsExcluded()` (specifically `useIsExcludedByGroup`), the test node is strictly verified against the `onlyGroup` rule. If `onlyGroup` is active, and the test lacks a `groupName`, it is instantly excluded. This rule handles edge cases dynamically—even if a top-level test shares the exact name of a successfully `only`'d test inside an allowed group, the top-level test will remain isolated and excluded.
 
 ### 3. Field Granularity (`useIsExcludedByField`)

--- a/packages/vest/src/__tests__/inference.schemaRelationships.test.ts
+++ b/packages/vest/src/__tests__/inference.schemaRelationships.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Vest suite inference for Schema Relationships
+ * Ensures suite with schema infers data shape and that describe() is available
+ */
+
+/* eslint-disable vitest/valid-expect, vitest/no-commented-out-tests */
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import type { DescribeResult } from 'n4s';
+
+import { create, test, enforce } from '../vest';
+
+function typeChecks() {
+  const schema = enforce.shape({
+    password: enforce.isString(),
+    confirmPassword: enforce.isString().dependsOn($ => {
+      // scope should be inferred without explicit annotation
+      expectTypeOf($).toMatchTypeOf<{ root: unknown }>();
+      expectTypeOf($.password).toMatchTypeOf<unknown>();
+      expectTypeOf($.root).toMatchTypeOf<unknown>();
+      return $.password;
+    }),
+    profile: enforce.shape({
+      age: enforce.isNumber(),
+      displayName: enforce.isString().dependsOn($ => {
+        expectTypeOf($).toMatchTypeOf<{ root: unknown }>();
+        return $.age;
+      }),
+    }),
+  });
+
+  // inferred data shape - schema.infer
+  expectTypeOf(schema.infer).toEqualTypeOf<{
+    password: string;
+    confirmPassword: string;
+    profile: { age: number; displayName: string };
+  }>();
+
+  // describe() output shape
+  expectTypeOf(schema.describe).returns.toEqualTypeOf<DescribeResult>();
+
+  // Suite should infer data from schema
+  const suite = create(data => {
+    // inferred data shape inside suite callback
+    expectTypeOf(data).toEqualTypeOf<{
+      password: string;
+      confirmPassword: string;
+      profile: { age: number; displayName: string };
+    }>();
+    expectTypeOf(data.password).toEqualTypeOf<string>();
+    expectTypeOf(data.confirmPassword).toEqualTypeOf<string>();
+    expectTypeOf(data.profile).toEqualTypeOf<{
+      age: number;
+      displayName: string;
+    }>();
+    expectTypeOf(data.profile.age).toEqualTypeOf<number>();
+    expectTypeOf(data.profile.displayName).toEqualTypeOf<string>();
+    test('password', () => {
+      enforce(data.password).isString();
+    });
+    test('confirmPassword', () => {
+      enforce(data.confirmPassword).isString();
+    });
+    test('profile.displayName', () => {
+      enforce(data.profile.displayName).isString();
+    });
+  }, schema);
+
+  // inferred data shape - suite.run parameter
+  expectTypeOf(suite.run).parameter(0).toEqualTypeOf<{
+    password: string;
+    confirmPassword: string;
+    profile: { age: number; displayName: string };
+  }>();
+  expectTypeOf(suite.get).returns.toMatchTypeOf<{
+    hasErrors: unknown;
+  }>();
+
+  // data should be { password: string, confirmPassword: string, profile: { age: number, displayName: string } }
+  // The following should be valid
+  suite.run({
+    password: 'a',
+    confirmPassword: 'a',
+    profile: { age: 1, displayName: 'x' },
+  });
+
+  // changed() should accept field names from schema - dependency fields
+  expectTypeOf(suite.changed).toBeFunction();
+  // string acceptance is proven by the value-level changed() calls below
+  // valid dependency field should be accepted
+  suite.changed('password').run({
+    password: 'a',
+    confirmPassword: 'a',
+    profile: { age: 1, displayName: 'x' },
+  });
+  suite.changed('profile.displayName').run({
+    password: 'a',
+    confirmPassword: 'a',
+    profile: { age: 1, displayName: 'x' },
+  });
+  // also test changed with array of fields
+  suite.changed(['password', 'profile.displayName']).run({
+    password: 'a',
+    confirmPassword: 'a',
+    profile: { age: 1, displayName: 'x' },
+  });
+
+  // describe should be on schema - describe() output
+  const d = schema.describe();
+  expectTypeOf(d).toEqualTypeOf<ReturnType<typeof schema.describe>>();
+  expectTypeOf(d.dependencies).toEqualTypeOf<DescribeResult['dependencies']>();
+  expectTypeOf(d.relationships).toEqualTypeOf<
+    DescribeResult['relationships']
+  >();
+  expectTypeOf(d.dependencies).toBeArray();
+  expectTypeOf(d.relationships).toBeArray();
+  const deps: typeof d.dependencies = d.dependencies;
+  void deps;
+}
+
+// typeChecks is type-only — not invoked at runtime to avoid enforce.shape side effects;
+// tsc --noEmit with expectTypeOf validates it statically
+void typeChecks;
+
+describe('inference vest schemaRelationships', () => {
+  it('suite with schema infers precise types', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/vest/src/__tests__/runtimeTestUtils.ts
+++ b/packages/vest/src/__tests__/runtimeTestUtils.ts
@@ -1,0 +1,6 @@
+export function invokeWithUnknown<Result>(
+  fn: (...args: never[]) => Result,
+  ...args: unknown[]
+): Result {
+  return fn(...(args as never[]));
+}

--- a/packages/vest/src/core/isolate/IsolateSuite/IsolateSuite.ts
+++ b/packages/vest/src/core/isolate/IsolateSuite/IsolateSuite.ts
@@ -17,6 +17,11 @@ import {
 } from '../VestIsolateType';
 
 export type TIsolateSuite = TVestIsolate<{
+  /**
+   * Last successful full callback value. Root ownership makes it follow the
+   * same reset, replacement, serialization, and hydration lifecycle as tests.
+   */
+  mappedSchemaOutput?: MappedSchemaOutput;
   optional: OptionalFields;
   resolver: CB<SuiteResult<TFieldName, TGroupName, any>>;
   // Registry indices (populated by IsolateRegistry)
@@ -30,11 +35,18 @@ export type TIsolateSuite = TVestIsolate<{
   registry_warning?: RegistryIndex;
 }>;
 
+export type MappedSchemaOutput = {
+  hasValue: true;
+  value: unknown;
+};
+
 export function IsolateSuite<Callback extends CB = CB>(
   callback: Callback,
   resolver: CB<SuiteResult<TFieldName, TGroupName, any>>,
+  mappedSchemaOutput?: MappedSchemaOutput,
 ): TIsolateSuite {
   return createVestIsolate(VestIsolateType.Suite, callback, {
+    ...(mappedSchemaOutput === undefined ? {} : { mappedSchemaOutput }),
     optional: {},
     resolver,
   });

--- a/packages/vest/src/core/isolate/IsolateTest/IsolateTestReconciler.ts
+++ b/packages/vest/src/core/isolate/IsolateTest/IsolateTestReconciler.ts
@@ -76,12 +76,30 @@ function useHandleTestWithKey(newNode: TIsolateTest): Result<TIsolateTest> {
       }
 
       if (useIsExcluded(newNode)) {
+        retainCurrentFieldName(prevNode, newNode);
         return false;
       }
 
       return true;
     }),
   );
+}
+
+/**
+ * A keyed test keeps its previous verdict when focused out, but its declaration
+ * may have moved inside a reorderable container. Retain the verdict under the
+ * field name declared by the current run so selectors and registries follow
+ * item identity instead of the item's former array index.
+ */
+function retainCurrentFieldName(
+  retainedNode: TIsolateTest,
+  currentNode: TIsolateTest,
+): void {
+  const currentFieldName = VestTest.getData(currentNode).fieldName;
+  VestTest.setData(retainedNode, retainedData => ({
+    ...retainedData,
+    fieldName: currentFieldName,
+  }));
 }
 
 function cancelOverriddenPendingTestOnTestReRun(

--- a/packages/vest/src/isolates/__tests__/each.test.ts
+++ b/packages/vest/src/isolates/__tests__/each.test.ts
@@ -105,4 +105,36 @@ describe('each', () => {
     expect(suite.hasErrors('item.9' as TFieldName)).toBe(false);
     expect(suite.hasErrors('item.10' as TFieldName)).toBe(true);
   });
+
+  it('moves retained keyed results to their current field after a focused reorder', () => {
+    type Item = { id: string; value: string };
+    const suite = vest.create((items: Item[], focused: string | null) => {
+      if (focused !== null) vest.only(focused);
+      vest.each(items, (item, index) => {
+        vest.test(
+          `item.${index}` as TFieldName,
+          () => item.value.length > 0,
+          item.id,
+        );
+      });
+    });
+
+    suite.run(
+      [
+        { id: 'invalid', value: '' },
+        { id: 'valid', value: 'ok' },
+      ],
+      null,
+    );
+    const result = suite.run(
+      [
+        { id: 'valid', value: 'ok' },
+        { id: 'invalid', value: '' },
+      ],
+      'item.0',
+    );
+
+    expect(result.hasErrors('item.0' as TFieldName)).toBe(false);
+    expect(result.hasErrors('item.1' as TFieldName)).toBe(true);
+  });
 });

--- a/packages/vest/src/suite/SuiteTypes.ts
+++ b/packages/vest/src/suite/SuiteTypes.ts
@@ -1,4 +1,4 @@
-import { CB } from 'vest-utils';
+import { CB, type DropFirst } from 'vest-utils';
 import { StandardSchemaV1 } from 'vest-utils/standardSchemaSpec';
 
 import { Subscribe } from '../core/VestBus/VestBus';
@@ -16,12 +16,23 @@ import { SuiteSelectors } from '../suiteResult/selectors/suiteSelectors';
 
 import { TTypedMethods } from './getTypedMethods';
 
+type CallbackTail<T extends CB> =
+  DropFirst<Parameters<T>> extends never ? [] : DropFirst<Parameters<T>>;
+
+export type SuiteRunArguments<
+  S extends TSchema,
+  T extends CB,
+  Data = InferSchemaData<S>,
+> = S extends undefined
+  ? Parameters<T>
+  : [data: Data, ...args: CallbackTail<T>];
+
 export type SuiteCallbackWithSchema<
   S extends TSchema,
   T extends CB,
 > = S extends undefined
   ? T
-  : (data: InferSchemaOutput<S>, ...args: any[]) => void;
+  : (data: InferSchemaOutput<S>, ...args: CallbackTail<T>) => void;
 
 export type Suite<
   F extends TFieldName,
@@ -44,21 +55,13 @@ type SuiteMethods<
   reset: CB<void>;
   remove: CB<void, [fieldName: F]>;
   resetField: CB<void, [fieldName: F]>;
-  run: (
-    ...args: S extends undefined
-      ? Parameters<T>
-      : [data: InferSchemaData<S>, ...args: any[]]
-  ) => SuiteResult<F, G, S>;
-  runStatic: (
-    ...args: S extends undefined
-      ? Parameters<T>
-      : [data: InferSchemaData<S>, ...args: any[]]
-  ) => SuiteResult<F, G, S>;
-  validate: (
-    ...args: S extends undefined
-      ? Parameters<T>
-      : [data: InferSchemaData<S>, ...args: any[]]
-  ) => SuiteResult<F, G, S>;
+  changed: CB<
+    FocusedMethods<F, G, T, S>,
+    [changedField: FieldExclusion<F> | string | string[]]
+  >;
+  run: (...args: SuiteRunArguments<S, T>) => SuiteResult<F, G, S>;
+  runStatic: (...args: SuiteRunArguments<S, T>) => SuiteResult<F, G, S>;
+  validate: (...args: SuiteRunArguments<S, T>) => SuiteResult<F, G, S>;
   subscribe: Subscribe;
 } & AfterMethods<F, G, T, S> &
   TTypedMethods<F, G> &
@@ -72,14 +75,16 @@ type FocusedMethods<
 > = {
   afterEach: CB<FocusedMethods<F, G, T, S>, [callback: CB]>;
   afterField: CB<FocusedMethods<F, G, T, S>, [fieldName: F, callback: CB]>;
+  changed: CB<
+    FocusedMethods<F, G, T, S>,
+    [changedField: FieldExclusion<F> | string | string[]]
+  >;
   focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F, G>]>;
   only: CB<FocusedMethods<F, G, T, S>, [onlyField: FieldExclusion<F>]>;
   // run is included but runStatic is intentionally omitted: runStatic is stateless
   // and does not carry focus modifiers, so it is not part of the focused API surface.
   run: (
-    ...args: S extends undefined
-      ? Parameters<T>
-      : [data: Partial<InferSchemaData<S>>, ...args: any[]]
+    ...args: SuiteRunArguments<S, T, Partial<InferSchemaData<S>>>
   ) => SuiteResult<F, G, S>;
 };
 
@@ -91,13 +96,13 @@ type AfterMethods<
 > = {
   afterEach: CB<AfterMethods<F, G, T, S>, [callback: CB]>;
   afterField: CB<AfterMethods<F, G, T, S>, [fieldName: F, callback: CB]>;
+  changed: CB<
+    FocusedMethods<F, G, T, S>,
+    [changedField: FieldExclusion<F> | string | string[]]
+  >;
   focus: CB<FocusedMethods<F, G, T, S>, [config: SuiteModifiers<F, G>]>;
   only: CB<FocusedMethods<F, G, T, S>, [onlyField: FieldExclusion<F>]>;
-  run: (
-    ...args: S extends undefined
-      ? Parameters<T>
-      : [data: InferSchemaData<S>, ...args: any[]]
-  ) => SuiteResult<F, G, S>;
+  run: (...args: SuiteRunArguments<S, T>) => SuiteResult<F, G, S>;
 };
 
 /**
@@ -122,4 +127,13 @@ export type SuiteModifiers<
   onlyGroup?: G | G[];
   skip?: FieldExclusion<F>;
   skipGroup?: G | G[];
+};
+
+/** @internal Runtime-only state that must not leak into focus()'s public API. */
+export type InternalSuiteModifiers<
+  F extends TFieldName,
+  G extends TGroupName = TGroupName,
+> = SuiteModifiers<F, G> & {
+  __changed?: string[];
+  __skipAll?: boolean;
 };

--- a/packages/vest/src/suite/__tests__/__snapshots__/focus.test.ts.snap
+++ b/packages/vest/src/suite/__tests__/__snapshots__/focus.test.ts.snap
@@ -4,6 +4,7 @@ exports[`suite.focus: only > focus return value > should be the rest of the suit
 {
   "afterEach": [Function],
   "afterField": [Function],
+  "changed": [Function],
   "dump": [Function],
   "focus": [Function],
   "get": [Function],

--- a/packages/vest/src/suite/__tests__/acceptance.threePart.test.ts
+++ b/packages/vest/src/suite/__tests__/acceptance.threePart.test.ts
@@ -1,0 +1,976 @@
+import { enforce } from 'n4s';
+import type { ScopeHandle } from 'n4s';
+import { describe, it, expect } from 'vitest';
+import { invariant, isArray } from 'vest-utils';
+
+import {
+  create,
+  test,
+  group,
+  include,
+  skipWhen,
+  omitWhen,
+  only,
+  optional,
+  warn,
+} from '../../vest';
+import { each } from '../../isolates/each';
+import { invokeWithUnknown } from '../../__tests__/runtimeTestUtils';
+
+type SuiteLog = {
+  record: (field: string) => void;
+  reset: () => void;
+  get: () => string[];
+};
+
+function createLog(): SuiteLog {
+  const fields: string[] = [];
+  return {
+    record(f: string): void {
+      fields.push(f);
+    },
+    reset(): void {
+      fields.length = 0;
+    },
+    get(): string[] {
+      return [...fields];
+    },
+  };
+}
+
+// 1. Sanity / control tests
+describe('Acceptance — Sanity', (): void => {
+  it('runs an ordinary suite without relationships', async (): Promise<void> => {
+    const suite = create((data: { password: string }): void => {
+      test('password', 'Too short', (): void => {
+        enforce(data.password).longerThanOrEquals(8);
+      });
+    });
+    const result = await suite.run({ password: '123' });
+    expect(result.getErrors('password')).toEqual(['Too short']);
+  });
+
+  it('relationship metadata does not change existing suite test behavior', async (): Promise<void> => {
+    const cb = (data: {
+      password: string;
+      email?: string;
+      confirmPassword?: string;
+    }): void => {
+      test('password', 'Too short', (): void => {
+        enforce(data.password).longerThanOrEquals(8);
+      });
+      test('email', 'Required', (): void => {
+        enforce(data.email).isNotBlank();
+      });
+    };
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const withoutSchema = create(cb);
+    const withSchema = create(cb, schema);
+    const dataValid = { password: 'abcdefgh', email: 'a@b.com' };
+    const dataInvalid = { password: '123', email: '' };
+    const r1 = await withoutSchema.run(dataValid);
+    const _r2 = await invokeWithUnknown(withSchema.run, dataValid);
+    expect(r1.hasErrors('password')).toBe(_r2.hasErrors('password'));
+    expect(r1.hasErrors('email')).toBe(
+      invokeWithUnknown(_r2.hasErrors, 'email'),
+    );
+    const r3 = await withoutSchema.run(dataInvalid);
+    const r4 = await invokeWithUnknown(withSchema.run, dataInvalid);
+    expect(r3.getErrors('password')).toEqual(r4.getErrors('password'));
+  });
+
+  it('a schema with dependencies behaves identically under run()', async (): Promise<void> => {
+    const schemaWith = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const schemaWithout = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString(),
+    });
+    const logWith = createLog();
+    const logWithout = createLog();
+    const createSuite = (
+      schema: typeof schemaWith | typeof schemaWithout,
+      log: SuiteLog,
+    ) =>
+      create((data: { password: string; confirmPassword: string }): void => {
+        test('password', (): void => {
+          log.record('password');
+          enforce(data.password).isNotBlank();
+        });
+        test('confirmPassword', (): void => {
+          log.record('confirmPassword');
+          enforce(data.confirmPassword).equals(data.password);
+        });
+      }, schema);
+    const suiteWith = createSuite(schemaWith, logWith);
+    const suiteWithout = createSuite(schemaWithout, logWithout);
+    const data = { password: 'abcdefgh', confirmPassword: 'xyz' };
+    const rWith = await suiteWith.run(data);
+    const rWithout = await suiteWithout.run(data);
+    expect(logWith.get()).toEqual(logWithout.get());
+    expect(rWith.hasErrors('confirmPassword')).toBe(
+      rWithout.hasErrors('confirmPassword'),
+    );
+  });
+});
+
+// 2. Direct proof that the feature succeeds (before/after controls)
+describe('Acceptance — Feature success (before/after)', (): void => {
+  it('without relationship, changed() does not know about sibling (problem)', async (): Promise<void> => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString(),
+    });
+    const log = createLog();
+    const suite = create(
+      (data: { password: string; confirmPassword: string }): void => {
+        test('password', (): void => {
+          log.record('password');
+          enforce(data.password).isNotBlank();
+        });
+        test('confirmPassword', (): void => {
+          log.record('confirmPassword');
+          enforce(data.confirmPassword).equals(data.password);
+        });
+      },
+      schema,
+    );
+    await suite.run({ password: 'abcdefgh', confirmPassword: 'abcdefgh' });
+    log.reset();
+    const result = await suite
+      .changed('password')
+      .run({ password: 'abcdefgh2', confirmPassword: 'abcdefgh' });
+    expect(log.get()).toEqual(['password']);
+    expect(result.hasErrors('confirmPassword')).toBe(false); // stale
+  });
+
+  it('with relationship, changed() does know about sibling (solution)', async (): Promise<void> => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const log = createLog();
+    const suite = create(
+      (data: { password: string; confirmPassword: string }): void => {
+        test('password', (): void => {
+          log.record('password');
+          enforce(data.password).isNotBlank();
+        });
+        test('confirmPassword', (): void => {
+          log.record('confirmPassword');
+          enforce(data.confirmPassword).equals(data.password);
+        });
+      },
+      schema,
+    );
+    await suite.run({ password: 'abcdefgh', confirmPassword: 'abcdefgh' });
+    log.reset();
+    const result = await suite
+      .changed('password')
+      .run({ password: 'abcdefgh2', confirmPassword: 'abcdefgh' });
+    expect(log.get()).toEqual(['password', 'confirmPassword']);
+    expect(result.hasErrors('confirmPassword')).toBe(true);
+  });
+
+  it('fixing dependent clears result', async (): Promise<void> => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const suite = create(
+      (data: { password: string; confirmPassword: string }): void => {
+        test('password', (): void => {
+          enforce(data.password).isNotBlank();
+        });
+        test('confirmPassword', (): void => {
+          enforce(data.confirmPassword).equals(data.password);
+        });
+      },
+      schema,
+    );
+    await suite.run({ password: 'abcdefgh', confirmPassword: 'abcdefgh' });
+    let result = await suite
+      .changed('password')
+      .run({ password: 'newpass1', confirmPassword: 'abcdefgh' });
+    expect(result.hasErrors('confirmPassword')).toBe(true);
+    result = await suite
+      .changed('confirmPassword')
+      .run({ password: 'newpass1', confirmPassword: 'newpass1' });
+    expect(result.hasErrors('confirmPassword')).toBe(false);
+  });
+
+  it('nested dependency success before/after', async (): Promise<void> => {
+    const schemaWithout = enforce.shape({
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString(),
+      }),
+    });
+    const schemaWith = enforce.shape({
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+    });
+    const makeSuite = (schema: typeof schemaWithout | typeof schemaWith) =>
+      create((data: { profile: { country: string; state: string } }): void => {
+        test('profile.country', (): void => {
+          enforce(data.profile.country).isNotBlank();
+        });
+        test('profile.state', (): void => {
+          if (data.profile.country === 'US')
+            enforce(data.profile.state).isNotBlank();
+        });
+      }, schema);
+    const suiteWithout = makeSuite(schemaWithout);
+    const suiteWith = makeSuite(schemaWith);
+    await suiteWithout.run({ profile: { country: 'CA', state: '' } });
+    await suiteWith.run({ profile: { country: 'CA', state: '' } });
+    // Monkey-patch to capture - simpler: just check hasErrors after changed
+    await suiteWithout
+      .changed('profile.country')
+      .run({ profile: { country: 'US', state: '' } });
+    const rWithoutHasError = suiteWithout.get().hasErrors('profile.state');
+    await suiteWith
+      .changed('profile.country')
+      .run({ profile: { country: 'US', state: '' } });
+    const rWithHasError = suiteWith.get().hasErrors('profile.state');
+    expect(rWithoutHasError).toBe(false); // stale-valid
+    expect(rWithHasError).toBe(true);
+  });
+
+  it('async success — without relationship stale, with relationship correct', async (): Promise<void> => {
+    const schemaWithout = enforce.shape({
+      organizationId: enforce.isString(),
+      username: enforce.isString(),
+    });
+    const schemaWith = enforce.shape({
+      organizationId: enforce.isString(),
+      username: enforce.isString().dependsOn($ => $.organizationId),
+    });
+    const makeSuite = (schema: typeof schemaWithout | typeof schemaWith) =>
+      create((data: { organizationId: string; username: string }): void => {
+        test('username', async (): Promise<void> => {
+          await Promise.resolve(
+            data.username !== 'taken' || data.organizationId === 'A',
+          );
+          // For org B, 'taken' should be invalid
+          const isAvailable =
+            data.organizationId === 'B' ? data.username !== 'taken' : true;
+          enforce(isAvailable).isTruthy();
+        });
+      }, schema);
+    const suiteWithout = makeSuite(schemaWithout);
+    const suiteWith = makeSuite(schemaWith);
+    await suiteWithout.run({ organizationId: 'A', username: 'free' });
+    await suiteWith.run({ organizationId: 'A', username: 'free' });
+    await suiteWithout
+      .changed('organizationId')
+      .run({ organizationId: 'B', username: 'taken' });
+    expect(suiteWithout.get().hasErrors('username')).toBe(false); // stale
+    await suiteWith
+      .changed('organizationId')
+      .run({ organizationId: 'B', username: 'taken' });
+    expect(suiteWith.get().hasErrors('username')).toBe(true);
+  });
+
+  it('dependsOn is directional — changed(source) runs target, not vice versa', async (): Promise<void> => {
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn($ => $.a),
+    });
+    const log = createLog();
+    const suite = create((data: { a: string; b: string }): void => {
+      test('a', (): void => {
+        log.record('a');
+        enforce(data.a).isNotBlank();
+      });
+      test('b', (): void => {
+        log.record('b');
+        enforce(data.b).isNotBlank();
+      });
+    }, schema);
+    await suite.run({ a: 'x', b: 'y' });
+    log.reset();
+    await suite.changed('a').run({ a: 'x', b: 'y' });
+    expect(log.get()).toEqual(['a', 'b']);
+    log.reset();
+    await suite.changed('b').run({ a: 'x', b: 'y' });
+    expect(log.get()).toEqual(['b']);
+  });
+});
+
+// 3. No-regression
+describe('Acceptance — No regression', (): void => {
+  it('run() unchanged', async (): Promise<void> => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const suite = create(
+      (data: { password: string; confirmPassword: string }): void => {
+        test('password', (): void => {
+          enforce(data.password).isNotBlank();
+        });
+        test('confirmPassword', (): void => {
+          enforce(data.confirmPassword).equals(data.password);
+        });
+      },
+      schema,
+    );
+    const result = await suite.run({
+      password: 'abcdefgh',
+      confirmPassword: 'xyz',
+    });
+    expect(result.hasErrors('confirmPassword')).toBe(true);
+    // Should run complete suite, not just changed
+    const log = createLog();
+    const suite2 = create(
+      (data: {
+        password: string;
+        confirmPassword: string;
+        a?: string;
+        b?: string;
+      }): void => {
+        test('a', (): void => {
+          log.record('a');
+          enforce(data.a).isNotBlank();
+        });
+        test('b', (): void => {
+          log.record('b');
+          enforce(data.b).isNotBlank();
+        });
+      },
+      schema,
+    );
+    await invokeWithUnknown(suite2.run, { a: '1', b: '2' });
+    expect(log.get()).toEqual(['a', 'b']);
+  });
+
+  it('only() unchanged — only exact, changed is dependency-aware', async (): Promise<void> => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const log = createLog();
+    const suite = create(
+      (data: { password: string; confirmPassword: string }): void => {
+        test('password', (): void => {
+          log.record('password');
+          enforce(data.password).isNotBlank();
+        });
+        test('confirmPassword', (): void => {
+          log.record('confirmPassword');
+          enforce(data.confirmPassword).equals(data.password);
+        });
+      },
+      schema,
+    );
+    await suite.run({ password: 'abcdefgh', confirmPassword: 'abcdefgh' });
+    log.reset();
+    await suite
+      .only('password')
+      .run({ password: 'xyz', confirmPassword: 'mismatch' });
+    expect(log.get()).toEqual(['password']);
+    log.reset();
+    await suite
+      .changed('password')
+      .run({ password: 'xyz2', confirmPassword: 'mismatch' });
+    expect(log.get()).toEqual(['password', 'confirmPassword']);
+  });
+
+  it('focus() unchanged', async (): Promise<void> => {
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn($ => $.a),
+    });
+    const suite = create((data: { a: string; b: string }): void => {
+      test('a', (): void => {
+        enforce(data.a).isNotBlank();
+      });
+      test('b', (): void => {
+        enforce(data.b).isNotBlank();
+      });
+    }, schema);
+    const resultFocused = await suite
+      .focus({ only: 'a' })
+      .run({ a: '', b: '' });
+    expect(resultFocused.hasErrors('a')).toBe(true);
+    // b should not have run (focused)
+    const resultFull = await suite.run({ a: '', b: '' });
+    expect(resultFull.hasErrors('b')).toBe(true);
+  });
+
+  it('include() unchanged — include().when() cross-field inclusion ignores relationship metadata', async (): Promise<void> => {
+    const schemaWithout = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString(),
+      c: enforce.isString(),
+    });
+    const schemaWith = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn($ => $.a),
+      c: enforce.isString(),
+    });
+    const makeSuite = (schema: typeof schemaWith | typeof schemaWithout) => {
+      const log = createLog();
+      const suite = create(
+        (data: { a: string; b: string; c: string }): void => {
+          only('a');
+          include('b').when('a');
+          test('a', (): void => {
+            log.record('a');
+            enforce(data.a).isNotBlank();
+          });
+          test('b', (): void => {
+            log.record('b');
+            enforce(data.b).isNotBlank();
+          });
+          test('c', (): void => {
+            log.record('c');
+            enforce(data.c).isNotBlank();
+          });
+        },
+        schema,
+      );
+      return { log, suite };
+    };
+    const data = { a: '', b: '', c: '' };
+    const plain = makeSuite(schemaWithout);
+    const withRel = makeSuite(schemaWith);
+    const rPlain = await plain.suite.run(data);
+    const rWith = await withRel.suite.run(data);
+    // Cross-field inclusion actually happened: only('a') ran 'a' plus the
+    // included 'b', while unrelated 'c' stayed out.
+    expect(plain.log.get()).toEqual(['a', 'b']);
+    expect(rPlain.hasErrors('a')).toBe(true);
+    expect(rPlain.hasErrors('b')).toBe(true);
+    expect(rPlain.hasErrors('c')).toBe(false);
+    // Attached dependsOn() relationships leave that behavior unchanged.
+    expect(withRel.log.get()).toEqual(plain.log.get());
+    expect(rWith.hasErrors('a')).toBe(rPlain.hasErrors('a'));
+    expect(rWith.hasErrors('b')).toBe(rPlain.hasErrors('b'));
+    expect(rWith.hasErrors('c')).toBe(rPlain.hasErrors('c'));
+    // Inclusion survives dependency-aware runs: changed('a') still runs the
+    // included dependent 'b' while unrelated 'c' stays out.
+    withRel.log.reset();
+    await withRel.suite.changed('a').run(data);
+    expect(withRel.log.get()).toEqual(['a', 'b']);
+  });
+
+  it('skipWhen() unchanged — canonical sequence', async (): Promise<void> => {
+    const suite = create((data: { a: string; b: string }): void => {
+      test('a', (): void => {
+        enforce(data.a).isNotBlank();
+      });
+      skipWhen(data.b !== 'run', (): void => {
+        test('b', (): void => {
+          enforce(data.b).isNotBlank();
+        });
+      });
+    });
+    const r1 = await suite.run({ a: '1', b: '' });
+    expect(r1.hasErrors('b')).toBe(false); // skipped, so no error even though blank
+    // Attach irrelevant schema and ensure same
+    const schema = enforce.shape({
+      x: enforce.isString(),
+      y: enforce.isString().dependsOn($ => $.x),
+    });
+    const suiteWithSchema = create(
+      (data: { x: string; y: string; a?: string; b?: string }): void => {
+        test('a', (): void => {
+          enforce(data.a).isNotBlank();
+        });
+        skipWhen(data.b !== 'run', (): void => {
+          test('b', (): void => {
+            enforce(data.b).isNotBlank();
+          });
+        });
+      },
+      schema,
+    );
+    const r3 = await invokeWithUnknown(suiteWithSchema.run, { a: '1', b: '' });
+    expect(invokeWithUnknown(r3.hasErrors, 'b')).toBe(false);
+  });
+
+  it('omitWhen() unchanged', async (): Promise<void> => {
+    const suite = create((data: { a: string; b: string }): void => {
+      test('a', (): void => {
+        enforce(data.a).isNotBlank();
+      });
+      omitWhen(data.b === 'omit', (): void => {
+        test('b', (): void => {
+          enforce(data.b).isNotBlank();
+        });
+      });
+    });
+    const r1 = await suite.run({ a: '1', b: '' });
+    // b is not omitted (b !== 'omit'), so should have error
+    expect(r1.hasErrors('b')).toBe(true);
+    const _r2 = await suite.run({ a: '1', b: 'omit' });
+    // b omitted, so no error
+    expect(_r2.hasErrors('b')).toBe(false);
+  });
+
+  it('optional() unchanged', async (): Promise<void> => {
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn($ => $.a),
+    });
+    const log = createLog();
+    const suite = create((data: { a: string; b: string }): void => {
+      optional('b');
+      test('a', (): void => {
+        log.record('a');
+        enforce(data.a).isNotBlank();
+      });
+      test('b', (): void => {
+        log.record('b');
+        enforce(data.b).isNotBlank();
+      });
+    }, schema);
+    const r1 = await suite.run({ a: 'x', b: '' });
+    expect(r1.isValid()).toBe(true); // optional empty is valid
+    expect(log.get()).toEqual(['a']); // blank optional omitted, as in run()
+    log.reset();
+    // A valued optional dependent is still included when its source changes.
+    const r2 = await suite.changed('a').run({ a: 'y', b: 'z' });
+    expect(log.get()).toEqual(['a', 'b']);
+    expect(r2.isValid()).toBe(true);
+    log.reset();
+    // A blank optional dependent stays omitted under changed(), like run().
+    const r3 = await suite.changed('a').run({ a: 'y', b: '' });
+    expect(log.get()).toEqual(['a']);
+    expect(r3.isValid()).toBe(true);
+  });
+
+  it('warn() unchanged', async (): Promise<void> => {
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn($ => $.a),
+    });
+    const log = createLog();
+    const suite = create((data: { a: string; b: string }): void => {
+      test('a', (): void => {
+        log.record('a');
+        enforce(data.a).isNotBlank();
+      });
+      test('b', (): void => {
+        log.record('b');
+        warn();
+        enforce(data.b).isNotBlank();
+      });
+    }, schema);
+    const r1 = await suite.run({ a: '', b: '' });
+    expect(r1.hasErrors('a')).toBe(true);
+    expect(r1.hasWarnings('b')).toBe(true);
+    expect(r1.hasErrors('b')).toBe(false);
+    log.reset();
+    const r2 = await suite.changed('a').run({ a: '', b: '' });
+    // Warn dependents are included as normal tests, keeping warn severity.
+    expect(log.get()).toEqual(['a', 'b']);
+    expect(r2.hasErrors('a')).toBe(true);
+    expect(r2.hasWarnings('b')).toBe(true);
+    expect(r2.hasErrors('b')).toBe(false);
+  });
+
+  it('group() unchanged', async (): Promise<void> => {
+    const suite = create((data: { a: string; b: string }): void => {
+      group('g1', (): void => {
+        test('a', (): void => {
+          enforce(data.a).isNotBlank();
+        });
+      });
+      group('g2', (): void => {
+        test('b', (): void => {
+          enforce(data.b).isNotBlank();
+        });
+      });
+    });
+    const r1 = await suite.run({ a: '', b: '' });
+    expect(r1.hasErrors('a')).toBe(true);
+    expect(r1.hasErrors('b')).toBe(true);
+    const schema = enforce.shape({
+      x: enforce.isString(),
+      y: enforce.isString().dependsOn($ => $.x),
+    });
+    const suiteWithSchema = create(
+      (data: { x: string; y: string; a?: string; b?: string }): void => {
+        group('g1', (): void => {
+          test('a', (): void => {
+            enforce(data.a).isNotBlank();
+          });
+        });
+        group('g2', (): void => {
+          test('b', (): void => {
+            enforce(data.b).isNotBlank();
+          });
+        });
+      },
+      schema,
+    );
+    const _r2 = await invokeWithUnknown(suiteWithSchema.run, { a: '', b: '' });
+    expect(invokeWithUnknown(_r2.hasErrors, 'a')).toBe(true);
+    expect(invokeWithUnknown(_r2.hasErrors, 'b')).toBe(true);
+  });
+
+  it('each() unchanged — no relationships', async (): Promise<void> => {
+    const suite = create((data: { items: string[] }): void => {
+      each(data.items, (item: string, index: number): void => {
+        test(`items.${index}`, (): void => {
+          enforce(item).isNotBlank();
+        });
+      });
+    });
+    const r1 = await suite.run({ items: ['a', '', 'c'] });
+    expect(r1.hasErrors('items.1')).toBe(true);
+    const schema = enforce.shape({
+      x: enforce.isString(),
+      y: enforce.isString().dependsOn($ => $.x),
+    });
+    const suiteWithSchema = create(
+      (data: { x: string; y: string; items?: string[] }): void => {
+        invariant(isArray(data.items), 'Expected items to be an array');
+        each(data.items, (item: string, index: number): void => {
+          test(`items.${index}`, (): void => {
+            enforce(item).isNotBlank();
+          });
+        });
+      },
+      schema,
+    );
+    const _r2 = await invokeWithUnknown(suiteWithSchema.run, {
+      items: ['a', '', 'c'],
+    });
+    expect(invokeWithUnknown(_r2.hasErrors, 'items.1')).toBe(true);
+  });
+});
+
+// 4. Prove unrelated fields are truly unaffected
+describe('Acceptance — Unrelated unaffected', (): void => {
+  it('changed() does not execute unrelated work and does not lose unrelated state', async (): Promise<void> => {
+    const schema = enforce.shape({
+      email: enforce.isString(),
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+    });
+    const log = createLog();
+    const suite = create(
+      (data: {
+        email: string;
+        password: string;
+        confirmPassword: string;
+        profile: { country: string; state: string };
+      }): void => {
+        test('email', (): void => {
+          log.record('email');
+          enforce(data.email).isNotBlank();
+        });
+        test('password', (): void => {
+          log.record('password');
+          enforce(data.password).isNotBlank();
+        });
+        test('confirmPassword', (): void => {
+          log.record('confirmPassword');
+          enforce(data.confirmPassword).equals(data.password);
+        });
+        test('profile.country', (): void => {
+          log.record('profile.country');
+          enforce(data.profile.country).isNotBlank();
+        });
+        test('profile.state', (): void => {
+          log.record('profile.state');
+          enforce(data.profile.state).isNotBlank();
+        });
+      },
+      schema,
+    );
+    await suite.run({
+      email: 'a@b.com',
+      password: 'abcdefgh',
+      confirmPassword: 'abcdefgh',
+      profile: { country: 'US', state: 'CA' },
+    });
+    log.reset();
+    await suite.changed('password').run({
+      email: 'a@b.com',
+      password: 'xyz',
+      confirmPassword: 'abcdefgh',
+      profile: { country: 'US', state: 'CA' },
+    });
+    expect(log.get()).toEqual(['password', 'confirmPassword']);
+    expect(log.get()).not.toContain('email');
+    expect(log.get()).not.toContain('profile.country');
+    expect(log.get()).not.toContain('profile.state');
+    // Unrelated state remains (email still valid, profile still valid)
+    expect(suite.get().hasErrors('email')).toBe(false);
+    expect(suite.get().hasErrors('profile.state')).toBe(false);
+  });
+});
+
+// 5. Performance sanity
+describe('Acceptance — Performance sanity', (): void => {
+  it('changed() is minimal and deduplicated', async (): Promise<void> => {
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn($ => $.a),
+      c: enforce.isString(),
+      d: enforce.isString(),
+      e: enforce.isString(),
+    });
+    const counts: Record<string, number> = { a: 0, b: 0, c: 0, d: 0, e: 0 };
+    const suite = create(
+      (data: {
+        a: string;
+        b: string;
+        c: string;
+        d: string;
+        e: string;
+      }): void => {
+        test('a', (): void => {
+          counts.a++;
+          enforce(data.a).isNotBlank();
+        });
+        test('b', (): void => {
+          counts.b++;
+          enforce(data.b).isNotBlank();
+        });
+        test('c', (): void => {
+          counts.c++;
+          enforce(data.c).isNotBlank();
+        });
+        test('d', (): void => {
+          counts.d++;
+          enforce(data.d).isNotBlank();
+        });
+        test('e', (): void => {
+          counts.e++;
+          enforce(data.e).isNotBlank();
+        });
+      },
+      schema,
+    );
+    await suite.run({ a: '1', b: '2', c: '3', d: '4', e: '5' });
+    Object.keys(counts).forEach((k: string): void => {
+      counts[k as keyof typeof counts] = 0;
+    });
+    await suite.changed('a').run({ a: 'x', b: '2', c: '3', d: '4', e: '5' });
+    expect(counts).toEqual({ a: 1, b: 1, c: 0, d: 0, e: 0 });
+    Object.keys(counts).forEach((k: string): void => {
+      counts[k as keyof typeof counts] = 0;
+    });
+    await suite
+      .changed(['a', 'b'])
+      .run({ a: 'x', b: 'y', c: '3', d: '4', e: '5' });
+    expect(counts.a).toBe(1);
+    expect(counts.b).toBe(1);
+  });
+});
+
+// 6. Repeated calls don't accumulate garbage
+describe('Acceptance — Stateful lifecycle', (): void => {
+  it('repeated changed() does not accumulate garbage', async (): Promise<void> => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const log = createLog();
+    const suite = create(
+      (data: { password: string; confirmPassword: string }): void => {
+        test('password', (): void => {
+          log.record('password');
+          enforce(data.password).isNotBlank();
+        });
+        test('confirmPassword', (): void => {
+          log.record('confirmPassword');
+          enforce(data.confirmPassword).equals(data.password);
+        });
+      },
+      schema,
+    );
+    await suite.run({ password: 'abcdefgh', confirmPassword: 'abcdefgh' });
+    for (let i = 0; i < 4; i++) {
+      log.reset();
+      await suite
+        .changed('password')
+        .run({ password: `pass${i}`, confirmPassword: 'abcdefgh' });
+      expect(log.get()).toEqual(['password', 'confirmPassword']);
+    }
+    // Ensure no extra focused nodes remain — suite should still be usable via normal run
+    log.reset();
+    await suite.run({ password: 'abcdefgh', confirmPassword: 'abcdefgh' });
+    expect(log.get()).toEqual(['password', 'confirmPassword']);
+  });
+
+  it('schema reuse does not mutate reusable schema', async (): Promise<void> => {
+    const addressSchema = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+    const schemaA = enforce.shape({
+      billing: addressSchema,
+    });
+    const schemaB = enforce.shape({
+      shipping: addressSchema,
+    });
+    const suiteA = create(
+      (data: { billing: { country: string; state: string } }): void => {
+        test('billing.country', (): void => {
+          enforce(data.billing.country).isNotBlank();
+        });
+        test('billing.state', (): void => {
+          enforce(data.billing.state).isNotBlank();
+        });
+      },
+      schemaA,
+    );
+    const suiteB = create(
+      (data: { shipping: { country: string; state: string } }): void => {
+        test('shipping.country', (): void => {
+          enforce(data.shipping.country).isNotBlank();
+        });
+        test('shipping.state', (): void => {
+          enforce(data.shipping.state).isNotBlank();
+        });
+      },
+      schemaB,
+    );
+    await suiteA.run({ billing: { country: 'US', state: 'CA' } });
+    await suiteB.run({ shipping: { country: 'US', state: 'NY' } });
+    // Run A changed
+    await suiteA
+      .changed('billing.country')
+      .run({ billing: { country: 'CA', state: 'CA' } });
+    // B should still be independent
+    const logB = createLog();
+    const suiteB2 = create(
+      (data: { shipping: { country: string; state: string } }): void => {
+        test('shipping.country', (): void => {
+          logB.record('shipping.country');
+          enforce(data.shipping.country).isNotBlank();
+        });
+        test('shipping.state', (): void => {
+          logB.record('shipping.state');
+          enforce(data.shipping.state).isNotBlank();
+        });
+      },
+      schemaB,
+    );
+    await suiteB2.run({ shipping: { country: 'US', state: 'NY' } });
+    logB.reset();
+    await suiteB2
+      .changed('shipping.country')
+      .run({ shipping: { country: 'CA', state: 'NY' } });
+    expect(logB.get()).toEqual(['shipping.country', 'shipping.state']);
+  });
+
+  it('relationship metadata does not leak between suite instances', async (): Promise<void> => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const suiteA = create(
+      (data: { password: string; confirmPassword: string }): void => {
+        test('password', (): void => {
+          enforce(data.password).isNotBlank();
+        });
+        test('confirmPassword', (): void => {
+          enforce(data.confirmPassword).equals(data.password);
+        });
+      },
+      schema,
+    );
+    const suiteB = create(
+      (data: { password: string; confirmPassword: string }): void => {
+        test('password', (): void => {
+          enforce(data.password).isNotBlank();
+        });
+        test('confirmPassword', (): void => {
+          enforce(data.confirmPassword).equals(data.password);
+        });
+      },
+      schema,
+    );
+    await suiteA.run({ password: 'abcdefgh', confirmPassword: 'abcdefgh' });
+    await suiteB.run({ password: 'abcdefgh', confirmPassword: 'abcdefgh' });
+    await suiteA
+      .changed('password')
+      .run({ password: 'xyz', confirmPassword: 'abcdefgh' });
+    expect(suiteA.get().hasErrors('confirmPassword')).toBe(true);
+    expect(suiteB.get().hasErrors('confirmPassword')).toBe(false);
+    await suiteB.run({ password: 'abcdefgh', confirmPassword: 'abcdefgh' });
+    expect(suiteB.get().hasErrors('confirmPassword')).toBe(false);
+  });
+
+  it('invalid relationship fails before suite execution', async (): Promise<void> => {
+    let callbackInvoked = false;
+    expect((): void => {
+      enforce.shape({
+        password: enforce.isString(),
+        confirmPassword: enforce
+          .isString()
+          .dependsOn(($: ScopeHandle): unknown => $.pasword),
+      });
+    }).toThrow(/unknown field.*pasword/i);
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString(),
+    });
+    const suite = create(
+      (data: { password: string; confirmPassword: string }): void => {
+        callbackInvoked = true;
+        test('password', (): void => {
+          enforce(data.password).isNotBlank();
+        });
+      },
+      schema,
+    );
+    await suite.run({ password: '123', confirmPassword: '456' });
+    expect(callbackInvoked).toBe(true);
+  });
+
+  it('keeps cross-field validation correct across user interactions (docs-like)', async (): Promise<void> => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const suite = create(
+      (data: { password: string; confirmPassword: string }): void => {
+        test('password', (): void => {
+          enforce(data.password).isNotBlank();
+        });
+        test('confirmPassword', (): void => {
+          enforce(data.confirmPassword).equals(data.password);
+        });
+      },
+      schema,
+    );
+    // Initial valid state.
+    await suite.run({
+      password: 'abcdefgh',
+      confirmPassword: 'abcdefgh',
+    });
+    expect(suite.get().hasErrors('confirmPassword')).toBe(false);
+    // User changes password.
+    let result = await suite.changed('password').run({
+      password: 'newpassword',
+      confirmPassword: 'abcdefgh',
+    });
+    expect(result.hasErrors('confirmPassword')).toBe(true);
+    // User fixes confirmation.
+    result = await suite.changed('confirmPassword').run({
+      password: 'newpassword',
+      confirmPassword: 'newpassword',
+    });
+    expect(result.hasErrors('confirmPassword')).toBe(false);
+  });
+});

--- a/packages/vest/src/suite/__tests__/changed.callbackMapping.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.callbackMapping.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest';
+import { compose, enforce } from 'n4s';
+
+import { create } from '../../vest';
+
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      focusedToNumber: (value: unknown) => { pass: boolean; type: number };
+      focusedAppend: (value: string) => { pass: boolean; type: string };
+      focusedValidator: (value: unknown) => boolean;
+    }
+  }
+}
+
+describe('focused schema callback mapping', () => {
+  it('maps a composed structural parser exactly once', async () => {
+    enforce.extend(
+      {
+        focusedAppend: (value: string) => ({
+          pass: true,
+          type: `${value}!`,
+        }),
+      },
+      { parsers: ['focusedAppend'] },
+    );
+    const seen: string[] = [];
+    const suite = create(
+      data => {
+        seen.push(data.profile.label);
+      },
+      enforce.shape({
+        profile: compose(enforce.shape({ label: enforce.focusedAppend() })),
+        note: enforce.isString(),
+      }),
+    );
+
+    await suite.changed('note').run({
+      profile: { label: 'value' },
+      note: 'changed',
+    });
+
+    expect(seen).toEqual(['value!']);
+  });
+
+  it('maps untouched fields before the first-ever focused callback without validating them', async () => {
+    const validationCalls: unknown[] = [];
+    const seenAges: number[] = [];
+    const schema = enforce.shape({
+      age: enforce.isNumeric().toNumber(),
+      guard: enforce.condition((value: unknown): boolean => {
+        validationCalls.push(value);
+        return typeof value === 'string';
+      }),
+      note: enforce.isString(),
+    });
+    const suite = create(data => {
+      seenAges.push(data.age);
+    }, schema);
+
+    await suite
+      .changed('note')
+      .run({ age: '42', guard: 'untouched', note: 'hello' });
+
+    expect(seenAges).toEqual([42]);
+    expect(validationCalls).toEqual([]);
+  });
+
+  it('maps explicitly registered custom parsers without running custom validators', async () => {
+    const validationCalls: unknown[] = [];
+    enforce.extend(
+      {
+        focusedToNumber: (value: unknown) => ({
+          pass: true,
+          type: Number(value),
+        }),
+        focusedValidator: (value: unknown) => {
+          validationCalls.push(value);
+          return true;
+        },
+      },
+      { parsers: ['focusedToNumber'] },
+    );
+    const seenAges: number[] = [];
+    const suite = create(
+      data => {
+        seenAges.push(data.age);
+      },
+      enforce.shape({
+        age: enforce.focusedToNumber(),
+        guard: enforce.focusedValidator(),
+        note: enforce.isString(),
+      }),
+    );
+
+    await suite
+      .changed('note')
+      .run({ age: '42', guard: 'untouched', note: 'hello' });
+
+    expect(seenAges).toEqual([42]);
+    expect(validationCalls).toEqual([]);
+  });
+
+  it('retains successful untouched transformations across sequential changed runs', async () => {
+    const seen: unknown[] = [];
+    const schema = enforce.shape({
+      age: enforce.isNumeric().toNumber(),
+      quantity: enforce.isNumeric().toNumber(),
+      note: enforce.isString(),
+    });
+    const suite = create(data => {
+      seen.push(data);
+    }, schema);
+
+    await suite.run({ age: '42', quantity: '1', note: 'a' });
+    await suite.changed('note').run({ age: '42', quantity: '1', note: 'b' });
+    await suite
+      .changed('quantity')
+      .run({ age: '42', quantity: '2', note: 'b' });
+
+    expect(seen).toEqual([
+      { age: 42, quantity: 1, note: 'a' },
+      { age: 42, quantity: 1, note: 'b' },
+      { age: 42, quantity: 2, note: 'b' },
+    ]);
+  });
+
+  it('does not leak mapped values between suites created from the same callback', async () => {
+    const seen: unknown[] = [];
+    const callback = (data: unknown): void => {
+      seen.push(data);
+    };
+    const schema = enforce.shape({
+      age: enforce.isNumeric().toNumber(),
+      note: enforce.isString(),
+    });
+    const first = create(callback, schema);
+    const second = create(callback, schema);
+
+    await first.run({ age: '10', note: 'first' });
+    await second.run({ age: '20', note: 'second' });
+    await first.changed('note').run({ age: '10', note: 'first-next' });
+    await second.changed('note').run({ age: '20', note: 'second-next' });
+
+    expect(seen).toEqual([
+      { age: 10, note: 'first' },
+      { age: 20, note: 'second' },
+      { age: 10, note: 'first-next' },
+      { age: 20, note: 'second-next' },
+    ]);
+  });
+
+  it('does not let a failing focused schema run poison the last successful mapping', async () => {
+    const seen: unknown[] = [];
+    const schema = enforce.shape({
+      age: enforce.isNumeric().toNumber(),
+      note: enforce.isString(),
+    });
+    const suite = create(data => {
+      seen.push(data);
+    }, schema);
+
+    await suite.run({ age: '42', note: 'good' });
+
+    const failed = await suite
+      .changed('note')
+      .run({ age: '42', note: 123 as unknown as string });
+    expect(failed.isValid()).toBe(false);
+
+    await suite.changed('note').run({ age: '42', note: 'recovered' });
+
+    // Failed validation keeps the established raw-input callback fallback.
+    // The next successful focused run must still recover the previously
+    // transformed age rather than inheriting raw state from the failure.
+    expect(seen).toEqual([
+      { age: 42, note: 'good' },
+      { age: '42', note: 123 },
+      { age: 42, note: 'recovered' },
+    ]);
+  });
+
+  it('does not resurrect a stale mapping after a failed full run', async () => {
+    const seen: unknown[] = [];
+    const suite = create(
+      data => {
+        seen.push(data);
+      },
+      enforce.shape({
+        age: enforce.isNumeric().toNumber(),
+        state: enforce.isString(),
+      }),
+    );
+
+    await suite.run({ age: '42', state: 'CA' });
+    await suite.run({ age: '99', state: 123 as unknown as string });
+    await suite.changed('state').run({ age: '99', state: 'NY' });
+
+    expect(seen).toEqual([
+      { age: 42, state: 'CA' },
+      { age: '99', state: 123 },
+      { age: 99, state: 'NY' },
+    ]);
+  });
+
+  it('discards retained mapped callback data when the suite is reset', async () => {
+    const seen: unknown[] = [];
+    const suite = create(
+      data => {
+        seen.push(data);
+      },
+      enforce.shape({
+        age: enforce.isNumeric().toNumber(),
+        note: enforce.isString(),
+      }),
+    );
+
+    await suite.run({ age: '10', note: 'before' });
+    suite.reset();
+    await suite.changed('note').run({ age: '99', note: 'after' });
+
+    expect(seen).toEqual([
+      { age: 10, note: 'before' },
+      { age: 99, note: 'after' },
+    ]);
+  });
+
+  it('preserves the declared output type when an untouched parser fails during initial focused mapping', async () => {
+    const seen: number[] = [];
+    const suite = create(
+      data => {
+        seen.push(data.age);
+        // The schema contract promises a number here even when the focused
+        // field is elsewhere. This must never throw because raw input leaked
+        // through the parser-only mapping path.
+        data.age.toFixed();
+      },
+      enforce.shape({
+        age: enforce.isNumeric().toNumber(),
+        note: enforce.isString(),
+      }),
+    );
+
+    await expect(
+      suite.changed('note').run({ age: 'not-numeric', note: 'ok' }),
+    ).resolves.toBeDefined();
+    expect(seen).toHaveLength(1);
+    expect(Number.isNaN(seen[0])).toBe(true);
+  });
+
+  it('keeps only() exact while retaining untouched successful mappings', async () => {
+    const seen: unknown[] = [];
+    const schema = enforce.shape({
+      age: enforce.isNumeric().toNumber(),
+      quantity: enforce.isNumeric().toNumber(),
+    });
+    const suite = create(data => {
+      seen.push(data);
+    }, schema);
+
+    await suite.run({ age: '42', quantity: '1' });
+    await suite.only('quantity').run({ age: '42', quantity: '2' });
+
+    expect(seen).toEqual([
+      { age: 42, quantity: 1 },
+      { age: 42, quantity: 2 },
+    ]);
+  });
+});

--- a/packages/vest/src/suite/__tests__/changed.coercion.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.coercion.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { enforce } from 'n4s';
+
+import { create } from '../../vest';
+
+const coercingSchema = enforce.shape({
+  rows: enforce.isArrayOf(enforce.isNumeric().toNumber()),
+});
+
+type CoercingData = {
+  rows: string[];
+};
+
+describe('changed() coercion parity for excluded array members', () => {
+  it('passing run: changed() parsed data equals the full-run coerced values', async () => {
+    let fullInput: unknown;
+    let changedInput: unknown;
+    const fullSuite = create(data => {
+      fullInput = data;
+    }, coercingSchema);
+    const changedSuite = create(data => {
+      changedInput = data;
+    }, coercingSchema);
+
+    const data: CoercingData = { rows: ['42'] };
+    const full = await fullSuite.run(data);
+    const changed = await changedSuite.changed('rows.0').run(data);
+
+    expect(full.run.data.parsed).toEqual({ rows: [42] });
+    expect(changed.run.data.parsed).toEqual(full.run.data.parsed);
+    expect(changed.run.data.parsed).toEqual({ rows: [42] });
+    expect(changedInput).toEqual({ rows: [42] });
+    expect(changedInput).toEqual(fullInput);
+  });
+
+  it('passing run: every affected index keeps its coercion', async () => {
+    const suite = create(() => {}, coercingSchema);
+
+    const data: CoercingData = { rows: ['1', '2'] };
+    const full = await suite.run(data);
+    const changed = await suite.changed(['rows.0', 'rows.1']).run(data);
+
+    expect(full.run.data.parsed).toEqual({ rows: [1, 2] });
+    expect(changed.run.data.parsed).toEqual(full.run.data.parsed);
+  });
+
+  it('preserves the full mapped schema output for the suite callback', async () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({ state: enforce.isString() }),
+      age: enforce.isNumeric().toNumber(),
+    });
+
+    let callbackInput: unknown;
+    const suite = create(data => {
+      callbackInput = data;
+    }, schema);
+
+    const input = { profile: { state: 'CA' }, age: '42' };
+    const full = await suite.run(input);
+    const changed = await suite.changed('profile.state').run(input);
+
+    expect(full.run.data.parsed).toEqual({
+      profile: { state: 'CA' },
+      age: 42,
+    });
+
+    // Parsed metadata is intentionally per-run in Vest 6: this changed run
+    // mapped profile.state and did not claim that it remapped age.
+    expect(changed.run.data.parsed).toEqual({
+      profile: { state: 'CA' },
+      age: '42',
+    });
+
+    // The suite callback has a different contract: its parameter is typed as
+    // the schema's full output, so untouched successful transformations are
+    // retained from the previous mapped snapshot.
+    expect(callbackInput).toEqual(full.run.data.parsed);
+  });
+
+  it('failing run: raw-input fallback parity is preserved', async () => {
+    let fullInput: unknown;
+    let changedInput: unknown;
+    const fullSuite = create(data => {
+      fullInput = data;
+    }, coercingSchema);
+    const changedSuite = create(data => {
+      changedInput = data;
+    }, coercingSchema);
+
+    const data: CoercingData = { rows: ['nope'] };
+    const full = await fullSuite.run(data);
+    const changed = await changedSuite.changed('rows.0').run(data);
+
+    expect(full.isValid()).toBe(false);
+    expect(changed.isValid()).toBe(false);
+    expect(changed.run.data.parsed).toEqual(full.run.data.parsed);
+    expect(changedInput).toEqual(data);
+    expect(changedInput).toEqual(fullInput);
+  });
+});

--- a/packages/vest/src/suite/__tests__/changed.extrakey.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.extrakey.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { enforce } from 'n4s';
+
+import { create, test } from '../../vest';
+
+const topSchema = enforce.shape({
+  profile: enforce.shape({
+    state: enforce.isString(),
+  }),
+});
+
+const nestedSchema = enforce.shape({
+  profile: enforce.shape({
+    state: enforce.shape({
+      city: enforce.isString(),
+    }),
+    country: enforce.isString(),
+  }),
+});
+
+// `nickname` is unknown at the profile level; `state.city` narrows the
+// known sibling so the fragment actually rebuilds (a no-op narrowing
+// would retain the whole rule and mask the bug).
+const nestedData = {
+  profile: { state: { city: 'ok' }, country: 'US', nickname: 'extra' },
+};
+const nestedAffected = ['profile.state.city', 'profile.nickname'];
+const topData = { profile: { state: 'ok' }, email: 'extra' };
+
+describe('changed() strict-shape extra-key parity', () => {
+  it('top-level extra key fails the changed run like the full run', async () => {
+    // 'email' is out of schema, so the typed hasErrors() selector cannot
+    // name it — the untyped getErrors() map pins the failure instead.
+    const suite = create(data => {
+      test('profile.state', () => {
+        enforce(data.profile.state).isString();
+      });
+    }, topSchema);
+
+    const full = await suite.run(topData);
+    expect(full.getErrors()).toHaveProperty('email');
+
+    const changed = await suite
+      .changed(['profile.state', 'email'])
+      .run(topData);
+    expect(changed.getErrors()).toHaveProperty('email');
+  });
+
+  it('nested extra key fails the changed run like the full run', async () => {
+    const suite = create(data => {
+      test('profile.state.city', () => {
+        enforce(data.profile.state.city).isString();
+      });
+    }, nestedSchema);
+
+    const full = await suite.run(nestedData);
+    expect(full.hasErrors('profile.nickname')).toBe(true);
+
+    const changed = await suite.changed(nestedAffected).run(nestedData);
+    expect(changed.hasErrors('profile.nickname')).toBe(true);
+  });
+
+  it('absent top-level key passes the changed run', async () => {
+    const suite = create(data => {
+      test('profile.state', () => {
+        enforce(data.profile.state).isString();
+      });
+    }, topSchema);
+
+    const data = { profile: { state: 'ok' } };
+    const full = await suite.run(data);
+    expect(full.hasErrors()).toBe(false);
+
+    const changed = await suite.changed(['profile.state', 'email']).run(data);
+    expect(changed.hasErrors()).toBe(false);
+  });
+
+  it('absent nested key passes the changed run', async () => {
+    const suite = create(data => {
+      test('profile.state.city', () => {
+        enforce(data.profile.state.city).isString();
+      });
+    }, nestedSchema);
+
+    const data = { profile: { state: { city: 'ok' }, country: 'US' } };
+    const full = await suite.run(data);
+    expect(full.hasErrors()).toBe(false);
+
+    const changed = await suite.changed(nestedAffected).run(data);
+    expect(changed.hasErrors()).toBe(false);
+  });
+});

--- a/packages/vest/src/suite/__tests__/changed.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.integration.test.ts
@@ -1,0 +1,1155 @@
+import { enforce } from 'n4s';
+import { runSchemaPaths } from 'n4s/exports/internal';
+import { describe, it, expect } from 'vitest';
+
+import {
+  create,
+  test,
+  group,
+  skipWhen,
+  omitWhen,
+  optional,
+  warn,
+  include,
+} from '../../vest';
+import { each } from '../../isolates/each';
+import { invokeWithUnknown } from '../../__tests__/runtimeTestUtils';
+
+type Deferred = {
+  promise: Promise<void>;
+  release: () => void;
+};
+
+function createDeferred(): Deferred {
+  let release: () => void = () => {};
+  const promise = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+// Drains pending microtasks and one macrotask turn without any wall-clock
+// margin: the stale async continuation after a gate release is a bounded
+// microtask chain, so awaiting it to quiesce is deterministic.
+function flushAsyncWork(): Promise<void> {
+  return new Promise<void>(resolve => {
+    setImmediate(resolve);
+  });
+}
+
+function createExecutionLog() {
+  const fields: string[] = [];
+  return {
+    record(field: string) {
+      fields.push(field);
+    },
+    reset() {
+      fields.length = 0;
+    },
+    get() {
+      return [...fields];
+    },
+    expect(...expected: string[]) {
+      expect(fields).toEqual(expected);
+    },
+  };
+}
+
+describe('Integration: suite.changed() — merge gate (13)', () => {
+  // 1. Flat dependent rerun
+  it('1. flat dependent rerun — changed(password) runs password + confirmPassword', async () => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const log = createExecutionLog();
+    const suite = create(
+      (data: { password: string; confirmPassword: string; email?: string }) => {
+        test('password', () => {
+          log.record('password');
+          enforce(data.password).longerThanOrEquals(8);
+        });
+        test('confirmPassword', () => {
+          log.record('confirmPassword');
+          enforce(data.confirmPassword).equals(data.password);
+        });
+        test('email', () => {
+          log.record('email');
+          enforce(data.email).isNotBlank();
+        });
+      },
+      schema,
+    );
+
+    await invokeWithUnknown(suite.run, {
+      email: 'a@b.com',
+      password: 'abcdefgh',
+      confirmPassword: 'abcdefgh',
+    });
+    log.reset();
+    const result = await invokeWithUnknown(suite.changed('password').run, {
+      email: 'a@b.com',
+      password: 'abcdefgh2',
+      confirmPassword: 'abcdefgh',
+    });
+    expect(log.get()).toEqual(['password', 'confirmPassword']);
+    expect(result.hasErrors('password')).toBe(false);
+    expect(result.hasErrors('confirmPassword')).toBe(true);
+  });
+
+  // 2. Inverse does not rerun source
+  it('2. directionality — changed(confirmPassword) does NOT run password', async () => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('password', () => {
+        log.record('password');
+        enforce(data.password).isNotBlank();
+      });
+      test('confirmPassword', () => {
+        log.record('confirmPassword');
+        enforce(data.confirmPassword).equals(data.password);
+      });
+    }, schema);
+    await suite.run({ password: 'abcdefgh', confirmPassword: 'abcdefgh' });
+    log.reset();
+    await suite
+      .changed('confirmPassword')
+      .run({ password: 'abcdefgh', confirmPassword: 'xyz' });
+    expect(log.get()).toEqual(['confirmPassword']);
+  });
+
+  // 3. Unrelated retained error survives
+  it('3. unrelated retained errors survive changed()', async () => {
+    const schema = enforce.shape({
+      email: enforce.isString(),
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const suite = create(data => {
+      test('email', 'Email required', () => {
+        enforce(data.email).isNotBlank();
+      });
+      test('password', () => {
+        enforce(data.password).isNotBlank();
+      });
+      test('confirmPassword', () => {
+        enforce(data.confirmPassword).equals(data.password);
+      });
+    }, schema);
+    await suite.run({
+      email: '',
+      password: 'abcdefgh',
+      confirmPassword: 'abcdefgh',
+    });
+    expect(suite.get().hasErrors('email')).toBe(true);
+    const result = await suite
+      .changed('password')
+      .run({ email: '', password: 'xyz', confirmPassword: 'abcdefgh' });
+    expect(result.hasErrors('email')).toBe(true);
+    expect(result.hasErrors('confirmPassword')).toBe(true);
+  });
+
+  // 4. Nested dependency
+  it('4. nested dependency — changed(profile.country) runs profile.state', async () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('profile.country', () => {
+        log.record('profile.country');
+        enforce(data.profile.country).isNotBlank();
+      });
+      test('profile.state', () => {
+        log.record('profile.state');
+        if (data.profile.country === 'US')
+          enforce(data.profile.state).isNotBlank();
+      });
+    }, schema);
+    await suite.run({ profile: { country: 'CA', state: '' } });
+    log.reset();
+    const result = await suite
+      .changed('profile.country')
+      .run({ profile: { country: 'US', state: '' } });
+    expect(log.get()).toEqual(['profile.country', 'profile.state']);
+    expect(result.hasErrors('profile.state')).toBe(true);
+  });
+
+  // 5. Reusable nested schema isolated
+  it('5. reusable nested schema remains isolated', async () => {
+    const addressSchema = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+    const schema = enforce.shape({
+      billing: addressSchema,
+      shipping: addressSchema,
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      group('billing', () => {
+        test('billing.country', () => {
+          log.record('billing.country');
+          enforce(data.billing.country).isNotBlank();
+        });
+        test('billing.state', () => {
+          log.record('billing.state');
+          enforce(data.billing.state).isNotBlank();
+        });
+      });
+      group('shipping', () => {
+        test('shipping.country', () => {
+          log.record('shipping.country');
+          enforce(data.shipping.country).isNotBlank();
+        });
+        test('shipping.state', () => {
+          log.record('shipping.state');
+          enforce(data.shipping.state).isNotBlank();
+        });
+      });
+    }, schema);
+    await suite.run({
+      billing: { country: 'US', state: 'CA' },
+      shipping: { country: 'US', state: 'NY' },
+    });
+    log.reset();
+    await suite.changed('billing.country').run({
+      billing: { country: 'CA', state: 'CA' },
+      shipping: { country: 'US', state: 'NY' },
+    });
+    expect(log.get()).toEqual(['billing.country', 'billing.state']);
+    expect(log.get()).not.toContain('shipping.country');
+  });
+
+  // 6. Same-array-item dependency
+  it('6. same-array-item — changed(travelers.1.country) affects only travelers.1.passport', async () => {
+    const travelerSchema = enforce.shape({
+      country: enforce.isString(),
+      passportNumber: enforce.isString().dependsOn($ => $.country),
+    });
+    const schema = enforce.shape({
+      travelers: enforce.isArrayOf(travelerSchema),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      each(data.travelers, (traveler, index) => {
+        test(`travelers.${index}.country`, () => {
+          log.record(`travelers.${index}.country`);
+          enforce(traveler.country).isNotBlank();
+        });
+        test(`travelers.${index}.passportNumber`, () => {
+          log.record(`travelers.${index}.passportNumber`);
+          enforce(traveler.passportNumber).isNotBlank();
+        });
+      });
+    }, schema);
+    const data = {
+      travelers: [
+        { country: 'US', passportNumber: 'A' },
+        { country: 'IL', passportNumber: 'B' },
+        { country: 'FR', passportNumber: 'C' },
+      ],
+    };
+    await suite.run(data);
+    log.reset();
+    const next = {
+      travelers: [
+        { country: 'US', passportNumber: 'A' },
+        { country: 'CA', passportNumber: 'B' },
+        { country: 'FR', passportNumber: 'C' },
+      ],
+    };
+    await suite.changed('travelers.1.country').run(next);
+    expect(log.get()).toEqual([
+      'travelers.1.country',
+      'travelers.1.passportNumber',
+    ]);
+    expect(log.get()).not.toContain('travelers.0.passportNumber');
+    expect(log.get()).not.toContain('travelers.2.passportNumber');
+  });
+
+  // 7. Multiple dependents dedupe
+  it('7. multiple dependents dedupe — changed(password) runs both dependents once', async () => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+      passwordStrengthMessage: enforce.isString().dependsOn($ => $.password),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('password', () => {
+        log.record('password');
+        enforce(data.password).isNotBlank();
+      });
+      test('confirmPassword', () => {
+        log.record('confirmPassword');
+        enforce(data.confirmPassword).equals(data.password);
+      });
+      test('passwordStrengthMessage', () => {
+        log.record('passwordStrengthMessage');
+        enforce(data.password).longerThan(5);
+      });
+    }, schema);
+    await suite.run({
+      password: 'abcdefgh',
+      confirmPassword: 'abcdefgh',
+      passwordStrengthMessage: 'ok',
+    });
+    log.reset();
+    await suite.changed('password').run({
+      password: 'xyz',
+      confirmPassword: 'abcdefgh',
+      passwordStrengthMessage: 'ok',
+    });
+    expect(log.get()).toEqual([
+      'password',
+      'confirmPassword',
+      'passwordStrengthMessage',
+    ]);
+  });
+
+  // 8. Non-transitive
+  it('8. non-transitive — A->B, B->C, changed(A) runs A,B not C', async () => {
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn($ => $.a),
+      c: enforce.isString().dependsOn($ => $.b),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('a', () => {
+        log.record('a');
+        enforce(data.a).isNotBlank();
+      });
+      test('b', () => {
+        log.record('b');
+        enforce(data.b).isNotBlank();
+      });
+      test('c', () => {
+        log.record('c');
+        enforce(data.c).isNotBlank();
+      });
+    }, schema);
+    await suite.run({ a: '1', b: '2', c: '3' });
+    log.reset();
+    await suite.changed('a').run({ a: 'x', b: '2', c: '3' });
+    expect(log.get()).toEqual(['a', 'b']);
+    expect(log.get()).not.toContain('c');
+  });
+
+  // 9. only() stays explicit
+  it('9. only() ignores dependencies', async () => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('password', () => {
+        log.record('password');
+        enforce(data.password).isNotBlank();
+      });
+      test('confirmPassword', () => {
+        log.record('confirmPassword');
+        enforce(data.confirmPassword).equals(data.password);
+      });
+    }, schema);
+    await suite.run({ password: 'abcdefgh', confirmPassword: 'abcdefgh' });
+    log.reset();
+    await suite
+      .only('password')
+      .run({ password: 'xyz', confirmPassword: 'mismatch' });
+    expect(log.get()).toEqual(['password']);
+    log.reset();
+    await suite
+      .changed('password')
+      .run({ password: 'xyz2', confirmPassword: 'mismatch' });
+    expect(log.get()).toEqual(['password', 'confirmPassword']);
+  });
+
+  // 10. skipWhen
+  it('10. skipWhen — dependency affects candidate but Vest semantics remain authoritative', async () => {
+    const schema = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('country', () => {
+        log.record('country');
+        enforce(data.country).isNotBlank();
+      });
+
+      skipWhen(data.country !== 'US', () => {
+        test('state', () => {
+          log.record('state');
+          enforce(data.state).isNotBlank();
+        });
+      });
+    }, schema);
+    await suite.run({ country: 'CA', state: '' });
+    log.reset();
+    await suite.changed('country').run({ country: 'US', state: '' });
+    // country changed, state is affected and is now not skipped, so both run
+    expect(log.get()).toEqual(['country', 'state']);
+  });
+
+  // 11. async dependent rerun
+  it('11. async dependent rerun — changed(organizationId) reruns username', async () => {
+    const schema = enforce.shape({
+      organizationId: enforce.isString(),
+      username: enforce.isString().dependsOn($ => $.organizationId),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('organizationId', () => {
+        log.record('organizationId');
+        enforce(data.organizationId).isNotBlank();
+      });
+      test('username', async () => {
+        log.record('username');
+        const available = await Promise.resolve(data.username !== 'taken');
+        enforce(available).isTruthy();
+      });
+    }, schema);
+    await suite.run({ organizationId: 'A', username: 'free' });
+    log.reset();
+    await suite
+      .changed('organizationId')
+      .run({ organizationId: 'B', username: 'free' });
+    expect(log.get()).toEqual(['organizationId', 'username']);
+  });
+
+  // 12. stale async cannot win — deterministic: A is gated behind a manual
+  // deferred (no wall-clock margins). The superseded run adopts the
+  // successor's promise, so awaiting p1 observes B's outcome and the stale
+  // late result can never surface through any handle.
+  it('12. stale async result cannot win after changed()', async () => {
+    const schema = enforce.shape({
+      organizationId: enforce.isString(),
+      username: enforce.isString().dependsOn($ => $.organizationId),
+    });
+    const gate = createDeferred();
+    const firstDone = createDeferred();
+    const suite = create(data => {
+      test('username', async () => {
+        try {
+          // Only the stale run waits; the successor never blocks on it.
+          if (data.organizationId === 'A') {
+            await gate.promise;
+          }
+          const available = data.organizationId !== 'B';
+          enforce(available).isTruthy();
+        } finally {
+          if (data.organizationId === 'A') {
+            firstDone.release();
+          }
+        }
+      });
+    }, schema);
+    const p1 = suite.run({ organizationId: 'A', username: 'evyatar' });
+    const p2 = suite
+      .changed('organizationId')
+      .run({ organizationId: 'B', username: 'evyatar' });
+    // B wins: its invalid username is the current state.
+    const r2 = await p2;
+    expect(r2.hasErrors('username')).toBe(true);
+    expect(suite.get().hasErrors('username')).toBe(true);
+    // Release A; its late completion is neutralized by the reconciler, and
+    // p1 adopted p2's promise at B's start, so both handles agree.
+    gate.release();
+    await firstDone.promise;
+    await flushAsyncWork();
+    const r1 = await p1;
+    expect(r1.hasErrors('username')).toBe(true);
+    expect(r1).toBe(r2);
+    expect(suite.get().hasErrors('username')).toBe(true);
+  });
+
+  // 13. realistic registration flow
+  it('13. realistic registration flow sequence', async () => {
+    const schema = enforce.shape({
+      email: enforce.isString(),
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+      organizationId: enforce.isString(),
+      username: enforce.isString().dependsOn($ => $.organizationId),
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+    });
+    const suite = create(data => {
+      test('email', 'Email required', () => {
+        enforce(data.email).isNotBlank();
+      });
+      test('password', () => {
+        enforce(data.password).longerThanOrEquals(8);
+      });
+      test('confirmPassword', () => {
+        enforce(data.confirmPassword).equals(data.password);
+      });
+      test('username', async () => {
+        const available = await Promise.resolve(data.username !== 'taken');
+        enforce(available).isTruthy();
+      });
+      test('profile.country', () => {
+        enforce(data.profile.country).isNotBlank();
+      });
+      test('profile.state', () => {
+        if (data.profile.country === 'US')
+          enforce(data.profile.state).isNotBlank();
+      });
+    }, schema);
+
+    // Initial submit
+    await suite.run({
+      email: '',
+      password: 'abcdefgh',
+      confirmPassword: 'abcdefgh',
+      organizationId: 'A',
+      username: 'free',
+      profile: { country: 'CA', state: '' },
+    });
+    expect(suite.get().hasErrors('email')).toBe(true);
+
+    // Fix email via changed
+    await suite.changed('email').run({
+      email: 'a@b.com',
+      password: 'abcdefgh',
+      confirmPassword: 'abcdefgh',
+      organizationId: 'A',
+      username: 'free',
+      profile: { country: 'CA', state: '' },
+    });
+    expect(suite.get().hasErrors('email')).toBe(false);
+
+    // Change password
+    await suite.changed('password').run({
+      email: 'a@b.com',
+      password: 'abcdefgh2',
+      confirmPassword: 'abcdefgh',
+      organizationId: 'A',
+      username: 'free',
+      profile: { country: 'CA', state: '' },
+    });
+    expect(suite.get().hasErrors('confirmPassword')).toBe(true);
+
+    // Fix confirmation
+    await suite.changed('confirmPassword').run({
+      email: 'a@b.com',
+      password: 'abcdefgh2',
+      confirmPassword: 'abcdefgh2',
+      organizationId: 'A',
+      username: 'free',
+      profile: { country: 'CA', state: '' },
+    });
+    expect(suite.get().hasErrors('confirmPassword')).toBe(false);
+
+    // Change country CA->US
+    await suite.changed('profile.country').run({
+      email: 'a@b.com',
+      password: 'abcdefgh2',
+      confirmPassword: 'abcdefgh2',
+      organizationId: 'A',
+      username: 'free',
+      profile: { country: 'US', state: '' },
+    });
+    expect(suite.get().hasErrors('profile.state')).toBe(true);
+  });
+
+  // --- Additional matrix rows (V1 coverage) ---
+
+  it('14. multi-source dependsOn([$.a, $.b]) — changed(a) and changed(b) each trigger', async () => {
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString(),
+      c: enforce.isString().dependsOn($ => [$.a, $.b]),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('a', () => {
+        log.record('a');
+        enforce(data.a).isNotBlank();
+      });
+      test('b', () => {
+        log.record('b');
+        enforce(data.b).isNotBlank();
+      });
+      test('c', () => {
+        log.record('c');
+        enforce(data.c).isNotBlank();
+      });
+    }, schema);
+
+    await suite.run({ a: '1', b: '2', c: '3' });
+
+    log.reset();
+    await suite.changed('a').run({ a: 'x', b: '2', c: '3' });
+    expect(log.get()).toEqual(['a', 'c']);
+
+    log.reset();
+    await suite.changed('b').run({ a: 'x', b: 'y', c: '3' });
+    expect(log.get()).toEqual(['b', 'c']);
+
+    // Both changed together deduplicates c to once
+    log.reset();
+    await suite.changed(['a', 'b']).run({ a: 'x2', b: 'y2', c: '3' });
+    const got = log.get();
+    expect(got).toContain('a');
+    expect(got).toContain('b');
+    expect(got).toContain('c');
+    // c appears exactly once (deduplication)
+    expect(got.filter(f => f === 'c')).toHaveLength(1);
+  });
+
+  it('15. array reorder — same items different order does not over-invalidate', async () => {
+    const itemSchema = enforce.shape({
+      country: enforce.isString(),
+      passport: enforce.isString().dependsOn($ => $.country),
+    });
+    const schema = enforce.shape({
+      travelers: enforce.isArrayOf(itemSchema),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      each(data.travelers, (traveler, i) => {
+        test(`travelers.${i}.country`, () => {
+          log.record(`travelers.${i}.country`);
+          enforce(traveler.country).isNotBlank();
+        });
+        test(`travelers.${i}.passport`, () => {
+          log.record(`travelers.${i}.passport`);
+          enforce(traveler.passport).isNotBlank();
+        });
+      });
+    }, schema);
+
+    const base = {
+      travelers: [
+        { country: 'US', passport: 'P1' },
+        { country: 'IL', passport: 'P2' },
+        { country: 'FR', passport: 'P3' },
+      ],
+    };
+    await suite.run(base);
+
+    // Reordered same 3 items (different order) — changed on index 1 only affects index 1's dependent
+    log.reset();
+    const reordered = {
+      travelers: [
+        { country: 'FR', passport: 'P3' },
+        { country: 'US', passport: 'P1' },
+        { country: 'IL', passport: 'P2' },
+      ],
+    };
+    // Same-item semantics: changed travelers.1.country only touches travelers.1.passport
+    await suite.changed('travelers.1.country').run(reordered);
+    expect(log.get()).toEqual(['travelers.1.country', 'travelers.1.passport']);
+    expect(log.get()).not.toContain('travelers.0.passport');
+    expect(log.get()).not.toContain('travelers.2.passport');
+
+    // Changing index 0 separately still isolates
+    log.reset();
+    await suite.changed('travelers.0.country').run(reordered);
+    expect(log.get()).toEqual(['travelers.0.country', 'travelers.0.passport']);
+  });
+
+  it('15b. keyed array reorder retains failures under the moved item path', async () => {
+    const itemSchema = enforce.shape({
+      id: enforce.isString(),
+      country: enforce.isString(),
+      passport: enforce.isString().dependsOn($ => $.country),
+    });
+    const suite = create(
+      data => {
+        each(data.travelers, (traveler, index) => {
+          test(
+            `travelers.${index}.country`,
+            () => {
+              enforce(traveler.country).isNotBlank();
+            },
+            `${traveler.id}:country`,
+          );
+          test(
+            `travelers.${index}.passport`,
+            () => {
+              enforce(traveler.passport).isNotBlank();
+            },
+            `${traveler.id}:passport`,
+          );
+        });
+      },
+      enforce.shape({ travelers: enforce.isArrayOf(itemSchema) }),
+    );
+    const original = {
+      travelers: [
+        { id: 'a', country: '', passport: '' },
+        { id: 'b', country: 'IL', passport: 'P2' },
+      ],
+    };
+    const reordered = {
+      travelers: [
+        { id: 'b', country: 'IL', passport: 'P2' },
+        { id: 'a', country: '', passport: '' },
+      ],
+    };
+
+    const initial = await suite.run(original);
+    expect(initial.hasErrors('travelers.0.country')).toBe(true);
+    expect(initial.hasErrors('travelers.0.passport')).toBe(true);
+
+    const focused = await suite.changed('travelers.0.country').run(reordered);
+
+    expect(focused.hasErrors('travelers.0.country')).toBe(false);
+    expect(focused.hasErrors('travelers.0.passport')).toBe(false);
+    expect(focused.hasErrors('travelers.1.country')).toBe(true);
+    expect(focused.hasErrors('travelers.1.passport')).toBe(true);
+  });
+
+  it('16. nested arrays orders[$item].items[$item] depth 4', async () => {
+    const item = enforce.shape({
+      name: enforce.isString(),
+      discount: enforce.isString().dependsOn($ => $.name),
+    });
+    const order = enforce.shape({
+      items: enforce.isArrayOf(item),
+    });
+    const schema = enforce.shape({
+      orders: enforce.isArrayOf(order),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      each(data.orders, (orderData, oi) => {
+        each(orderData.items, (it, ii) => {
+          test(`orders.${oi}.items.${ii}.name`, () => {
+            log.record(`orders.${oi}.items.${ii}.name`);
+            enforce(it.name).isNotBlank();
+          });
+          test(`orders.${oi}.items.${ii}.discount`, () => {
+            log.record(`orders.${oi}.items.${ii}.discount`);
+            enforce(it.discount).isNotBlank();
+          });
+        });
+      });
+    }, schema);
+
+    const data = {
+      orders: [
+        {
+          items: [
+            { name: 'A', discount: '5%' },
+            { name: 'B', discount: '10%' },
+          ],
+        },
+        { items: [{ name: 'C', discount: '0%' }] },
+      ],
+    };
+    await suite.run(data);
+    log.reset();
+    // Change nested leaf in order 0, item 1 — only that item's dependent reruns
+    await suite.changed('orders.0.items.1.name').run(data);
+    expect(log.get()).toEqual([
+      'orders.0.items.1.name',
+      'orders.0.items.1.discount',
+    ]);
+    expect(log.get()).not.toContain('orders.0.items.0.discount');
+    expect(log.get()).not.toContain('orders.1.items.0.discount');
+
+    // Verify describe depth 4 has two item bindings
+    const dep = schema.describe().dependencies[0];
+    const itemCount = dep.target.filter(s => s.type === 'item').length;
+    expect(itemCount).toBe(2);
+  });
+
+  it('17. 3-level transitive a.b.c -> a.b.d (deep nested sibling)', async () => {
+    type DataWithOther = {
+      a: { b: { c: string; d: string; other?: string } };
+    };
+    const inner = enforce.shape({
+      c: enforce.isString(),
+      d: enforce.isString().dependsOn($ => $.c),
+    });
+    const middle = enforce.shape({
+      b: inner,
+    });
+    const schema = enforce.shape({
+      a: middle,
+    });
+    const log = createExecutionLog();
+    const suite = create((data: DataWithOther) => {
+      test('a.b.c', () => {
+        log.record('a.b.c');
+        enforce(data.a.b.c).isNotBlank();
+      });
+      test('a.b.d', () => {
+        log.record('a.b.d');
+        enforce(data.a.b.d).isNotBlank();
+      });
+      test('a.b.other', () => {
+        log.record('a.b.other');
+        enforce(data.a.b.other).isNotBlank();
+      });
+    }, schema);
+
+    await invokeWithUnknown(suite.run, {
+      a: { b: { c: 'x', d: 'y', other: 'z' } },
+    });
+    log.reset();
+    await invokeWithUnknown(suite.changed('a.b.c').run, {
+      a: { b: { c: 'xx', d: 'y', other: 'z' } },
+    });
+    expect(log.get()).toEqual(['a.b.c', 'a.b.d']);
+    expect(log.get()).not.toContain('a.b.other');
+  });
+
+  it('18. $.root — changed(rootField) invalidates nested dependent', async () => {
+    const schema = enforce.shape({
+      accountType: enforce.isString(),
+      company: enforce.shape({
+        country: enforce.isString(),
+        taxId: enforce
+          .isString()
+          .dependsOn($ => [$.country, $.root.accountType]),
+      }),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('accountType', () => {
+        log.record('accountType');
+        enforce(data.accountType).isNotBlank();
+      });
+      test('company.country', () => {
+        log.record('company.country');
+        enforce(data.company.country).isNotBlank();
+      });
+      test('company.taxId', () => {
+        log.record('company.taxId');
+        enforce(data.company.taxId).isNotBlank();
+      });
+    }, schema);
+
+    await suite.run({
+      accountType: 'personal',
+      company: { country: 'US', taxId: '123' },
+    });
+    log.reset();
+    await suite.changed('accountType').run({
+      accountType: 'business',
+      company: { country: 'US', taxId: '123' },
+    });
+    // accountType change must invalidate company.taxId via $.root edge
+    expect(log.get()).toEqual(
+      expect.arrayContaining(['accountType', 'company.taxId']),
+    );
+    expect(log.get()).toContain('company.taxId');
+
+    // Changing sibling country also invalidates taxId, but via local edge
+    log.reset();
+    await suite.changed('company.country').run({
+      accountType: 'business',
+      company: { country: 'CA', taxId: '123' },
+    });
+    expect(log.get()).toEqual(['company.country', 'company.taxId']);
+  });
+
+  it('19. cycle terminates — a->b, b->a, changed(a) => a,b only once', async () => {
+    const schema = enforce.shape({
+      a: enforce.isString().dependsOn($ => $.b),
+      b: enforce.isString().dependsOn($ => $.a),
+    });
+    const log = createExecutionLog();
+    const suite = create((data: { a: string; b: string; c?: string }) => {
+      test('a', () => {
+        log.record('a');
+        enforce(data.a).isNotBlank();
+      });
+      test('b', () => {
+        log.record('b');
+        enforce(data.b).isNotBlank();
+      });
+      test('c', () => {
+        log.record('c');
+        enforce(data.c).isNotBlank();
+      });
+    }, schema);
+
+    await invokeWithUnknown(suite.run, { a: '1', b: '2', c: '3' });
+    log.reset();
+    await invokeWithUnknown(suite.changed('a').run, {
+      a: 'x',
+      b: '2',
+      c: '3',
+    });
+    // Non-transitive + deduped: a changes -> b reruns, but b's change does not loop back to a again or to c
+    const got = log.get();
+    expect(got).toContain('a');
+    expect(got).toContain('b');
+    expect(got).not.toContain('c');
+    expect(got.filter(f => f === 'a')).toHaveLength(1);
+    expect(got.filter(f => f === 'b')).toHaveLength(1);
+
+    log.reset();
+    await invokeWithUnknown(suite.changed('b').run, {
+      a: 'x',
+      b: 'y',
+      c: '3',
+    });
+    const got2 = log.get();
+    expect(got2).toContain('a');
+    expect(got2).toContain('b');
+    expect(got2.filter(f => f === 'b')).toHaveLength(1);
+  });
+
+  // 20. only() merges into the changed() affected set
+  it('20. only() merges with changed() — base-only plus affected all run', async () => {
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn($ => $.a),
+      c: enforce.isString(),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('a', () => {
+        log.record('a');
+        enforce(data.a).isNotBlank();
+      });
+      test('b', () => {
+        log.record('b');
+        enforce(data.b).isNotBlank();
+      });
+      test('c', () => {
+        log.record('c');
+        enforce(data.c).isNotBlank();
+      });
+    }, schema);
+    await suite.run({ a: 'x', b: 'y', c: 'z' });
+    log.reset();
+    await suite.only('c').changed('a').run({ a: 'x', b: 'y', c: 'z' });
+    expect(log.get().sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  // 22. omitWhen removes the dependent test but the edge still exists
+  it('22. omitWhen — dependent edge recorded but omitted test never runs', async () => {
+    const schema = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('country', () => {
+        log.record('country');
+        enforce(data.country).isNotBlank();
+      });
+      omitWhen(true, () => {
+        test('state', () => {
+          log.record('state');
+          enforce(data.state).isNotBlank();
+        });
+      });
+    }, schema);
+    const result = await suite
+      .changed('country')
+      .run({ country: 'US', state: '' });
+    expect(log.get()).toEqual(['country']);
+    expect(result.hasErrors('country')).toBe(false);
+  });
+
+  // 23. optional() fields keep their dependency edges under changed()
+  it('23. optional() — dependent edge fires alongside the optional marker', async () => {
+    const schema = enforce.shape({
+      country: enforce.isString(),
+      nick: enforce.isString().dependsOn($ => $.country),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      optional('nick');
+      test('country', () => {
+        log.record('country');
+        enforce(data.country).isNotBlank();
+      });
+      test('nick', () => {
+        log.record('nick');
+        enforce(data.nick).isNotBlank();
+      });
+    }, schema);
+    await suite.run({ country: 'US', nick: 'bob' });
+    log.reset();
+    await suite.changed('country').run({ country: 'CA', nick: 'bob' });
+    expect(log.get()).toEqual(['country', 'nick']);
+  });
+
+  // 24. warn dependents are included as normal tests
+  it('24. warn — dependent warn test runs on source change', async () => {
+    const schema = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('country', () => {
+        log.record('country');
+        enforce(data.country).isNotBlank();
+      });
+      test('state', () => {
+        log.record('state');
+        warn();
+        enforce(data.state).isNotBlank();
+      });
+    }, schema);
+    await suite.run({ country: 'US', state: 'CA' });
+    log.reset();
+    await suite.changed('country').run({ country: 'US', state: 'CA' });
+    expect(log.get()).toEqual(['country', 'state']);
+  });
+
+  // 25. group dependents respect rebasing under changed()
+  it('25. group — dependent inside a group runs on source change', async () => {
+    const schema = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      test('country', () => {
+        log.record('country');
+        enforce(data.country).isNotBlank();
+      });
+      group('address', () => {
+        test('state', () => {
+          log.record('state');
+          enforce(data.state).isNotBlank();
+        });
+      });
+    }, schema);
+    await suite.run({ country: 'US', state: 'CA' });
+    log.reset();
+    await suite.changed('country').run({ country: 'US', state: 'CA' });
+    expect(log.get()).toEqual(['country', 'state']);
+  });
+
+  it('25b. treats synthesized schema failures as top-level tests for group focus', async () => {
+    const schema = enforce.shape({
+      source: enforce.isString(),
+      dependent: enforce.isString().dependsOn($ => $.source),
+    });
+    const suite = create(data => {
+      group('dependent-group', () => {
+        test('dependent', () => Boolean(data.dependent));
+      });
+    }, schema);
+    const invalid = {
+      source: 'changed',
+      dependent: 42 as unknown as string,
+    };
+
+    const skippedGroup = await suite
+      .focus({ skipGroup: 'dependent-group' })
+      .changed('source')
+      .run(invalid);
+    expect(skippedGroup.hasErrors('dependent')).toBe(true);
+
+    suite.reset();
+    const onlyGroup = await suite
+      .focus({ onlyGroup: 'dependent-group' })
+      .changed('source')
+      .run(invalid);
+    expect(onlyGroup.hasErrors('dependent')).toBe(false);
+  });
+
+  // 26. include().when() under changed() — both the included branch
+  // (condition field is part of the run) and the withheld branch
+  // (condition field is not part of the run). The schema deliberately has
+  // no country->state dependency edge, so `include()` is the only reason
+  // 'state' can run: it is never in the affected set itself.
+  it('26. include().when() — conditional inclusion coexists with changed()', async () => {
+    const schema = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString(),
+      city: enforce.isString(),
+    });
+    const log = createExecutionLog();
+    const suite = create(data => {
+      include('state').when('country');
+      test('country', () => {
+        log.record('country');
+        enforce(data.country).isNotBlank();
+      });
+      test('state', () => {
+        log.record('state');
+        enforce(data.state).isNotBlank();
+      });
+      test('city', () => {
+        log.record('city');
+        enforce(data.city).isNotBlank();
+      });
+    }, schema);
+    await suite.run({ country: 'US', state: 'CA', city: 'NYC' });
+    log.reset();
+    // Condition met: 'country' is in the changed() run, so inclusion fires
+    // and otherwise-unaffected 'state' runs.
+    await suite
+      .changed('country')
+      .run({ country: 'US', state: 'CA', city: 'NYC' });
+    expect(log.get()).toEqual(['country', 'state']);
+    log.reset();
+    // Condition unmet: 'country' is not in the changed() run, so inclusion
+    // is withheld and 'state' stays skipped.
+    await suite.changed('city').run({ country: 'US', state: 'CA', city: 'LA' });
+    expect(log.get()).toEqual(['city']);
+  });
+
+  // 27. root-container suite schemas filter failures by affected path.
+  // Pins the schema-level filter (n4s `runSchemaPaths` affected narrowing),
+  // not just focus exclusion: focus-excluded tests still land in the result
+  // inventory as skipped nodes, so a missing key proves the failure was
+  // dropped before emission — only the schema-level filter can do that.
+  it('27. root array schema — changed() reports only affected failures', async () => {
+    const schema = enforce.isArrayOf(
+      enforce.shape({
+        country: enforce.isString().longerThan(5),
+        state: enforce.isString().longerThan(5),
+      }),
+    );
+    const data = [
+      { country: 'abcdef', state: 'abcdef' },
+      { country: 'abcdef', state: 'yy' },
+    ];
+    const failurePaths = (
+      results: readonly { pass: boolean; path?: readonly string[] }[],
+    ): string[] =>
+      results
+        .filter(result => !result.pass)
+        .map(result => (result.path ?? []).join('.'));
+    // Schema level: the full run surfaces the 1.state failure (array runs
+    // short-circuit at the first failing element); narrowing to the
+    // affected path keeps exactly it, while narrowing to an unaffected
+    // path drops it via pass-through.
+    expect(failurePaths(runSchemaPaths(schema, data))).toEqual(['1.state']);
+    expect(
+      failurePaths(runSchemaPaths(schema, data, { affected: ['1.state'] })),
+    ).toEqual(['1.state']);
+    expect(
+      runSchemaPaths(schema, data, { affected: ['0.state'] }).some(
+        result => !result.pass,
+      ),
+    ).toBe(false);
+    // Suite level: the same narrowing is observable through changed().
+    const suite = create(() => {}, schema);
+    const affected = await suite.changed('1.state').run(data);
+    // Array-element paths are runtime failure names that the type-level field
+    // vocabulary cannot name, so probe them through the explicit runtime seam.
+    expect(invokeWithUnknown(affected.hasErrors, '1.state')).toBe(true);
+    expect(invokeWithUnknown(affected.hasErrors, '0.state')).toBe(false);
+    const unaffected = await suite.changed('0.state').run(data);
+    expect(invokeWithUnknown(unaffected.hasErrors, '1.state')).toBe(false);
+    expect(Object.keys(unaffected.tests)).not.toContain('1.state');
+  });
+});

--- a/packages/vest/src/suite/__tests__/changed.nestedFocus.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.nestedFocus.test.ts
@@ -1,0 +1,266 @@
+import { enforce } from 'n4s';
+import { describe, it, expect } from 'vitest';
+
+import { create, test } from '../../vest';
+import { invokeWithUnknown } from '../../__tests__/runtimeTestUtils';
+import { getAffectedFields } from '../changed';
+
+describe('changed() nested schema focus and empty changed', () => {
+  it('normalizes bracket and dotted paths to identical suite focus', async () => {
+    const executed: string[] = [];
+    const schema = enforce.shape({
+      rows: enforce.isArrayOf(
+        enforce.shape({
+          name: enforce.isString(),
+          slug: enforce.isString().dependsOn($ => $.name),
+        }),
+      ),
+    });
+    const suite = create(() => {
+      test('rows.1.name', () => {
+        executed.push('rows.1.name');
+      });
+      test('rows.1.slug', () => {
+        executed.push('rows.1.slug');
+      });
+      test('rows.0.name', () => {
+        executed.push('rows.0.name');
+      });
+    }, schema);
+    const data = {
+      rows: [
+        { name: 'zero', slug: 'zero' },
+        { name: 'one', slug: 'one' },
+      ],
+    };
+
+    const bracket = await suite.changed('rows[1].name').run(data);
+    const bracketExecuted = [...executed];
+    executed.length = 0;
+    const dotted = await suite.changed('rows.1.name').run(data);
+
+    expect(bracketExecuted).toEqual(['rows.1.name', 'rows.1.slug']);
+    expect(executed).toEqual(bracketExecuted);
+    expect(bracket.run.focus).toEqual(dotted.run.focus);
+  });
+
+  it('P1: changed(profile.country) reports nested profile.state schema failure', async () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+    });
+    const suite = create(() => {}, schema);
+    const data: { profile: { country: string; state: string | number } } = {
+      profile: { country: 'US', state: 42 },
+    };
+    const result = await invokeWithUnknown(
+      suite.changed('profile.country').run,
+      data,
+    );
+    expect(result.hasErrors('profile.state')).toBe(true);
+  });
+
+  it('P1 control: full run() reports nested profile.state schema failure', async () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+    });
+    const suite = create(() => {}, schema);
+    const data: { profile: { country: string; state: string | number } } = {
+      profile: { country: 'US', state: 42 },
+    };
+    const result = await invokeWithUnknown(suite.run, data);
+    expect(result.hasErrors('profile.state')).toBe(true);
+  });
+
+  it('P1: changed(profile.country) with valid nested data reports no errors', async () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+    });
+    const suite = create(() => {}, schema);
+    const result = await suite
+      .changed('profile.country')
+      .run({ profile: { country: 'US', state: 'CA' } });
+    expect(result.hasErrors('profile.state')).toBe(false);
+    expect(result.hasErrors('profile.country')).toBe(false);
+  });
+
+  it('P1: changed(profile.country) excludes failures outside affected paths', async () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+      nickname: enforce.isString(),
+    });
+    const suite = create(() => {}, schema);
+    const data: {
+      profile: { country: string; state: string | number };
+      nickname: string | number;
+    } = {
+      profile: { country: 'US', state: 42 },
+      nickname: 7,
+    };
+    const result = await invokeWithUnknown(
+      suite.changed('profile.country').run,
+      data,
+    );
+    expect(result.hasErrors('profile.state')).toBe(true);
+    expect(result.hasErrors('nickname')).toBe(false);
+  });
+
+  it('P2: changed([]) runs no tests and reports no schema errors', async () => {
+    const schema = enforce.shape({
+      username: enforce.isString(),
+    });
+    const executed: string[] = [];
+    const suite = create(data => {
+      test('username', () => {
+        executed.push('username');
+        enforce(data.username).isNotBlank();
+      });
+      test('other', () => {
+        executed.push('other');
+      });
+    }, schema);
+    const data: { username: string | number } = { username: 42 };
+    const result = await invokeWithUnknown(suite.changed([]).run, data);
+    expect(executed).toEqual([]);
+    expect(result.hasErrors('username')).toBe(false);
+    expect(result.hasErrors()).toBe(false);
+  });
+
+  it('P0: changed(profile) reports the nested failure on a FRESH suite (no prior full run)', async () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+    });
+    const suite = create(() => {}, schema);
+    const data: { profile: { country: string; state: string | number } } = {
+      profile: { country: 'US', state: 42 },
+    };
+    const result = await invokeWithUnknown(suite.changed('profile').run, data);
+    expect(result.hasErrors('profile.state')).toBe(true);
+    expect(result.getErrors()).not.toEqual({});
+  });
+
+  it('P0: changed(travelers) array-parent expands item dependents with data', async () => {
+    const travelerSchema = enforce.shape({
+      country: enforce.isString(),
+      passportNumber: enforce.isString().dependsOn($ => $.country),
+    });
+    const schema = enforce.shape({
+      travelers: enforce.isArrayOf(travelerSchema),
+    });
+    const suite = create(() => {}, schema);
+    const data: {
+      travelers: { country: string; passportNumber: string | number }[];
+    } = {
+      travelers: [
+        { country: 'US', passportNumber: 'A' },
+        { country: 'IL', passportNumber: 42 },
+      ],
+    };
+    const result = await invokeWithUnknown(
+      suite.changed('travelers').run,
+      data,
+    );
+    expect(result.hasErrors('travelers.1.passportNumber')).toBe(true);
+  });
+
+  it('P0 order-sensitivity: unrelated earlier field must not hide the affected nested failure', async () => {
+    const schema = enforce.shape({
+      unrelated: enforce.isString(),
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+    });
+    const suite = create(() => {}, schema);
+    const data: {
+      unrelated: string | number;
+      profile: { country: string; state: string | number };
+    } = {
+      unrelated: 42,
+      profile: { country: 'US', state: 42 },
+    };
+    const result = await invokeWithUnknown(
+      suite.changed('profile.country').run,
+      data,
+    );
+    expect(result.hasErrors('profile.state')).toBe(true);
+    expect(result.hasErrors('unrelated')).toBe(false);
+  });
+
+  it('P1: changed(undefined) is a legal no-op like only(undefined)', async () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+      }),
+    });
+    const suite = create(() => {}, schema);
+    const data: { profile: { country: string; state: string | number } } = {
+      profile: { country: 'US', state: 42 },
+    };
+    const result = await invokeWithUnknown(suite.changed(undefined).run, data);
+    expect(result.hasErrors('profile.state')).toBe(true);
+  });
+
+  it('clears changed focus when chained after an earlier changed field', async () => {
+    const schema = enforce.shape({
+      first: enforce.isString(),
+      second: enforce.isString(),
+    });
+    const suite = create(() => {}, schema);
+
+    const result = await invokeWithUnknown(
+      suite.changed('first').changed(undefined).run,
+      { first: 'valid', second: 42 },
+    );
+
+    expect(result.hasErrors('second')).toBe(true);
+  });
+
+  it('P2: root→array affected set without data falls back to the top-level key', () => {
+    const schema = enforce.shape({
+      region: enforce.isString(),
+      travelers: enforce.isArrayOf(
+        enforce.shape({
+          country: enforce.isString(),
+          tax: enforce.isString().dependsOn($ => $.root.region),
+        }),
+      ),
+    });
+    const affected = getAffectedFields('region', schema, undefined);
+    expect(affected).toContain('region');
+    expect(affected).toContain('travelers');
+    expect(affected.some(field => field.includes('$'))).toBe(false);
+  });
+
+  it('P2 control: full run() with the same data runs tests and reports errors', async () => {
+    const schema = enforce.shape({
+      username: enforce.isString(),
+    });
+    const executed: string[] = [];
+    const suite = create(data => {
+      test('username', () => {
+        executed.push('username');
+        enforce(data.username).isNotBlank();
+      });
+    }, schema);
+    const data: { username: string | number } = { username: 42 };
+    const result = await invokeWithUnknown(suite.run, data);
+    expect(executed).toEqual(['username']);
+    expect(result.hasErrors('username')).toBe(true);
+  });
+});

--- a/packages/vest/src/suite/__tests__/changed.noSpeculativeExecution.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.noSpeculativeExecution.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { enforce } from 'n4s';
+
+import { create } from '../../vest';
+
+const CHAIN_BASELINE = Symbol.for('vest:chainBaseline');
+
+/**
+ * Simulates an unknown/exotic container: a real combinator-built rule with
+ * its construction-time baseline removed, so no metadata describes its
+ * semantics. Introspection must never behaviorally probe such rules.
+ */
+function stripBaseline(rule: unknown): void {
+  (rule as unknown as Record<symbol, unknown>)[CHAIN_BASELINE] = undefined;
+}
+
+describe('changed() never speculatively executes user validators', () => {
+  it('does not probe an unmarked top-level container with a synthetic value', async () => {
+    // The spy sits on the first member: n4s containers short-circuit at
+    // the first failure, so a synthetic {} probe would execute it with
+    // undefined (the key is missing from the probe value).
+    const seenA: unknown[] = [];
+    const schema = enforce.shape({
+      a: enforce.condition((value: unknown): boolean => {
+        seenA.push(value);
+        return typeof value === 'string';
+      }),
+      b: enforce.isString(),
+    });
+    stripBaseline(schema);
+
+    const changed = await create((): void => {}, schema)
+      .changed('b')
+      .run({ a: 'x', b: 'ok' });
+
+    // Every execution of a's validator uses real run data ('x').
+    expect(seenA).toContain('x');
+    expect(seenA).not.toContain(undefined);
+    // Full-run fallback with affected filtering: 'a' is not reported.
+    expect(changed.hasErrors('a')).toBe(false);
+    expect(changed.hasErrors('b')).toBe(false);
+  });
+
+  it('does not probe an unmarked nested container with a synthetic value', async () => {
+    const seenY: unknown[] = [];
+    // Invalidity is runtime-driven (flag), not type-driven: the data stays
+    // well-typed while the member fails, so no type escape is needed to
+    // model an invalid unaffected member.
+    const xValid = { current: false };
+    const nested = enforce.shape({
+      y: enforce.condition((value: unknown): boolean => {
+        seenY.push(value);
+        return typeof value === 'string';
+      }),
+      x: enforce.condition((): boolean => xValid.current),
+    });
+    stripBaseline(nested);
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      nested,
+    });
+
+    const changed = await create((): void => {}, schema)
+      .changed('nested.y')
+      .run({ a: 'ok', nested: { y: 'ok', x: 'bad' } });
+
+    expect(seenY).toContain('ok');
+    expect(seenY).not.toContain(undefined);
+    expect(changed.hasErrors('nested.x')).toBe(false);
+    expect(changed.hasErrors('nested.y')).toBe(false);
+
+    // The affected-invalid direction still surfaces through the filter.
+    const changedInvalid = await create((): void => {}, schema)
+      .changed('nested.x')
+      .run({ a: 'ok', nested: { y: 'ok', x: 'bad' } });
+    expect(changedInvalid.hasErrors('nested.x')).toBe(true);
+  });
+
+  it('positive controls: unaffected-invalid stays unreported while affected validators fire with real data', async () => {
+    const seenB: unknown[] = [];
+    const schema = enforce.shape({
+      a: enforce.condition(
+        (value: unknown): boolean => typeof value === 'string',
+      ),
+      b: enforce.condition((value: unknown): boolean => {
+        seenB.push(value);
+        return typeof value === 'string';
+      }),
+    });
+    stripBaseline(schema);
+
+    const suite = create((): void => {}, schema);
+    const changed = await suite.changed('b').run({ a: 42, b: 'ok' });
+
+    // The affected validator really fired, with real run data.
+    expect(seenB).toEqual(['ok']);
+    // 'a' is invalid but unaffected: the fallback narrows it out.
+    expect(changed.hasErrors('a')).toBe(false);
+    expect(changed.hasErrors('b')).toBe(false);
+
+    // Affected-invalid variant: the changed field itself reports.
+    const changedInvalid = await suite.changed('b').run({ a: 42, b: 42 });
+    expect(changedInvalid.hasErrors('b')).toBe(true);
+    expect(changedInvalid.hasErrors('a')).toBe(false);
+  });
+});

--- a/packages/vest/src/suite/__tests__/changed.projection.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.projection.test.ts
@@ -1,0 +1,721 @@
+import { describe, expect, it } from 'vitest';
+import { enforce } from 'n4s';
+
+import { create, test } from '../../vest';
+import { invokeWithUnknown } from '../../__tests__/runtimeTestUtils';
+
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      hasAllowedFlag: (value: { flag?: unknown }) => boolean;
+      countCountry: (value: unknown) => boolean;
+    }
+  }
+}
+
+enforce.extend({
+  hasAllowedFlag: (value: { flag?: unknown }): boolean => value.flag === true,
+});
+
+const rootSchema = enforce.shape({
+  accountType: enforce.isString(),
+  company: enforce.shape({
+    country: enforce.isString(),
+    taxId: enforce.isString().dependsOn($ => [$.country, $.root.accountType]),
+  }),
+});
+
+describe('changed() source-retaining projection', () => {
+  it('retains the local sibling source for a nested dependent', async () => {
+    // The invalid dependent composes only with its sibling source
+    // retained: the affected leaf failure is reported, not swallowed by an
+    // orphaned-source fallback.
+    const suite = create(() => {}, rootSchema);
+    const data: {
+      accountType: string;
+      company: { country: string; taxId: string | number };
+    } = {
+      accountType: 'business',
+      company: { country: 'CA', taxId: 42 },
+    };
+    const changed = await invokeWithUnknown(
+      suite.changed('company.taxId').run,
+      data,
+    );
+    expect(changed.hasErrors('company.taxId')).toBe(true);
+  });
+
+  it('retains the $.root provider for a nested dependent', async () => {
+    // Broken provider, valid dependent: the retained source composes, and
+    // the provider failure attributes away from the affected leaf.
+    const suite = create(() => {}, rootSchema);
+    const data: {
+      accountType: string | number;
+      company: { country: string; taxId: string };
+    } = {
+      accountType: 42,
+      company: { country: 'CA', taxId: 'ok' },
+    };
+    const changed = await invokeWithUnknown(
+      suite.changed('company.taxId').run,
+      data,
+    );
+    expect(changed.hasErrors('company.taxId')).toBe(false);
+    expect(changed.hasErrors()).toBe(false);
+  });
+
+  it('projected fragments compose without orphaned sources', async () => {
+    // Both the source-side and target-side changes run to a verdict:
+    // neither direction orphans a dependency source at composition.
+    const suite = create(() => {}, rootSchema);
+    const badTax: {
+      accountType: string;
+      company: { country: string; taxId: string | number };
+    } = {
+      accountType: 'business',
+      company: { country: 'CA', taxId: 42 },
+    };
+    const byTarget = await invokeWithUnknown(
+      suite.changed('company.taxId').run,
+      badTax,
+    );
+    expect(byTarget.hasErrors('company.taxId')).toBe(true);
+    const badCountry: {
+      accountType: string;
+      company: { country: string | number; taxId: string };
+    } = {
+      accountType: 'business',
+      company: { country: 42, taxId: 'ok' },
+    };
+    const bySource = await invokeWithUnknown(
+      suite.changed('company.country').run,
+      badCountry,
+    );
+    expect(bySource.hasErrors('company.country')).toBe(true);
+  });
+
+  it('concretizes array item targets to the changed index', async () => {
+    // Only index 0 is invalid while index 1 changed: same-index
+    // concretization must not leak the unaffected index 0 failure in.
+    const schema = enforce.shape({
+      rows: enforce.isArrayOf(
+        enforce.shape({
+          country: enforce.isString(),
+          state: enforce.isString().dependsOn($ => $.country),
+        }),
+      ),
+    });
+    const suite = create(() => {}, schema);
+    const data: {
+      rows: { country: string; state: string | number }[];
+    } = {
+      rows: [
+        { country: 'US', state: 42 },
+        { country: 'CA', state: 'ok' },
+      ],
+    };
+    const changed = await invokeWithUnknown(
+      suite.changed('rows.1.country').run,
+      data,
+    );
+    expect(changed.hasErrors('rows.1.state')).toBe(false);
+    expect(changed.hasErrors('rows.0.state')).toBe(false);
+    expect(changed.hasErrors()).toBe(false);
+  });
+
+  it('passes changed names through when the schema exposes no dependencies', async () => {
+    // No graph, no expansion: the raw changed name still selects its test.
+    const seen: string[] = [];
+    const suite = create((data: { a: { b: string } }) => {
+      test('a.b', () => {
+        seen.push('a.b');
+        enforce(data.a.b).isString();
+      });
+    });
+    await suite.changed('a.b').run({ a: { b: 'x' } });
+    expect(seen).toEqual(['a.b']);
+  });
+
+  it('record string keys: changed(recordKey.field) invalidates dependents', async () => {
+    // 'x' is a string (type-valid) but too short (rule-invalid), so the
+    // fixture violates the rule without type escape hatches.
+    const schema = enforce.shape({
+      dictionary: enforce.record(
+        enforce.shape({
+          country: enforce.isString(),
+          state: enforce
+            .isString()
+            .longerThan(5)
+            .dependsOn($ => $.country),
+        }),
+      ),
+    });
+    const seen: string[] = [];
+    const suite = create(data => {
+      test('dictionary.home.country', () => {
+        seen.push('dictionary.home.country');
+        enforce(data.dictionary.home.country).isString();
+      });
+      test('dictionary.home.state', () => {
+        seen.push('dictionary.home.state');
+        enforce(data.dictionary.home.state).isString();
+      });
+    }, schema);
+
+    const data = { dictionary: { home: { country: 'US', state: 'x' } } };
+    const full = await suite.run(data);
+    expect(full.hasErrors('dictionary.home.state')).toBe(true);
+
+    seen.length = 0;
+    const changed = await suite.changed('dictionary.home.country').run(data);
+    // The string record key must match the relationship's item segment —
+    // the dependent's failure cannot be swallowed.
+    expect(changed.hasErrors('dictionary.home.state')).toBe(true);
+    expect(seen).toContain('dictionary.home.state');
+  });
+
+  it('array per-index: a shadowed affected failure is still reported', async () => {
+    // Both states are rule-invalid ('x' fails longerThan) but only index 1
+    // is affected. The union projection reports just the first failing item
+    // (rows.0.state), which the post-filter drops — the per-index supplement
+    // must still surface the affected rows.1.state failure.
+    const schema = enforce.shape({
+      rows: enforce.isArrayOf(
+        enforce.shape({
+          country: enforce.isString(),
+          state: enforce
+            .isString()
+            .longerThan(5)
+            .dependsOn($ => $.country),
+        }),
+      ),
+    });
+    const seen: string[] = [];
+    const suite = create(data => {
+      test('rows.0.country', () => {
+        seen.push('rows.0.country');
+        enforce(data.rows[0].country).isString();
+      });
+      test('rows.1.country', () => {
+        seen.push('rows.1.country');
+        enforce(data.rows[1].country).isString();
+      });
+    }, schema);
+
+    const data = {
+      rows: [
+        { country: 'US', state: 'x' },
+        { country: 'CA', state: 'x' },
+      ],
+    };
+    const changed = await suite.changed('rows.1.country').run(data);
+    expect(changed.hasErrors('rows.1.state')).toBe(true);
+    expect(changed.hasErrors('rows.0.state')).toBe(false);
+    expect(seen).toContain('rows.1.country');
+    expect(seen).not.toContain('rows.0.country');
+  });
+
+  it('record per-key: a shadowed affected key is still reported', async () => {
+    // Both keys are rule-invalid, but only b is affected. The union
+    // projection reports just the first failing key (a), which the
+    // post-filter drops — the per-key supplement must surface b.state.
+    const schema = enforce.shape({
+      dictionary: enforce.record(
+        enforce.shape({
+          country: enforce.isString(),
+          state: enforce
+            .isString()
+            .longerThan(5)
+            .dependsOn($ => $.country),
+        }),
+      ),
+    });
+    const seen: string[] = [];
+    const suite = create(data => {
+      test('dictionary.b.country', () => {
+        seen.push('dictionary.b.country');
+        enforce(data.dictionary.b.country).isString();
+      });
+    }, schema);
+
+    const data = {
+      dictionary: {
+        a: { country: 'US', state: 'x' },
+        b: { country: 'CA', state: 'x' },
+      },
+    };
+    const changed = await suite.changed('dictionary.b.country').run(data);
+    expect(changed.hasErrors('dictionary.b.state')).toBe(true);
+    expect(changed.hasErrors('dictionary.a.state')).toBe(false);
+    expect(seen).toContain('dictionary.b.country');
+  });
+
+  it('nested shape array: shadowed failures surface below shapes', async () => {
+    // Same shadowing as top-level arrays, but nested under a shape: the
+    // supplement must descend through group to reach rows.
+    const schema = enforce.shape({
+      group: enforce.shape({
+        rows: enforce.isArrayOf(
+          enforce.shape({
+            country: enforce.isString(),
+            state: enforce
+              .isString()
+              .longerThan(5)
+              .dependsOn($ => $.country),
+          }),
+        ),
+      }),
+    });
+    const seen: string[] = [];
+    const suite = create(data => {
+      test('group.rows.1.country', () => {
+        seen.push('group.rows.1.country');
+        enforce(data.group.rows[1].country).isString();
+      });
+    }, schema);
+
+    const data = {
+      group: {
+        rows: [
+          { country: 'US', state: 'x' },
+          { country: 'CA', state: 'x' },
+        ],
+      },
+    };
+    const changed = await suite.changed('group.rows.1.country').run(data);
+    expect(changed.hasErrors('group.rows.1.state')).toBe(true);
+    expect(changed.hasErrors('group.rows.0.state')).toBe(false);
+    expect(seen).toContain('group.rows.1.country');
+  });
+
+  it('skip() narrows synthesized schema failures by exact name', async () => {
+    // Suite tests use isString (pass on 'x'); only schema synthesis fails.
+    const schema = enforce.shape({
+      nick: enforce.isString().longerThan(5),
+    });
+    const suite = create(data => {
+      test('nick', () => {
+        enforce(data.nick).isString();
+      });
+    }, schema);
+
+    const data = { nick: 'x' };
+    const unskipped = await suite.changed('nick').run(data);
+    expect(unskipped.hasErrors('nick')).toBe(true);
+
+    // omit() honors the top-level skip and the post-filter agrees.
+    const skipped = await suite
+      .focus({ skip: 'nick' })
+      .changed('nick')
+      .run(data);
+    expect(skipped.hasErrors('nick')).toBe(false);
+  });
+
+  it('skip() of a parent does not suppress nested synthesis', async () => {
+    // Runtime skip() matches user tests by exact field name; synthesized
+    // schema tests mirror that — skipping 'profile' leaves a nested
+    // 'profile.state' failure in place, exactly as a user test there would.
+    const schema = enforce.shape({
+      profile: enforce.shape({
+        country: enforce.isString(),
+        state: enforce
+          .isString()
+          .longerThan(5)
+          .dependsOn($ => $.country),
+      }),
+    });
+    const suite = create(data => {
+      test('profile.country', () => {
+        enforce(data.profile.country).isString();
+      });
+    }, schema);
+
+    const data = { profile: { country: 'US', state: 'x' } };
+    const skipped = await suite
+      .focus({ skip: 'profile' })
+      .changed('profile.country')
+      .run(data);
+    expect(skipped.hasErrors('profile.state')).toBe(true);
+  });
+
+  it('record numeric keys: supplement dispatches stringified', async () => {
+    // Affected paths coerce numeric segments to numbers, but record keys
+    // stay strings at runtime — the supplement must match across that.
+    const schema = enforce.shape({
+      dictionary: enforce.record(
+        enforce.shape({
+          country: enforce.isString(),
+          state: enforce
+            .isString()
+            .longerThan(5)
+            .dependsOn($ => $.country),
+        }),
+      ),
+    });
+    const seen: string[] = [];
+    const suite = create(data => {
+      test('dictionary.1.country', () => {
+        seen.push('dictionary.1.country');
+        enforce(data.dictionary['1'].country).isString();
+      });
+    }, schema);
+
+    const data = {
+      dictionary: {
+        '0': { country: 'US', state: 'x' },
+        '1': { country: 'CA', state: 'x' },
+      },
+    };
+    const changed = await suite.changed('dictionary.1.country').run(data);
+    expect(changed.hasErrors('dictionary.1.state')).toBe(true);
+    expect(changed.hasErrors('dictionary.0.state')).toBe(false);
+    expect(seen).toContain('dictionary.1.country');
+  });
+
+  it('supplement skips members when data contradicts the container kind', async () => {
+    // Array schema with object data: per-key dispatch would invent a
+    // member failure the full run never attributed. The container-kind
+    // guard must skip the supplement (the container failure itself stays).
+    const schema = enforce.shape({
+      tags: enforce.isArrayOf(enforce.isString().longerThan(5)),
+    });
+    const suite = create(() => {
+      test('tags', () => {
+        enforce('x').isString();
+      });
+    }, schema);
+
+    const data = { tags: { 0: 'xx' } };
+    // The explicit runtime seam admits the intentionally mistyped container
+    // needed to prove that the supplement skips this contradiction.
+    const changed = await invokeWithUnknown(suite.changed('tags.0').run, data);
+    expect(changed.hasErrors('tags.0')).toBe(false);
+  });
+
+  it('supplement surfaces shadowed failures in kind-contradicting members', async () => {
+    // A nested member whose value contradicts the member kind: the full
+    // run attributes the inner failure to the member path (isArrayOf
+    // prefixes the member index), so the supplement must surface it even
+    // when an earlier member's failure shadows it in the main run.
+    // Guarding the member run itself by container kind would report this
+    // affected member clean — that guard belongs only to dispatch.
+    const schema = enforce.shape({
+      matrix: enforce.isArrayOf(
+        enforce.isArrayOf(
+          enforce.shape({ v: enforce.isString().longerThan(5) }),
+        ),
+      ),
+    });
+    const suite = create(() => {}, schema);
+    const data = { matrix: [[{ v: 'xx' }], 'oops'] };
+    // The explicit runtime seam admits the intentionally mistyped member
+    // needed to pin supplement attribution for contradicting members.
+    const changed = await invokeWithUnknown(
+      suite.changed('matrix.1').run,
+      data,
+    );
+    expect(changed.hasErrors('matrix.1')).toBe(true);
+  });
+
+  it('primitive containers: per-member failures without graphs', async () => {
+    // Arrays/records of primitives carry no dependency graph, but
+    // per-member attribution must still work — first-failure shadowing
+    // applies. Values stay type-valid ('xx' fails longerThan, not isString).
+    const schema = enforce.shape({
+      tags: enforce.isArrayOf(enforce.isString().longerThan(5)),
+      dictionary: enforce.record(enforce.isString().longerThan(5)),
+    });
+    const seen: string[] = [];
+    const suite = create(data => {
+      test('tags.1', () => {
+        seen.push('tags.1');
+        enforce(data.tags[1]).isString();
+      });
+    }, schema);
+
+    const data = { tags: ['xx', 'yy'], dictionary: { a: 'xx', b: 'yy' } };
+    const changedTags = await suite.changed('tags.1').run(data);
+    expect(changedTags.hasErrors('tags.1')).toBe(true);
+    expect(changedTags.hasErrors('tags.0')).toBe(false);
+    expect(seen).toContain('tags.1');
+
+    const changedRecord = await suite.changed('dictionary.b').run(data);
+    expect(changedRecord.hasErrors('dictionary.b')).toBe(true);
+    expect(changedRecord.hasErrors('dictionary.a')).toBe(false);
+  });
+
+  it('deferred rooted validation timing is observable', () => {
+    // Composition and describe() stay lenient for rooted paths so focused
+    // fragments keep composing; enforcement lands at execution.
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn($ => $.root.missing),
+    });
+    const described = schema.describe();
+    expect(described.dependencies).toHaveLength(1);
+    expect(() => schema.test({ a: 'x', b: 'y' })).toThrow();
+  });
+
+  it('partial containers keep their semantics under projection', async () => {
+    // Narrowing profile to {country, state} must not make the dropped key
+    // or the missing state required: the container stays partial. A loose()
+    // rebuild would report a spurious missing-state failure.
+    const schema = enforce.shape({
+      profile: enforce.partial({
+        country: enforce.isString(),
+        state: enforce.isString().dependsOn($ => $.country),
+        nickname: enforce.isString(),
+      }),
+    });
+    const seen: string[] = [];
+    const suite = create(data => {
+      test('profile.country', () => {
+        seen.push('profile.country');
+        enforce(data.profile.country).isString();
+      });
+    }, schema);
+
+    const data = { profile: { country: 'US' } };
+    const full = await suite.run(data);
+    expect(full.hasErrors('profile.country')).toBe(false);
+    expect(full.hasErrors('profile.state')).toBe(false);
+
+    seen.length = 0;
+    const changed = await suite.changed('profile.country').run(data);
+    expect(seen).toContain('profile.country');
+    expect(changed.hasErrors('profile.country')).toBe(false);
+    expect(changed.hasErrors('profile.state')).toBe(false);
+  });
+
+  it('P1-1: changed() keeps container validators chained after the combinator', async () => {
+    // A validator chained onto the container itself (not a member) must
+    // survive projection: dropping it makes changed() pass a run that the
+    // full suite fails. The baseline bail-out retains the whole subtree.
+    const schema = enforce
+      .loose({
+        profile: enforce.shape({ country: enforce.isString() }),
+        flag: enforce.isBoolean(),
+      })
+      .hasAllowedFlag();
+    const suite = create((): void => {}, schema);
+    const bad: { profile: { country: string }; flag: boolean } = {
+      profile: { country: 'US' },
+      flag: false,
+    };
+    expect(suite.runStatic(bad).hasErrors()).toBe(true);
+    const changed = await suite.changed('profile.country').run(bad);
+    expect(changed.hasErrors()).toBe(true);
+  });
+
+  it('P1-2: changed() narrows an all-optional shape instead of retaining it', async () => {
+    // Every member is optional, so the container accepts {} — but it is an
+    // ordinary loose() shape, not partial(). Retaining the whole subtree
+    // lets the unrelated earlier failure (nickname) shadow the affected
+    // dependent failure (state) after post-filtering.
+    const schema = enforce.loose({
+      profile: enforce.shape({
+        nickname: enforce.optional(enforce.isString().shorterThan(3)),
+        state: enforce.optional(enforce.isString().dependsOn($ => $.country)),
+        country: enforce.optional(enforce.isString()),
+      }),
+    });
+    const suite = create((): void => {}, schema);
+    const data: {
+      profile: { nickname: string; state: string | number; country: string };
+    } = {
+      profile: { nickname: 'toolongname', state: 42, country: 'US' },
+    };
+    const changed = await invokeWithUnknown(
+      suite.changed('profile.state').run,
+      data,
+    );
+    expect(changed.hasErrors('profile.state')).toBe(true);
+    expect(changed.hasErrors('profile.nickname')).toBe(false);
+  });
+
+  it('projects a partial container without first-failure masking', async () => {
+    const schema = enforce.shape({
+      profile: enforce.partial({
+        unrelated: enforce.isString().longerThan(5),
+        country: enforce.isString(),
+        state: enforce
+          .isString()
+          .longerThan(5)
+          .dependsOn($ => $.country),
+      }),
+    });
+    const data = {
+      profile: { unrelated: 'x', country: 'US', state: 'x' },
+    };
+
+    expect(schema.run(data).path).toEqual(['profile', 'unrelated']);
+    const changed = await create((): void => {}, schema)
+      .changed('profile.country')
+      .run(data);
+
+    expect(changed.hasErrors('profile.unrelated')).toBe(false);
+    expect(changed.hasErrors('profile.state')).toBe(true);
+  });
+
+  it('projects a partial root without making omitted keys required', async () => {
+    const schema = enforce.partial({
+      unrelated: enforce.isString().longerThan(5),
+      country: enforce.isString(),
+      state: enforce
+        .isString()
+        .longerThan(5)
+        .dependsOn($ => $.country),
+    });
+    const data = { unrelated: 'x', country: 'US', state: 'x' };
+
+    expect(schema.run(data).path).toEqual(['unrelated']);
+    const changed = await create((): void => {}, schema)
+      .changed('country')
+      .run(data);
+
+    expect(changed.hasErrors('unrelated')).toBe(false);
+    expect(changed.hasErrors('state')).toBe(true);
+  });
+
+  it('supplements shadowed members in a retained chained container', async () => {
+    const schema = enforce.shape({
+      profile: enforce
+        .loose({
+          unrelated: enforce.isString().longerThan(5),
+          country: enforce.isString(),
+          state: enforce
+            .isString()
+            .longerThan(5)
+            .dependsOn($ => $.country),
+        })
+        .hasAllowedFlag(),
+    });
+    const data = {
+      profile: {
+        flag: true,
+        unrelated: 'x',
+        country: 'US',
+        state: 'x',
+      },
+    };
+
+    expect(schema.run(data).path).toEqual(['profile', 'unrelated']);
+    const changed = await create((): void => {}, schema)
+      .changed('profile.country')
+      .run(data);
+
+    expect(changed.hasErrors('profile.unrelated')).toBe(false);
+    expect(changed.hasErrors('profile.state')).toBe(true);
+  });
+
+  it('supplements shadowed members when the root container is retained', async () => {
+    const schema = enforce
+      .loose({
+        unrelated: enforce.isString().longerThan(5),
+        country: enforce.isString(),
+        state: enforce
+          .isString()
+          .longerThan(5)
+          .dependsOn($ => $.country),
+      })
+      .hasAllowedFlag();
+    const data = {
+      flag: true,
+      unrelated: 'x',
+      country: 'US',
+      state: 'x',
+    };
+
+    expect(schema.run(data).path).toEqual(['unrelated']);
+    const changed = await create((): void => {}, schema)
+      .changed('country')
+      .run(data);
+
+    expect(changed.hasErrors('unrelated')).toBe(false);
+    expect(changed.hasErrors('state')).toBe(true);
+  });
+
+  it('P1-3a: changed() surfaces an affected tuple member hidden by first-failure', async () => {
+    // Tuples report only the first failing position: member 0 fails, so the
+    // full run never reaches member 1. The positional supplement must still
+    // surface the affected member 1 failure with exact attribution.
+    const schema = enforce.shape({
+      point: enforce.tuple(
+        enforce.isString().shorterThan(2),
+        enforce.isNumber(),
+      ),
+    });
+    const suite = create((): void => {}, schema);
+    const data: { point: [string, number | string] } = {
+      point: ['toolong', 'x'],
+    };
+    const full = await invokeWithUnknown(suite.run, data);
+    expect(full.hasErrors('point.0')).toBe(true);
+    expect(full.hasErrors('point.1')).toBe(false);
+    const changed = await invokeWithUnknown(suite.changed('point.1').run, data);
+    expect(changed.hasErrors('point.1')).toBe(true);
+    expect(changed.hasErrors('point.0')).toBe(false);
+  });
+
+  it('P1-3b: changed() surfaces an affected union element hidden by first-failure', async () => {
+    // Union elements must match some member: element 0 matches neither, so
+    // the full run reports only element 0. The supplement resolves
+    // whole-member matching per affected index and reproduces the generic
+    // element failure for element 1.
+    const memberA = enforce.shape({
+      kind: enforce.isString(),
+      a: enforce.isString(),
+    });
+    const memberB = enforce.shape({
+      kind: enforce.isString(),
+      b: enforce.isString(),
+    });
+    const schema = enforce.shape({
+      rows: enforce.isArrayOf(memberA, memberB),
+    });
+    const suite = create((): void => {}, schema);
+    const data: { rows: Array<{ kind: string }> } = {
+      rows: [{ kind: 'x' }, { kind: 'y' }],
+    };
+    const full = await invokeWithUnknown(suite.run, data);
+    expect(full.hasErrors('rows.0')).toBe(true);
+    expect(full.hasErrors('rows.1')).toBe(false);
+    const changed = await invokeWithUnknown(
+      suite.changed('rows.1.kind').run,
+      data,
+    );
+    expect(changed.hasErrors('rows.1')).toBe(true);
+    expect(changed.hasErrors('rows.0')).toBe(false);
+  });
+
+  it('P1-4: focused array validation runs affected members exactly once', async () => {
+    // Selective execution: the unaffected rows.0 validator must not run,
+    // and the affected rows.1 validator must run exactly once (main run or
+    // supplement — never both). A counter matcher observes every call.
+    const seen: unknown[] = [];
+    enforce.extend({
+      countCountry: (value: unknown): boolean => {
+        seen.push(value);
+        return typeof value === 'string';
+      },
+    });
+    const schema = enforce.shape({
+      rows: enforce.isArrayOf(
+        enforce.shape({
+          country: enforce.isString().countCountry(),
+          state: enforce.isString(),
+        }),
+      ),
+    });
+    const suite = create((): void => {}, schema);
+    const data = {
+      rows: [
+        { country: 'US', state: 'CA' },
+        { country: 'CA', state: 'NY' },
+      ],
+    };
+    const changed = await suite.changed('rows.1.country').run(data);
+    expect(changed.hasErrors()).toBe(false);
+    expect(seen).toEqual(['CA']);
+  });
+});

--- a/packages/vest/src/suite/__tests__/changed.sourceRetention.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.sourceRetention.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { enforce } from 'n4s';
+
+import { create, test } from '../../vest';
+
+describe('changed() dependency source retention', () => {
+  it('does not execute an unaffected source schema validator when only the target changed', async () => {
+    const schemaCalls: string[] = [];
+    const suiteCalls: string[] = [];
+
+    const schema = enforce.shape({
+      country: enforce.condition((value: unknown) => {
+        schemaCalls.push(String(value));
+        return typeof value === 'string';
+      }),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+
+    const suite = create(data => {
+      test('country', () => {
+        suiteCalls.push('country');
+        enforce(data.country).isString();
+      });
+      test('state', () => {
+        suiteCalls.push('state');
+        enforce(data.state).isString();
+      });
+    }, schema);
+
+    await suite.run({ country: 'US', state: 'CA' });
+    schemaCalls.length = 0;
+    suiteCalls.length = 0;
+
+    await suite.changed('state').run({ country: 'US', state: 'NY' });
+
+    expect(suiteCalls).toEqual(['state']);
+    expect(schemaCalls).toEqual([]);
+  });
+});

--- a/packages/vest/src/suite/__tests__/changed.supplement.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.supplement.test.ts
@@ -1,0 +1,469 @@
+import { describe, expect, it } from 'vitest';
+import { enforce } from 'n4s';
+
+import { create } from '../../vest';
+
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      countSupplementValue: (value: unknown) => boolean;
+      countFallbackState: (value: unknown) => boolean;
+      hasFallbackFlag: (value: { flag?: unknown }) => boolean;
+      countKeyedValue: (value: unknown) => boolean;
+      countFlatMember: (value: unknown) => boolean;
+    }
+  }
+}
+
+describe('changed() supplement exactly-once execution', () => {
+  it('validates an affected array element whose value is undefined', async () => {
+    const schema = enforce.shape({
+      rows: enforce.isArrayOf(
+        enforce.condition(
+          (value: unknown): boolean => typeof value === 'string',
+        ),
+      ),
+    });
+    const data = { rows: ['ok', undefined] };
+
+    expect(schema.run(data).path).toEqual(['rows', '1']);
+    const changed = await create((): void => {}, schema)
+      .changed('rows.1')
+      .run(data);
+
+    expect(changed.hasErrors('rows.1')).toBe(true);
+  });
+
+  it('validates an affected record entry whose value is undefined', async () => {
+    const valueRule = enforce.condition(
+      (value: unknown): boolean => typeof value === 'string',
+    );
+    const schema = enforce.shape({ dict: enforce.record(valueRule) });
+    const data = { dict: { first: 42, selected: undefined } };
+
+    expect(schema.run(data).path).toEqual(['dict', 'first']);
+    const changed = await create((): void => {}, schema)
+      .changed('dict.selected')
+      .run(data);
+
+    expect(changed.hasErrors('dict.first')).toBe(false);
+    expect(changed.hasErrors('dict.selected')).toBe(true);
+  });
+
+  it('record per-key: the affected member validator fires exactly once', async () => {
+    // F3: the projection keeps records whole (key-rule parity), so the
+    // main run already executes every key. The supplement must not re-run
+    // affected keys on top: a once-only stateful validator false-fails on
+    // its second call.
+    const calls: unknown[] = [];
+    enforce.extend({
+      countSupplementValue: (value: unknown): boolean => {
+        calls.push(value);
+        return (
+          calls.filter(seen => seen === value).length === 1 &&
+          typeof value === 'string'
+        );
+      },
+    });
+    const schema = enforce.shape({
+      dict: enforce.record(enforce.isString().countSupplementValue()),
+    });
+    const suite = create((): void => {}, schema);
+    const data = { dict: { a: 'x', b: 'y' } };
+
+    const changed = await suite.changed('dict.a').run(data);
+    expect(changed.hasErrors()).toBe(false);
+    // The affected key ran once (in the kept-whole main run, never again
+    // in the supplement); the whole-record main run covers both keys once.
+    expect(calls.filter(value => value === 'x')).toHaveLength(1);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('record per-key: a failing affected key is still reported', async () => {
+    // Guard against over-skipping: the exactly-once skip applies only when
+    // the main run passed the container, never to real failures.
+    const schema = enforce.shape({
+      dict: enforce.record(enforce.isString().longerThan(5)),
+    });
+    const suite = create((): void => {}, schema);
+    const data = { dict: { a: 'x', b: 'yyyyyy' } };
+
+    const changed = await suite.changed('dict.a').run(data);
+    expect(changed.hasErrors('dict.a')).toBe(true);
+    expect(changed.hasErrors('dict.b')).toBe(false);
+  });
+
+  it('record per-key: an affected key-rule violation surfaces', async () => {
+    // W1: two-arg records close over a key rule no slot exposes. The
+    // whole-record main run reports only the first failing key and the
+    // supplement ran only the value rule, so changed('dict.a') stayed
+    // clean though 'a' itself violates the key rule.
+    const schema = enforce.shape({
+      dict: enforce.record(
+        enforce.isString().longerThan(2),
+        enforce.isNumber(),
+      ),
+    });
+    const suite = create((): void => {}, schema);
+    const data = { dict: { ab: 1, a: 2 } };
+
+    const full = await suite.run(data);
+    expect(full.hasErrors('dict.ab')).toBe(true);
+
+    const changedA = await suite.changed('dict.a').run(data);
+    expect(changedA.hasErrors('dict.a')).toBe(true);
+
+    const changedAb = await suite.changed('dict.ab').run(data);
+    expect(changedAb.hasErrors('dict.ab')).toBe(true);
+  });
+
+  it('record per-key: passing two-arg entries still execute exactly once', async () => {
+    // The single-entry run replaces the value-only run (never adds to
+    // it), so a stateful value validator fires once total.
+    const calls: unknown[] = [];
+    enforce.extend({
+      countKeyedValue: (value: unknown): boolean => {
+        calls.push(value);
+        return typeof value === 'number';
+      },
+    });
+    const schema = enforce.shape({
+      dict: enforce.record(
+        enforce.isString().longerThan(2),
+        enforce.isNumber().countKeyedValue(),
+      ),
+    });
+    const suite = create((): void => {}, schema);
+    const data = { dict: { abc: 1, def: 2 } };
+
+    const changed = await suite.changed('dict.abc').run(data);
+    expect(changed.hasErrors()).toBe(false);
+    expect(calls.filter(value => value === 1)).toHaveLength(1);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('flat changed() surfaces an affected member hidden by first-failure order', async () => {
+    // W2: the flat path filtered a first-failure-only full run with no
+    // per-member supplement, so changed('b') stayed clean though 'b' is
+    // invalid — the full run only ever reported 'a'.
+    const schema = enforce.shape({
+      a: enforce.isString().longerThan(5),
+      b: enforce.isString().longerThan(5),
+    });
+    const suite = create((): void => {}, schema);
+    const data = { a: 'x', b: 'y' };
+
+    const full = await suite.run(data);
+    expect(full.hasErrors('a')).toBe(true);
+
+    const changed = await suite.changed('b').run(data);
+    expect(changed.hasErrors('b')).toBe(true);
+    expect(changed.hasErrors('a')).toBe(false);
+  });
+
+  it('only()+changed() merge honors the affected member too', async () => {
+    // W3: the merged base-only + affected set filters reporting, but the
+    // affected failure never made it into the merged results at all.
+    const schema = enforce.shape({
+      a: enforce.isString().longerThan(5),
+      b: enforce.isString().longerThan(5),
+    });
+    const suite = create((): void => {}, schema);
+    const data = { a: 'x', b: 'y' };
+
+    const changed = await suite.focus({ only: 'a' }).changed('b').run(data);
+    expect(changed.hasErrors('a')).toBe(true);
+    expect(changed.hasErrors('b')).toBe(true);
+  });
+
+  it('flat supplement runs each shadowed member through one execution unit', async () => {
+    // Members the main run reached (up to and including the failure) run
+    // there; members after it run once in the supplement — never both. One
+    // unit is parse-then-run: a failing member fires twice inside it (the
+    // engine's own duality, identical in full runs), a passing member once.
+    const calls: unknown[] = [];
+    enforce.extend({
+      countFlatMember: (value: unknown): boolean => {
+        calls.push(value);
+        return typeof value === 'string' && value.length > 5;
+      },
+    });
+    const schema = enforce.shape({
+      a: enforce.isString().longerThan(5),
+      b: enforce.isString().countFlatMember(),
+      c: enforce.isString().countFlatMember(),
+    });
+    const suite = create((): void => {}, schema);
+    const data = { a: 'x', b: 'y', c: 'ok-ok-ok' };
+
+    const changed = await suite.changed(['b', 'c']).run(data);
+    expect(changed.hasErrors('b')).toBe(true);
+    expect(changed.hasErrors('c')).toBe(false);
+    expect(calls.filter(value => value === 'y')).toHaveLength(2);
+    expect(calls.filter(value => value === 'ok-ok-ok')).toHaveLength(1);
+  });
+
+  it('union supplement rejection mirrors the full-run failure exactly', async () => {
+    // W4: an all-rejected union element fails generically on both sides
+    // (n4s returns a message-less failure for multi-rule rejection). The
+    // supplement must not invent a message the full run does not report —
+    // identical keys dedupe correctly, differing messages would diverge.
+    // Contract-pinning (green before and after): guards future drift.
+    const schema = enforce.shape({
+      rows: enforce.isArrayOf(
+        enforce.shape({
+          kind: enforce.isString(),
+          v: enforce.isNumber(),
+        }),
+        enforce.isString().longerThan(5),
+      ),
+    });
+    const suite = create((): void => {}, schema);
+    // Type-valid inputs: 'xx' is a string, but too short for the string
+    // member and not an object for the shape member — rejected by all.
+    const data = { rows: ['long-enough', 'xx'] };
+
+    const full = await suite.run(data);
+    expect(full.hasErrors('rows.1')).toBe(true);
+
+    const changed = await suite.changed('rows.1').run(data);
+    expect(changed.hasErrors('rows.1')).toBe(true);
+    expect(changed.getErrors()['rows.1']).toEqual(full.getErrors()['rows.1']);
+  });
+
+  it('flat supplement skips absent members of partial-like tops', async () => {
+    // Wave-3 F1: partial({a: fail, b}) with b absent — b is valid-absent,
+    // but past the failure boundary the supplement ran it standalone and
+    // invented a failure the full run never reports.
+    const schema = enforce.partial({
+      a: enforce.isString().longerThan(5),
+      b: enforce.isString(),
+    });
+    const suite = create((): void => {}, schema);
+    const data = { a: 'x' };
+
+    const full = await suite.run(data);
+    expect(full.hasErrors('a')).toBe(true);
+    expect(full.hasErrors('b')).toBe(false);
+
+    const changed = await suite.changed('b').run(data);
+    expect(changed.hasErrors('b')).toBe(false);
+  });
+
+  it('flat supplement still fails absent required members of loose tops', async () => {
+    // Discriminator: loose requires presence, so an absent affected member
+    // past the boundary is genuinely invalid — the supplement must run it.
+    const schema = enforce.loose({
+      a: enforce.isString().longerThan(5),
+      b: enforce.isString(),
+    });
+    const suite = create((): void => {}, schema);
+    const data = { a: 'x', b: 'present-for-type-inference' };
+    Reflect.deleteProperty(data, 'b');
+
+    const full = await suite.run(data);
+    expect(full.hasErrors('a')).toBe(true);
+
+    // The failure is latent, not invented: unshadowed, the full run
+    // reports the absent required member too.
+    const unshadowedData = { a: 'ok-ok-ok', b: 'present-for-type-inference' };
+    Reflect.deleteProperty(unshadowedData, 'b');
+    const unshadowed = await suite.run(unshadowedData);
+    expect(unshadowed.hasErrors('b')).toBe(true);
+
+    const changed = await suite.changed('b').run(data);
+    expect(changed.hasErrors('b')).toBe(true);
+  });
+
+  it('flat supplement still fails absent required members of strict shapes', async () => {
+    // Control: absent-required under shape() is invalid in the full run,
+    // so the supplement must surface it past the boundary too.
+    const schema = enforce.shape({
+      a: enforce.isString().longerThan(5),
+      b: enforce.isString(),
+    });
+    const suite = create((): void => {}, schema);
+    const data = { a: 'x', b: 'present-for-type-inference' };
+    Reflect.deleteProperty(data, 'b');
+
+    // The failure is latent, not invented: unshadowed, the full run
+    // reports the absent required member too.
+    const unshadowedData = { a: 'ok-ok-ok', b: 'present-for-type-inference' };
+    Reflect.deleteProperty(unshadowedData, 'b');
+    const unshadowed = await suite.run(unshadowedData);
+    expect(unshadowed.hasErrors('b')).toBe(true);
+
+    const changed = await suite.changed('b').run(data);
+    expect(changed.hasErrors('b')).toBe(true);
+  });
+
+  it('nested supplement skips absent members of partial containers', async () => {
+    // Wave-3 F2: shape({profile: partial({u: fail, b})}) with b absent —
+    // b is valid-absent, but past the nested boundary the supplement ran
+    // the raw member rule against undefined and invented profile.b.
+    const schema = enforce.shape({
+      profile: enforce.partial({
+        u: enforce.isString().longerThan(5),
+        b: enforce.isString(),
+      }),
+    });
+    const suite = create((): void => {}, schema);
+    const data = { profile: { u: 'x' } };
+
+    const full = await suite.run(data);
+    expect(full.hasErrors('profile.u')).toBe(true);
+
+    const changed = await suite.changed(['profile.u', 'profile.b']).run(data);
+    expect(changed.hasErrors('profile.u')).toBe(true);
+    expect(changed.hasErrors('profile.b')).toBe(false);
+  });
+
+  it('flat supplement evaluates explicit-undefined members', async () => {
+    // Presence, not value, decides absence: container iteration evaluates
+    // an explicit undefined in the full run, so the supplement must run it
+    // too — even under a partial-like top.
+    const schema = enforce.partial({
+      a: enforce.isString().longerThan(5),
+      b: enforce.isString(),
+    });
+    const suite = create((): void => {}, schema);
+
+    const unshadowed = await suite.run({ a: 'ok-ok-ok', b: undefined });
+    expect(unshadowed.hasErrors('b')).toBe(true);
+
+    const changed = await suite.changed('b').run({ a: 'x', b: undefined });
+    expect(changed.hasErrors('b')).toBe(true);
+  });
+
+  it('flat supplement ignores non-enumerable members of partial tops', async () => {
+    const schema = enforce.partial({
+      a: enforce.isString().longerThan(5),
+      b: enforce.isString(),
+    });
+    const suite = create((): void => {}, schema);
+    const data = { a: 'x', b: 'present-for-type-inference' };
+    Object.defineProperty(data, 'b', {
+      enumerable: false,
+      value: undefined,
+    });
+
+    const full = await suite.run(data);
+    expect(full.hasErrors('a')).toBe(true);
+    expect(full.hasErrors('b')).toBe(false);
+
+    const changed = await suite.changed('b').run(data);
+    expect(changed.hasErrors('b')).toBe(false);
+  });
+
+  it('nested supplement ignores non-enumerable members of partial containers', async () => {
+    const schema = enforce.shape({
+      profile: enforce.partial({
+        a: enforce.isString().longerThan(5),
+        b: enforce.isString(),
+      }),
+    });
+    const suite = create((): void => {}, schema);
+    const data = {
+      profile: { a: 'x', b: 'present-for-type-inference' },
+    };
+    Object.defineProperty(data.profile, 'b', {
+      enumerable: false,
+      value: undefined,
+    });
+
+    const full = await suite.run(data);
+    expect(full.hasErrors('profile.a')).toBe(true);
+    expect(full.hasErrors('profile.b')).toBe(false);
+
+    const changed = await suite.changed(['profile.a', 'profile.b']).run(data);
+    expect(changed.hasErrors('profile.a')).toBe(true);
+    expect(changed.hasErrors('profile.b')).toBe(false);
+  });
+
+  it('full-fallback path executes each member validator at most once', async () => {
+    // F4: a validator chained after the top container moves the baseline,
+    // so the projection falls back to a full-schema main run. The
+    // per-member supplement must not run on top of it.
+    const calls: unknown[] = [];
+    enforce.extend({
+      countFallbackState: (value: unknown): boolean => {
+        calls.push(value);
+        return typeof value === 'string';
+      },
+    });
+    enforce.extend({
+      hasFallbackFlag: (value: { flag?: unknown }): boolean =>
+        value.flag === true,
+    });
+    const schema = enforce
+      .loose({
+        rows: enforce.isArrayOf(
+          enforce.shape({
+            country: enforce.isString(),
+            state: enforce.isString().countFallbackState(),
+          }),
+        ),
+        flag: enforce.isBoolean(),
+      })
+      .hasFallbackFlag();
+    const suite = create((): void => {}, schema);
+    const data = {
+      rows: [
+        { country: 'US', state: 'CA' },
+        { country: 'CA', state: 'NY' },
+      ],
+      flag: true,
+    };
+
+    const changed = await suite.changed('rows.1.state').run(data);
+    expect(changed.hasErrors()).toBe(false);
+    expect(calls.filter(value => value === 'NY')).toHaveLength(1);
+    expect(calls.filter(value => value === 'CA')).toHaveLength(1);
+  });
+
+  it('full-fallback supplement does not revisit array members before the failure', async () => {
+    const calls: unknown[] = [];
+    enforce.extend({
+      countFallbackState: (value: unknown): boolean => {
+        calls.push(value);
+        return typeof value === 'string' && value.length > 5;
+      },
+    });
+    enforce.extend({
+      hasFallbackFlag: (value: { flag?: unknown }): boolean =>
+        value.flag === true,
+    });
+    const schema = enforce
+      .loose({
+        rows: enforce.isArrayOf(enforce.isString().countFallbackState()),
+        flag: enforce.isBoolean(),
+      })
+      .hasFallbackFlag();
+    const data = {
+      rows: ['first-ok', 'x', 'third-ok'],
+      flag: true,
+    };
+
+    schema.run(data);
+    const baselineFirst = calls.filter(value => value === 'first-ok').length;
+    const baselineFailure = calls.filter(value => value === 'x').length;
+    expect(calls).not.toContain('third-ok');
+    calls.length = 0;
+
+    const changed = await create((): void => {}, schema)
+      .changed(['rows.0', 'rows.2'])
+      .run(data);
+
+    expect(changed.hasErrors()).toBe(false);
+    // Invalid changed() runs use n4s's normal parse-then-run fallback, so
+    // members reached by the main execution unit match two direct runs.
+    // The supplement must not add a third visit to an earlier member.
+    expect(calls.filter(value => value === 'first-ok')).toHaveLength(
+      baselineFirst * 2,
+    );
+    expect(calls.filter(value => value === 'x')).toHaveLength(
+      baselineFailure * 2,
+    );
+    expect(calls.filter(value => value === 'third-ok')).toHaveLength(1);
+  });
+});

--- a/packages/vest/src/suite/__tests__/cloneDataTree.test.ts
+++ b/packages/vest/src/suite/__tests__/cloneDataTree.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import { cloneDataTree } from '../cloneDataTree';
+
+describe('cloneDataTree', () => {
+  it('clones custom symbol descriptors and cycles on built-in values', () => {
+    const metadata = Symbol('metadata');
+    type DateWithMetadata = Date & {
+      [metadata]: { owner: DateWithMetadata; nested: { value: number } };
+      customMethod: () => string;
+    };
+    const input = new Date('2026-01-02T00:00:00.000Z') as DateWithMetadata;
+    const customMethod = (): string => 'custom';
+    Object.defineProperty(input, metadata, {
+      configurable: true,
+      enumerable: false,
+      value: { owner: input, nested: { value: 1 } },
+      writable: true,
+    });
+    Object.defineProperty(input, 'customMethod', {
+      configurable: true,
+      value: customMethod,
+      writable: true,
+    });
+
+    const snapshot = cloneDataTree(input, true) as DateWithMetadata;
+    const descriptor = Object.getOwnPropertyDescriptor(snapshot, metadata);
+
+    expect(snapshot).not.toBe(input);
+    expect(descriptor?.enumerable).toBe(false);
+    expect(snapshot[metadata]).not.toBe(input[metadata]);
+    expect(snapshot[metadata].owner).toBe(snapshot);
+    expect(Object.isFrozen(snapshot[metadata].nested)).toBe(true);
+    expect(snapshot.customMethod).toBe(customMethod);
+  });
+
+  it('deeply isolates mutable copies while preserving cycles', () => {
+    const input: { child: { value: number }; self?: unknown } = {
+      child: { value: 1 },
+    };
+    input.self = input;
+
+    const copy = cloneDataTree(input) as typeof input;
+    copy.child.value = 2;
+
+    expect(input.child.value).toBe(1);
+    expect(copy.self).toBe(copy);
+  });
+
+  it('creates readable immutable Map, Set, and Date snapshots', () => {
+    const input = {
+      date: new Date('2026-01-02T00:00:00.000Z'),
+      map: new Map([['a', 1]]),
+      set: new Set(['a']),
+    };
+    const snapshot = cloneDataTree(input, true) as typeof input;
+
+    expect(snapshot.map.get('a')).toBe(1);
+    expect([...snapshot.set]).toEqual(['a']);
+    expect(snapshot.date.toISOString()).toBe('2026-01-02T00:00:00.000Z');
+    expect(snapshot.map).toBeInstanceOf(Map);
+    expect(snapshot.set).toBeInstanceOf(Set);
+    expect(snapshot.date).toBeInstanceOf(Date);
+    expect(Object.isFrozen(snapshot.map)).toBe(true);
+    expect(Object.isFrozen(snapshot.set)).toBe(true);
+    expect(Object.isFrozen(snapshot.date)).toBe(true);
+    expect(() => snapshot.map.set('b', 2)).toThrow(TypeError);
+    expect(() => snapshot.set.add('b')).toThrow(TypeError);
+    expect(() => snapshot.date.setUTCFullYear(2030)).toThrow(TypeError);
+  });
+
+  it('preserves internal-slot objects without creating broken prototype shells', () => {
+    class PrivateValue {
+      readonly #value: number;
+
+      constructor(value: number) {
+        this.#value = value;
+      }
+
+      read(): number {
+        return this.#value;
+      }
+    }
+
+    const privateValue = new PrivateValue(7);
+    const weakKey = {};
+    const weakMap = new WeakMap([[weakKey, 'kept']]);
+    const input = {
+      buffer: new Uint8Array([3, 4]).buffer,
+      privateValue,
+      typed: new Uint8Array([1, 2]),
+      view: new DataView(new Uint8Array([5, 6]).buffer),
+      weakMap,
+    };
+
+    const snapshot = cloneDataTree(input, true) as typeof input;
+
+    expect(snapshot.typed).not.toBe(input.typed);
+    expect([...snapshot.typed]).toEqual([1, 2]);
+    expect([...snapshot.typed.slice(1)]).toEqual([2]);
+    expect(snapshot.buffer).not.toBe(input.buffer);
+    expect([...new Uint8Array(snapshot.buffer)]).toEqual([3, 4]);
+    expect(snapshot.view).not.toBe(input.view);
+    expect(snapshot.view.getUint8(0)).toBe(5);
+    expect(snapshot.privateValue).toBe(privateValue);
+    expect(snapshot.privateValue.read()).toBe(7);
+    expect(snapshot.weakMap).toBe(weakMap);
+    expect(snapshot.weakMap.get(weakKey)).toBe('kept');
+
+    snapshot.typed[0] = 9;
+    snapshot.view.setUint8(0, 9);
+    new Uint8Array(snapshot.buffer)[0] = 9;
+    expect([...input.typed]).toEqual([1, 2]);
+    expect(input.view.getUint8(0)).toBe(5);
+    expect([...new Uint8Array(input.buffer)]).toEqual([3, 4]);
+  });
+});

--- a/packages/vest/src/suite/__tests__/docsExamples.test.ts
+++ b/packages/vest/src/suite/__tests__/docsExamples.test.ts
@@ -38,17 +38,31 @@ function throwOnTranspileDiagnostics(output: ts.TranspileOutput): void {
   }
 }
 
-function readCodeBlock(relativePath: string, blockIndex: number): string {
+type CodeBlockSelector = number | { containing: string };
+
+function readCodeBlock(
+  relativePath: string,
+  selector: CodeBlockSelector,
+): string {
   const markdown = fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
   const blocks = [
     ...markdown.matchAll(
       /```(?:js|jsx|ts|tsx|javascript|typescript)[^\n]*\n([\s\S]*?)```/g,
     ),
   ];
-  const block = blocks[blockIndex]?.[1];
+  const block =
+    typeof selector === 'number'
+      ? blocks[selector]?.[1]
+      : blocks.find(candidate =>
+          candidate[1].includes(selector.containing),
+        )?.[1];
 
   if (!block) {
-    throw new Error(`Missing code block ${blockIndex} in ${relativePath}`);
+    const description =
+      typeof selector === 'number'
+        ? String(selector)
+        : `containing ${JSON.stringify(selector.containing)}`;
+    throw new Error(`Missing code block ${description} in ${relativePath}`);
   }
 
   return block;
@@ -56,10 +70,10 @@ function readCodeBlock(relativePath: string, blockIndex: number): string {
 
 function executeCodeBlock(
   relativePath: string,
-  blockIndex: number,
+  selector: CodeBlockSelector,
   runtime: Runtime = {},
 ): Record<string, unknown> {
-  const source = readCodeBlock(relativePath, blockIndex);
+  const source = readCodeBlock(relativePath, selector);
   const output = ts.transpileModule(source, {
     compilerOptions: {
       esModuleInterop: true,
@@ -94,10 +108,10 @@ function executeCodeBlock(
 
 function executeTestBody(
   relativePath: string,
-  blockIndex: number,
+  selector: CodeBlockSelector,
   runtime: Runtime = {},
 ) {
-  const source = readCodeBlock(relativePath, blockIndex);
+  const source = readCodeBlock(relativePath, selector);
   const imports = source.match(/^import .*;$/gm) ?? [];
   const body = source.replace(/^import .*;\n?/gm, '');
   const wrapped = `${imports.join('\n')}\nimport { create } from 'vest';\nexport const docsSuite = create((data) => {\n${body}\n});`;
@@ -202,7 +216,7 @@ describe('executable documentation examples', () => {
     expect(shipping.hasErrors('street')).toBe(true);
   });
 
-  it('revalidates documented dependent password fields together', () => {
+  it('re-runs documented dependent password fields together', () => {
     const { passwordSuite } = executeCodeBlock(
       'website/docs/guides/dependent-fields.md',
       0,
@@ -362,7 +376,7 @@ describe('executable documentation examples', () => {
   it('runs the documented context-aware schema rule', () => {
     const { schema } = executeCodeBlock(
       'website/docs/enforce/creating_custom_rules.md',
-      4,
+      { containing: 'export const schema = enforce.shape' },
     ) as { schema: ReturnType<typeof vest.enforce.shape> };
     const suite = vest.create(() => {}, schema);
 

--- a/packages/vest/src/suite/__tests__/finalizerParity.test.ts
+++ b/packages/vest/src/suite/__tests__/finalizerParity.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+// Public-entry imports pin both boundaries to the same n4s copy.
+import { enforce, EnforceSchemaError } from 'n4s';
+
+import { create } from '../../vest';
+
+function danglingRootSchema() {
+  return enforce.shape({
+    a: enforce.isString(),
+    b: enforce.isString().dependsOn($ => $.root.nope),
+  });
+}
+
+function captureThrow(fn: () => void): unknown {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  return undefined;
+}
+
+describe('finalizer identity parity for dangling $.root paths', () => {
+  it('standalone schema.test() throws a real EnforceSchemaError', () => {
+    const schema = danglingRootSchema();
+    const thrown = captureThrow(() => {
+      schema.test({ a: 'a', b: 'b' });
+    });
+
+    expect(thrown).toBeInstanceOf(EnforceSchemaError);
+    expect((thrown as Error).message).toBe(
+      'EnforceSchemaError: "b" depends on unknown field "nope"',
+    );
+  });
+
+  it('suite creation throws a real EnforceSchemaError with the identical message', () => {
+    const schema = danglingRootSchema();
+    const standaloneThrown = captureThrow(() => {
+      schema.test({ a: 'a', b: 'b' });
+    });
+    expect(standaloneThrown).toBeInstanceOf(EnforceSchemaError);
+
+    const suiteThrown = captureThrow(() => {
+      create(() => {}, schema);
+    });
+
+    expect(suiteThrown).toBeInstanceOf(EnforceSchemaError);
+    expect((suiteThrown as Error).constructor.name).toBe('EnforceSchemaError');
+    expect((suiteThrown as Error).message).toBe(
+      (standaloneThrown as Error).message,
+    );
+  });
+});

--- a/packages/vest/src/suite/__tests__/recordValidation.test.ts
+++ b/packages/vest/src/suite/__tests__/recordValidation.test.ts
@@ -23,7 +23,6 @@ describe('enforce.record() in Vest', () => {
     });
 
     expect(result.isValid()).toBe(false);
-    // @ts-expect-error - dot-path field name
     expect(result.hasErrors('settings.notifications')).toBe(true);
   });
 
@@ -43,7 +42,6 @@ describe('enforce.record() in Vest', () => {
       .run({ name: '', permissions: { bad: 'value' } });
 
     // permissions.bad should not be validated because we focused on name
-    // @ts-expect-error - dot-path field name
     expect(result.hasErrors('permissions.bad')).toBe(false);
     expect(result.isValid()).toBe(true);
   });

--- a/packages/vest/src/suite/__tests__/schema.example.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.example.test.ts
@@ -8,8 +8,10 @@
 
 import { enforce } from 'n4s';
 import { describe, expect, it } from 'vitest';
+import type { StandardSchemaV1 } from 'vest-utils/standardSchemaSpec';
 
 import { create, test } from 'vest';
+import type { Suite } from 'vest';
 
 // ✅ CORRECT: Data matches schema
 const userSchema = enforce.shape({
@@ -58,7 +60,18 @@ const personSchema = enforce.shape({
   address: addressSchema,
 });
 
-const nestedSuite = create(data => {
+type Person = {
+  name: string;
+  address: { street: string; city: string; zipCode: string };
+};
+type PersonSuite = Suite<
+  Extract<keyof Person, string>,
+  string,
+  (data: Person) => void,
+  StandardSchemaV1<Person, Person>
+>;
+
+const nestedSuite: PersonSuite = create(data => {
   // TypeScript knows the full nested structure
   // data.name: string
   // data.address.street: string

--- a/packages/vest/src/suite/__tests__/schema.example.ts
+++ b/packages/vest/src/suite/__tests__/schema.example.ts
@@ -7,8 +7,10 @@
  */
 
 import { enforce } from 'n4s';
+import type { StandardSchemaV1 } from 'vest-utils/standardSchemaSpec';
 
 import { create, test } from '../../vest';
+import type { Suite } from '../../vest';
 
 // ✅ CORRECT: Data matches schema
 const userSchema = enforce.shape({
@@ -94,7 +96,18 @@ const personSchema = enforce.shape({
   address: addressSchema,
 });
 
-const nestedSuite = create(data => {
+type Person = {
+  name: string;
+  address: { street: string; city: string; zipCode: string };
+};
+type PersonSuite = Suite<
+  Extract<keyof Person, string>,
+  string,
+  (data: Person) => void,
+  StandardSchemaV1<Person, Person>
+>;
+
+const nestedSuite: PersonSuite = create(data => {
   // TypeScript knows the full nested structure
   // data.name: string
   // data.address.street: string

--- a/packages/vest/src/suite/__tests__/schema.runtime.test.ts
+++ b/packages/vest/src/suite/__tests__/schema.runtime.test.ts
@@ -396,6 +396,81 @@ describe('Schema Runtime Validation', () => {
       expect(result.run.data.parsed).toEqual({ score: 42 });
       expect(Object.isFrozen(result.run.data.parsed)).toBe(true);
     });
+
+    it('isolates nested callback mutations from results and future focused runs', () => {
+      const nestedSchema = enforce.shape({
+        profile: enforce.shape({ name: enforce.isString() }),
+        score: enforce.isNumeric().toNumber(),
+      });
+      const callbackNames: string[] = [];
+      let runCount = 0;
+      const suite = create(data => {
+        callbackNames.push(data.profile.name);
+        if (runCount++ === 0) data.profile.name = 'callback-mutated';
+      }, nestedSchema);
+
+      const first = suite.run({
+        profile: { name: 'original' },
+        score: '1',
+      });
+
+      expect(first.types?.output).toEqual({
+        profile: { name: 'original' },
+        score: 1,
+      });
+      expect(first.run.data.parsed).toEqual(first.types?.output);
+      expect(Object.isFrozen(first.run.data.parsed?.profile)).toBe(true);
+
+      const second = suite.changed('score').run({
+        profile: { name: 'new-raw-value' },
+        score: '2',
+      });
+
+      // The focused run retains the last successfully mapped untouched field,
+      // but never the callback's mutation of that field.
+      expect(callbackNames).toEqual(['original', 'original']);
+      expect(second.types?.output).toEqual({
+        profile: { name: 'original' },
+        score: 2,
+      });
+      expect(second.run.data.parsed).toEqual({
+        profile: { name: 'new-raw-value' },
+        score: 2,
+      });
+    });
+
+    it('prevents mutation through Map, Set, and Date parsed snapshots', () => {
+      const originalDate = new Date('2026-01-02T00:00:00.000Z');
+      const containerSchema = enforce.shape({
+        date: enforce.condition(
+          (value: Date): boolean => value instanceof Date,
+        ),
+        map: enforce.condition(
+          (value: Map<string, number>): boolean => value instanceof Map,
+        ),
+        set: enforce.condition(
+          (value: Set<string>): boolean => value instanceof Set,
+        ),
+      });
+      const containerSuite = create(() => {}, containerSchema);
+
+      const result = containerSuite.run({
+        date: originalDate,
+        map: new Map([['a', 1]]),
+        set: new Set(['a']),
+      });
+      const parsed = result.run.data.parsed;
+      if (parsed === undefined) {
+        throw new Error('Expected a parsed container snapshot');
+      }
+
+      expect(() => parsed.map.set('b', 2)).toThrow(TypeError);
+      expect(() => parsed.set.add('b')).toThrow(TypeError);
+      expect(() => parsed.date.setUTCFullYear(2030)).toThrow(TypeError);
+      expect([...parsed.map]).toEqual([['a', 1]]);
+      expect([...parsed.set]).toEqual(['a']);
+      expect(parsed.date.toISOString()).toBe('2026-01-02T00:00:00.000Z');
+    });
   });
 
   describe('Stateful behavior', () => {

--- a/packages/vest/src/suite/__tests__/schemaRelationships.suite.test.ts
+++ b/packages/vest/src/suite/__tests__/schemaRelationships.suite.test.ts
@@ -1,0 +1,156 @@
+import { compose, enforce } from 'n4s';
+import { describe, it, expect } from 'vitest';
+
+import { create, test } from '../../vest';
+
+/**
+ * Vest suite integration — V1 boundary: describe() exists, suite execution NOT auto-affected.
+ * only('password') must NOT auto-include confirmPassword even when confirmPassword.dependsOn(password).
+ */
+
+describe('Schema Relationships — vest suite V1 boundary', () => {
+  it('creates a suite from composed root providers', () => {
+    const schema = compose(
+      enforce.loose({
+        name: enforce.isString().dependsOn($ => $.root.id),
+      }),
+      enforce.loose({ id: enforce.isString() }),
+    );
+
+    expect(() => create(() => {}, schema)).not.toThrow();
+  });
+
+  it('schema with dependsOn does not change suite execution — test still needed', () => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+
+    const suite = create(data => {
+      test('password', 'password required', () => {
+        enforce(data.password).isNotBlank();
+      });
+      test('confirmPassword', 'must match', () => {
+        enforce(data.confirmPassword).equals(data.password);
+      });
+    }, schema);
+
+    const result = suite.run({ password: 'abc', confirmPassword: 'xyz' });
+    expect(result.hasErrors('confirmPassword')).toBe(true);
+  });
+
+  it('only("password") does NOT auto-include confirmPassword in V1', () => {
+    const schema = enforce.shape({
+      password: enforce.isString(),
+      confirmPassword: enforce.isString().dependsOn($ => $.password),
+    });
+
+    const suite = create(data => {
+      test('password', () => {
+        enforce(data.password).isNotBlank();
+      });
+      test('confirmPassword', () => {
+        enforce(data.confirmPassword).equals(data.password);
+      });
+    }, schema);
+
+    const result = suite.only('password').run({
+      password: '',
+      confirmPassword: 'mismatch',
+    });
+
+    // In V1, only('password') runs only password, not dependents
+    expect(result.hasErrors('password')).toBe(true);
+    // confirmPassword was not run — even though it dependsOn password, it stays as before (not tested in this focused run)
+    // The key assertion: V1 does NOT expand affected set
+    expect(result.tests.confirmPassword).toBeDefined();
+    const executed: string[] = [];
+    const freshSuite = create(data => {
+      test('password', () => {
+        executed.push('password');
+        enforce(data.password).isNotBlank();
+      });
+      test('confirmPassword', () => {
+        executed.push('confirmPassword');
+        enforce(data.confirmPassword).equals(data.password);
+      });
+    }, schema);
+    const freshResult = freshSuite.only('password').run({
+      password: 'abc',
+      confirmPassword: 'xyz',
+    });
+    expect(freshResult.tests.password).toBeDefined();
+    expect(freshResult.tests.confirmPassword.testCount).toBe(0);
+    expect(executed).toEqual(['password']);
+  });
+
+  it('async username dependsOn organizationId — schema declares, suite owns async', async () => {
+    const schema = enforce.shape({
+      organizationId: enforce.isString(),
+      username: enforce.isString().dependsOn($ => $.organizationId),
+    });
+
+    const suite = create(data => {
+      test('username', 'Username unavailable', async () => {
+        const available = await Promise.resolve(data.username !== 'taken');
+        enforce(available).isTruthy();
+      });
+    }, schema);
+
+    const result = suite.run({ organizationId: 'org1', username: 'taken' });
+    expect(result.isPending('username')).toBe(true);
+    await result;
+    expect(suite.get().hasErrors('username')).toBe(true);
+
+    const result2 = suite.run({ organizationId: 'org2', username: 'free' });
+    await result2;
+    expect(suite.get().hasErrors('username')).toBe(false);
+
+    // Schema still records edge even though validation is suite-only async
+    expect(schema.describe().dependencies).toHaveLength(1);
+  });
+
+  it('repeated runs keep describe() stable', () => {
+    const schema = enforce.shape({
+      a: enforce.isString(),
+      b: enforce.isString().dependsOn($ => $.a),
+    });
+
+    const suite = create(data => {
+      test('a', () => {
+        enforce(data.a).isNotBlank();
+      });
+      test('b', () => {
+        enforce(data.b).isNotBlank();
+      });
+    }, schema);
+
+    suite.run({ a: '1', b: '2' });
+    suite.run({ a: '1', b: '2' });
+    suite.run({ a: '', b: '' });
+
+    expect(schema.describe().dependencies).toHaveLength(1);
+  });
+
+  it('suite supports dependsOn field inside group-like shape nesting', () => {
+    const addressSchema = enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    });
+
+    const schema = enforce.shape({ billingAddress: addressSchema });
+    const suite = create(data => {
+      test('billingAddress.state', () => {
+        enforce(data.billingAddress.state).isNotBlank();
+      });
+    }, schema);
+
+    const res = suite.run({
+      billingAddress: { country: 'US', state: '' },
+    });
+
+    // Schema graph exists
+    expect(schema.describe().dependencies).toHaveLength(1);
+    expect(res.hasErrors('billingAddress.state')).toBe(true);
+  });
+});

--- a/packages/vest/src/suite/__tests__/staticSuite.test.ts
+++ b/packages/vest/src/suite/__tests__/staticSuite.test.ts
@@ -1,3 +1,4 @@
+import { enforce } from 'n4s';
 import { describe, it, expect } from 'vitest';
 import wait from 'wait';
 
@@ -37,6 +38,26 @@ describe('runStatic', () => {
     expect(suite2.hasErrors('t2')).toBe(true);
     expect(suite2.hasErrors('t3')).toBe(false);
     expect(suite2.hasErrors('t4')).toBe(false);
+  });
+
+  it('restores mapped schema output for a focused run after static hydration', async () => {
+    const schema = enforce.shape({
+      age: enforce.isNumeric().toNumber(),
+      note: enforce.isString(),
+    });
+    const serverSuite = vest.create(() => {}, schema);
+    const serialized = SuiteSerializer.serialize(
+      serverSuite.runStatic({ age: '10', note: 'server' }),
+    );
+    const seen: unknown[] = [];
+    const clientSuite = vest.create(data => {
+      seen.push(data);
+    }, schema);
+
+    SuiteSerializer.resume(clientSuite, serialized);
+    await clientSuite.changed('note').run({ note: 'client' });
+
+    expect(seen).toEqual([{ age: 10, note: 'client' }]);
   });
 
   describe('runStatic (promise)', () => {

--- a/packages/vest/src/suite/__tests__/subscribe.test.ts
+++ b/packages/vest/src/suite/__tests__/subscribe.test.ts
@@ -76,6 +76,65 @@ describe('suite.subscribe', () => {
       expect(testStarted).toHaveBeenCalledTimes(3);
       expect(suiteStart).toHaveBeenCalledTimes(1);
     });
+
+    it('emits one completion for each executed user or schema test in a changed run', async () => {
+      const schema = enforce.shape({
+        source: enforce.isString(),
+        dependent: enforce.isString().dependsOn($ => $.source),
+        unrelated: enforce.isString(),
+      });
+      const sourceRun = vi.fn();
+      const dependentRun = vi.fn();
+      const suite = vest.create(data => {
+        vest.test('source', () => {
+          sourceRun();
+          enforce(data.source).isNotBlank();
+        });
+        vest.test('dependent', () => {
+          dependentRun();
+          enforce(data.dependent).isNotBlank();
+        });
+        vest.test('unrelated', () => {
+          enforce(data.unrelated).isNotBlank();
+        });
+      }, schema);
+      await suite.run({ source: 'a', dependent: 'b', unrelated: 'c' });
+      sourceRun.mockClear();
+      dependentRun.mockClear();
+      const completed = vi.fn();
+      const suiteStarted = vi.fn();
+      const events: string[] = [];
+      suite.subscribe('TEST_COMPLETED', () => {
+        completed();
+        events.push('test-completed');
+      });
+      suite.subscribe('SUITE_RUN_STARTED', () => {
+        suiteStarted();
+        events.push('suite-started');
+      });
+      suite.subscribe('ALL_RUNNING_TESTS_FINISHED', () => {
+        events.push('all-finished');
+      });
+
+      await suite.changed('source').run({
+        source: 'next',
+        dependent: 42 as unknown as string,
+        unrelated: 'c',
+      });
+
+      // Two affected user tests and the synthesized dependent schema failure.
+      expect(sourceRun).toHaveBeenCalledTimes(1);
+      expect(dependentRun).toHaveBeenCalledTimes(1);
+      expect(completed).toHaveBeenCalledTimes(3);
+      expect(suiteStarted).toHaveBeenCalledTimes(1);
+      expect(events).toEqual([
+        'suite-started',
+        'test-completed',
+        'test-completed',
+        'test-completed',
+        'all-finished',
+      ]);
+    });
   });
 
   describe('unsubscribe', () => {

--- a/packages/vest/src/suite/__tests__/supersededRuns.test.ts
+++ b/packages/vest/src/suite/__tests__/supersededRuns.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { create, enforce, test } from '../../vest';
+
+type Deferred = {
+  promise: Promise<void>;
+  release: () => void;
+};
+
+function createDeferred(): Deferred {
+  let release: () => void = () => {};
+  const promise = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+function flushAsyncWork(): Promise<void> {
+  return new Promise<void>(resolve => setImmediate(resolve));
+}
+
+describe('superseded suite.run() ownership', () => {
+  it('makes a pending plain run adopt its plain successor outcome', async () => {
+    const gate = createDeferred();
+    const firstDone = createDeferred();
+    const suite = create((data: { tag: string }) => {
+      test('tag', async () => {
+        try {
+          if (data.tag === 'first') await gate.promise;
+          enforce(data.tag).isNotBlank();
+        } finally {
+          if (data.tag === 'first') firstDone.release();
+        }
+      });
+    });
+
+    const first = suite.run({ tag: 'first' });
+    const second = suite.run({ tag: 'second' });
+    const secondResult = await second;
+    gate.release();
+    await firstDone.promise;
+    await flushAsyncWork();
+
+    expect(await first).toBe(secondResult);
+    expect(suite.get().hasErrors('tag')).toBe(false);
+  });
+
+  it('chains ownership independently for interleaved suites', async () => {
+    const firstGate = createDeferred();
+    const secondGate = createDeferred();
+    const createGatedSuite = (gate: Deferred, expected: string) =>
+      create((data: { tag: string }) => {
+        test('tag', async () => {
+          await gate.promise;
+          enforce(data.tag).equals(expected);
+        });
+      });
+    const firstSuite = createGatedSuite(firstGate, 'a');
+    const secondSuite = createGatedSuite(secondGate, 'b');
+
+    const staleFirst = firstSuite.run({ tag: 'a' });
+    const secondRun = secondSuite.run({ tag: 'b' });
+    const latestFirst = firstSuite.run({ tag: 'a' });
+    firstGate.release();
+    const latestFirstResult = await latestFirst;
+
+    expect(await staleFirst).toBe(latestFirstResult);
+    secondGate.release();
+    expect((await secondRun).hasErrors('tag')).toBe(false);
+  });
+
+  it('keeps a pending run owned by itself when its successor throws synchronously', async () => {
+    const gate = createDeferred();
+    const firstDone = createDeferred();
+    const suite = create((data: { explode?: boolean; tag: string }) => {
+      if (data.explode) throw new Error('boom');
+      test('tag', async () => {
+        try {
+          await gate.promise;
+          enforce(data.tag).isNotBlank();
+        } finally {
+          firstDone.release();
+        }
+      });
+    });
+
+    const first = suite.run({ tag: 'first' });
+    expect(() => suite.run({ explode: true, tag: 'second' })).toThrow('boom');
+
+    gate.release();
+    await firstDone.promise;
+    await flushAsyncWork();
+
+    const outcome = await Promise.race([
+      Promise.resolve(first),
+      new Promise<'timeout'>(resolve => setImmediate(() => resolve('timeout'))),
+    ]);
+    expect(outcome).not.toBe('timeout');
+    if (outcome !== 'timeout') {
+      expect(outcome.hasErrors('tag')).toBe(false);
+    }
+  });
+});

--- a/packages/vest/src/suite/changed.ts
+++ b/packages/vest/src/suite/changed.ts
@@ -1,0 +1,10 @@
+import { resolveAffectedPaths } from 'n4s/exports/internal';
+
+/** Vest-specific adapter to n4s's canonical dependency planner. */
+export function getAffectedFields(
+  changedFields: string | string[],
+  schema: unknown,
+  data?: unknown,
+): string[] {
+  return resolveAffectedPaths(schema, changedFields, data);
+}

--- a/packages/vest/src/suite/cloneDataTree.ts
+++ b/packages/vest/src/suite/cloneDataTree.ts
@@ -1,0 +1,157 @@
+import { hasOwnProperty, isArray, isObject } from 'vest-utils';
+
+/**
+ * Copies supported data containers without relying on JSON serialization,
+ * preserving undefined values, symbols, cycles, and property descriptors.
+ * Immutable copies reject mutation through built-in collection/date methods,
+ * whose internal slots are not protected by Object.freeze alone. Opaque class
+ * instances are retained by identity because cloning their visible properties
+ * cannot recreate private fields or other internal slots.
+ */
+// eslint-disable-next-line complexity, max-lines-per-function, max-statements -- preserves each supported JavaScript container type
+export function cloneDataTree(
+  data: unknown,
+  immutable = false,
+  seen = new WeakMap<object, unknown>(),
+): unknown {
+  if (!isObject(data)) return data;
+
+  const existing = seen.get(data);
+  if (existing !== undefined) return existing;
+
+  if (data instanceof Date) {
+    const copy = new Date(data.getTime());
+    const output = immutable ? immutableBuiltin(copy, DateMutators) : copy;
+    seen.set(data, output);
+    copyOwnDescriptors(data, copy, immutable, seen);
+    if (immutable) Object.freeze(copy);
+    return output;
+  }
+  if (data instanceof RegExp) {
+    const copy = new RegExp(data.source, data.flags);
+    copy.lastIndex = data.lastIndex;
+    seen.set(data, copy);
+    copyOwnDescriptors(data, copy, immutable, seen);
+    return immutable ? Object.freeze(copy) : copy;
+  }
+  if (data instanceof Map) {
+    const copy = new Map<unknown, unknown>();
+    const output = immutable ? immutableBuiltin(copy, MapMutators) : copy;
+    seen.set(data, output);
+    for (const [key, value] of data) {
+      copy.set(
+        cloneDataTree(key, immutable, seen),
+        cloneDataTree(value, immutable, seen),
+      );
+    }
+    copyOwnDescriptors(data, copy, immutable, seen);
+    if (immutable) Object.freeze(copy);
+    return output;
+  }
+  if (data instanceof Set) {
+    const copy = new Set<unknown>();
+    const output = immutable ? immutableBuiltin(copy, SetMutators) : copy;
+    seen.set(data, output);
+    for (const value of data) {
+      copy.add(cloneDataTree(value, immutable, seen));
+    }
+    copyOwnDescriptors(data, copy, immutable, seen);
+    if (immutable) Object.freeze(copy);
+    return output;
+  }
+  if (data instanceof ArrayBuffer) {
+    const copy = data.slice(0);
+    seen.set(data, copy);
+    copyOwnDescriptors(data, copy, immutable, seen);
+    return copy;
+  }
+  if (ArrayBuffer.isView(data)) {
+    const copy = cloneArrayBufferView(data);
+    seen.set(data, copy);
+    copyOwnDescriptors(data, copy, immutable, seen);
+    return copy;
+  }
+  if (!isArray(data) && !isPlainDataObject(data)) {
+    seen.set(data, data);
+    return data;
+  }
+
+  const copy: Record<PropertyKey, unknown> | unknown[] = isArray(data)
+    ? []
+    : Object.create(Object.getPrototypeOf(data));
+  seen.set(data, copy);
+  copyOwnDescriptors(data, copy, immutable, seen);
+  return immutable ? Object.freeze(copy) : copy;
+}
+
+function copyOwnDescriptors(
+  source: object,
+  target: object,
+  immutable: boolean,
+  seen: WeakMap<object, unknown>,
+): void {
+  for (const key of Reflect.ownKeys(source)) {
+    const descriptor = Object.getOwnPropertyDescriptor(source, key);
+    if (descriptor === undefined) continue;
+    if ('value' in descriptor) {
+      descriptor.value = cloneDataTree(descriptor.value, immutable, seen);
+    }
+    Object.defineProperty(target, key, descriptor);
+  }
+}
+
+function isPlainDataObject(data: object): boolean {
+  const prototype = Object.getPrototypeOf(data);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function cloneArrayBufferView(view: ArrayBufferView): ArrayBufferView {
+  const bytes = new Uint8Array(view.byteLength);
+  bytes.set(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
+  if (view instanceof DataView) return new DataView(bytes.buffer);
+  return Reflect.construct(view.constructor, [bytes.buffer]) as ArrayBufferView;
+}
+
+const DateMutators = new Set<PropertyKey>([
+  'setDate',
+  'setFullYear',
+  'setHours',
+  'setMilliseconds',
+  'setMinutes',
+  'setMonth',
+  'setSeconds',
+  'setTime',
+  'setUTCDate',
+  'setUTCFullYear',
+  'setUTCHours',
+  'setUTCMilliseconds',
+  'setUTCMinutes',
+  'setUTCMonth',
+  'setUTCSeconds',
+  'setYear',
+]);
+const MapMutators = new Set<PropertyKey>(['clear', 'delete', 'set']);
+const SetMutators = new Set<PropertyKey>(['add', 'clear', 'delete']);
+
+function immutableBuiltin<T extends object>(
+  target: T,
+  mutators: ReadonlySet<PropertyKey>,
+): T {
+  const rejectMutation = (): never => {
+    throw new TypeError('Cannot mutate a parsed-data snapshot');
+  };
+  return new Proxy(target, {
+    defineProperty: rejectMutation,
+    deleteProperty: rejectMutation,
+    get(current, property) {
+      if (mutators.has(property)) return rejectMutation;
+      const value = Reflect.get(current, property, current);
+      if (hasOwnProperty(current, property)) return value;
+      return typeof value === 'function' && property !== 'constructor'
+        ? value.bind(current)
+        : value;
+    },
+    set: rejectMutation,
+    setPrototypeOf: rejectMutation,
+  });
+}

--- a/packages/vest/src/suite/createSuite.ts
+++ b/packages/vest/src/suite/createSuite.ts
@@ -1,3 +1,4 @@
+import { assertSchemaRootPathsValid } from 'n4s/exports/internal';
 import { CB, makeResult, Result } from 'vest-utils';
 import { VestRuntime } from 'vestjs-runtime';
 
@@ -71,6 +72,11 @@ function createSuite<
   S extends TSchema = undefined,
 >(suiteCallback: T, schema?: S): Suite<F, G, T, S> {
   const suiteCallbackResult = validateSuiteCallback(suiteCallback).unwrap();
+  if (schema) {
+    // Deferred ($.root) relationship endpoints are validated by n4s against
+    // the final mounted graph.
+    assertSchemaRootPathsValid(schema);
+  }
 
   const stateRef = useCreateVestState({ VestReconciler });
 

--- a/packages/vest/src/suite/useCreateSuiteMethods.ts
+++ b/packages/vest/src/suite/useCreateSuiteMethods.ts
@@ -14,7 +14,13 @@ import {
 import { bindSuiteSelectors } from '../suiteResult/selectors/suiteSelectors';
 import { useCreateSuiteResult } from '../suiteResult/suiteResult';
 
-import { SuiteModifiers, SuiteCallbackWithSchema } from './SuiteTypes';
+import { FieldExclusion } from '../hooks/focused/focused';
+import {
+  InternalSuiteModifiers,
+  SuiteModifiers,
+  SuiteCallbackWithSchema,
+  SuiteRunArguments,
+} from './SuiteTypes';
 import { useDeferDoneCallback } from './after/deferDoneCallback';
 import { createSuite } from './createSuite';
 import { getStandardSchema } from './getStandardSchema';
@@ -36,7 +42,7 @@ export function useCreateSuiteMethods<
   S extends TSchema = undefined,
 >(
   suiteCallback: SuiteCallbackWithSchema<S, T>,
-  modifiers: SuiteModifiers<F, G>,
+  modifiers: InternalSuiteModifiers<F, G>,
   subscribe: Subscribe,
   schema?: S,
 ) {
@@ -64,7 +70,7 @@ function useCreateSuiteMethodsHelper<
   S extends TSchema = undefined,
 >(ctx: {
   suiteCallback: SuiteCallbackWithSchema<S, T>;
-  modifiers: SuiteModifiers<F, G>;
+  modifiers: InternalSuiteModifiers<F, G>;
   subscribe: Subscribe;
   schema?: S;
   persistedRun: any;
@@ -87,7 +93,7 @@ function useGetSuiteMethods<
   S extends TSchema = undefined,
 >(ctx: {
   suiteCallback: SuiteCallbackWithSchema<S, T>;
-  modifiers: SuiteModifiers<F, G>;
+  modifiers: InternalSuiteModifiers<F, G>;
   subscribe: Subscribe;
   schema?: S;
   persistedRun: any;
@@ -102,12 +108,15 @@ function useGetSuiteMethods<
     get,
     ...bindSuiteSelectors<F, G, S>(get),
     ...getTypedMethods<F, G>(),
-    // focus and only must come after the spreads to prevent spread keys from overriding them
+    // focus, only and changed must come after the spreads to prevent spread keys from overriding them
     focus: VestRuntime.persist(
       useCreateFocus<F, G, T, S>(suiteCallback, modifiers, subscribe, schema),
     ),
     only: VestRuntime.persist(
       useCreateOnly<F, G, T, S>(suiteCallback, modifiers, subscribe, schema),
+    ),
+    changed: VestRuntime.persist(
+      useCreateChanged<F, G, T, S>(suiteCallback, modifiers, subscribe, schema),
     ),
   };
 }
@@ -119,7 +128,7 @@ function useGetLifecycleMethods<
   S extends TSchema = undefined,
 >(ctx: {
   suiteCallback: SuiteCallbackWithSchema<S, T>;
-  modifiers: SuiteModifiers<F, G>;
+  modifiers: InternalSuiteModifiers<F, G>;
   subscribe: Subscribe;
   schema?: S;
   persistedRun: any;
@@ -161,7 +170,7 @@ function useAddAfterHelper<
 >(
   ctx: {
     suiteCallback: SuiteCallbackWithSchema<S, T>;
-    modifiers: SuiteModifiers<F, G>;
+    modifiers: InternalSuiteModifiers<F, G>;
     subscribe: Subscribe;
     schema?: S;
     persistedRun: any;
@@ -213,7 +222,7 @@ function useCreateFocus<
   S extends TSchema = undefined,
 >(
   suiteCallback: SuiteCallbackWithSchema<S, T>,
-  modifiers: SuiteModifiers<F, G>,
+  modifiers: InternalSuiteModifiers<F, G>,
   subscribe: Subscribe,
   schema?: S,
 ) {
@@ -244,7 +253,7 @@ function useCreateOnly<
   S extends TSchema = undefined,
 >(
   suiteCallback: SuiteCallbackWithSchema<S, T>,
-  modifiers: SuiteModifiers<F, G>,
+  modifiers: InternalSuiteModifiers<F, G>,
   subscribe: Subscribe,
   schema?: S,
 ) {
@@ -256,6 +265,48 @@ function useCreateOnly<
   );
   return function only(onlyField: NonNullable<SuiteModifiers<F, G>['only']>) {
     return focus({ only: onlyField });
+  };
+}
+
+function useCreateChanged<
+  F extends TFieldName,
+  G extends TGroupName,
+  T extends CB = CB,
+  S extends TSchema = undefined,
+>(
+  suiteCallback: SuiteCallbackWithSchema<S, T>,
+  modifiers: InternalSuiteModifiers<F, G>,
+  subscribe: Subscribe,
+  schema?: S,
+) {
+  // Defer affected-set expansion until run(data) so root->array targets
+  // can be expanded using the actual runtime data (rows.length).
+  // Without deferral, changed('global') with target rows[$item].tax would
+  // produce the unusable field 'rows.rows.$item.tax' and nothing would run.
+  return function changed(changedField: string | string[] | FieldExclusion<F>) {
+    if (changedField === undefined) {
+      // Mirror only(undefined): a legal no-op — run without changed focus.
+      const nextModifiers = { ...modifiers };
+      delete nextModifiers.__changed;
+      return useCreateSuiteMethods<F, G, T, S>(
+        suiteCallback,
+        nextModifiers,
+        subscribe,
+        schema,
+      );
+    }
+    const changedArray = Array.isArray(changedField)
+      ? (changedField as string[])
+      : [changedField as string];
+    // Store raw changed fields; useCreateSuiteRunner will expand using run data
+    // Fallback to immediate expansion for pre-run inspection (e.g., suite.get)
+    // is handled by runner; here we just create a focused suite with deferred modifier.
+    return useCreateSuiteMethods<F, G, T, S>(
+      suiteCallback,
+      { ...modifiers, __changed: changedArray },
+      subscribe,
+      schema,
+    );
   };
 }
 
@@ -272,11 +323,7 @@ function createStaticRunner<
   T extends CB = CB,
   S extends TSchema = undefined,
 >(suiteCallback: SuiteCallbackWithSchema<S, T>, schema?: S) {
-  return function runStatic(
-    ...runArgs: S extends undefined
-      ? Parameters<T>
-      : [data: InferSchemaData<S>, ...args: any[]]
-  ) {
+  return function runStatic(...runArgs: SuiteRunArguments<S, T>) {
     const suite = createSuite<F, G, T, S>(suiteCallback, schema);
     return suite.run(...(runArgs as Parameters<typeof suite.run>));
   };

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -1,40 +1,122 @@
-import { enforce } from 'n4s';
+import {
+  mapWithoutValidation,
+  parseAffectedFieldName,
+  runSchemaPaths,
+} from 'n4s/exports/internal';
+import type { SelectiveSchemaResult } from 'n4s/exports/internal';
 import {
   assign,
   asArray,
   CB,
   freezeAssign,
   isArray,
-  isFunction,
   isObject,
+  isUnsafeKey,
   withResolvers,
 } from 'vest-utils';
 
 import { useEmit } from '../core/VestBus/VestBus';
 
 import { SuiteContext } from '../core/context/SuiteContext';
-import { IsolateReorderable } from 'vestjs-runtime';
+import { IsolateReorderable, VestRuntime } from 'vestjs-runtime';
 import { IsolateSuite } from '../core/isolate/IsolateSuite/IsolateSuite';
+import type {
+  MappedSchemaOutput,
+  TIsolateSuite,
+} from '../core/isolate/IsolateSuite/IsolateSuite';
 import { test } from '../core/test/test';
 import { only, skip } from '../hooks/focused/focused';
 import {
   SuiteResult,
   TFieldName,
   TGroupName,
-  InferSchemaData,
   TSchema,
   InferSchemaOutput,
 } from '../suiteResult/SuiteResultTypes';
 import { useCreateSuiteResult } from '../suiteResult/suiteResult';
 
-import { SuiteModifiers, SuiteCallbackWithSchema } from './SuiteTypes';
+import { getAffectedFields } from './changed';
+import type { FieldExclusion } from '../hooks/focused/focused';
+import {
+  InternalSuiteModifiers,
+  SuiteModifiers,
+  SuiteCallbackWithSchema,
+  SuiteRunArguments,
+} from './SuiteTypes';
+import { cloneDataTree } from './cloneDataTree';
 
-type SchemaRunResult = {
-  readonly message?: string;
-  readonly pass: boolean;
-  readonly path?: readonly string[];
-  readonly type?: unknown;
-};
+/**
+ * Schema run outcome. Deliberately aliased to the n4s-owned
+ * `SelectiveSchemaResult` (canonically defined in n4s
+ * `./schema/selectiveRun`), never redefined: the selective engine lives in
+ * n4s (see `runSchemaPaths`), and this name stays for suite-level
+ * consumers so a schema failure means the same shape on both sides of the
+ * boundary.
+ */
+export type SchemaRunResult = SelectiveSchemaResult;
+
+/**
+ * Pending runs per suite, keyed by (suite callback, suite state identity).
+ * The callback is threaded unchanged through every focus/only/changed
+ * chain of a suite, so all of a suite's runners share it; the state
+ * identity (see `useCreateVestState`) keeps suites apart. Either dimension
+ * alone misattributes: state identity can be reused by persisted wrappers,
+ * while the callback alone aliases suites built from one shared callback and
+ * runStatic calls. The composite key is correct in all three cases.
+ *
+ * Ownership-chaining guarantee: when a newer run of the same suite starts
+ * while older runs are still pending, each older run's promise adopts the
+ * newer run's promise, so every awaited handle settles with the latest
+ * outcome — a stale handle can never observe a stale result, and no
+ * superseded run hangs. Chaining is transitive (a run superseded twice
+ * follows the chain to the latest run) and promise plumbing only: it reads
+ * no SuiteContext and builds no snapshot, so settling cannot misattribute
+ * state. A run with no successor settles on its own completion (normal
+ * path). Stale async results themselves are already neutralized by the
+ * test reconciler, which cancels the overridden pending test.
+ */
+const pendingRuns = new WeakMap<CB, WeakMap<object, Set<unknown>>>();
+
+function pendingRunsFor(suiteCallback: CB): WeakMap<object, Set<unknown>> {
+  const existing = pendingRuns.get(suiteCallback);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const created = new WeakMap<object, Set<unknown>>();
+  pendingRuns.set(suiteCallback, created);
+  return created;
+}
+
+function chainSupersededRuns<
+  F extends TFieldName,
+  G extends TGroupName,
+  S extends TSchema,
+>(
+  suiteCallback: CB,
+  state: object,
+  latest: Promise<SuiteResult<F, G, S>>,
+  ownResolve: (
+    value: SuiteResult<F, G, S> | PromiseLike<SuiteResult<F, G, S>>,
+  ) => void,
+): () => void {
+  const byState = pendingRunsFor(suiteCallback);
+  const previous = byState.get(state);
+  const current = new Set<unknown>([ownResolve]);
+  byState.set(state, current);
+  if (previous !== undefined) {
+    for (const resolvePrev of previous) {
+      // Sound: every resolver in one (callback, state) bucket was
+      // registered by this same runner, so all share F, G and S.
+      (resolvePrev as (value: Promise<SuiteResult<F, G, S>>) => void)(latest);
+    }
+  }
+  return () => {
+    current.delete(ownResolve);
+    if (current.size === 0 && byState.get(state) === current) {
+      byState.delete(state);
+    }
+  };
+}
 
 /**
  * Creates the suite runner bound to a callback, modifiers and (optional) schema.
@@ -42,7 +124,6 @@ type SchemaRunResult = {
  * The runner performs schema preprocessing once per run, stores the original input
  * and parsed output, and then executes the suite callback within SuiteContext.
  */
-// eslint-disable-next-line max-lines-per-function
 export function useCreateSuiteRunner<
   F extends TFieldName,
   G extends TGroupName,
@@ -50,22 +131,69 @@ export function useCreateSuiteRunner<
   S extends TSchema = undefined,
 >(
   suiteCallback: SuiteCallbackWithSchema<S, T>,
-  modifiers: SuiteModifiers<F, G>,
+  modifiers: InternalSuiteModifiers<F, G>,
   schema?: S,
 ) {
-  const transformedModifiers = useTransformedModifiers<F, G>(modifiers);
+  // Defer changed() expansion: if __changed is present, compute affected
+  // using the actual run data (enables root->array fan-out).
+  const changedFields = modifiers.__changed;
+  // Note: we cannot compute affected here without data, so we do it inside runSuite below.
+  const transformedModifiersBase = useTransformedModifiers<F, G>(modifiers);
 
+  // eslint-disable-next-line complexity -- orchestration branches mirror suite modifiers
   return function runSuite(
-    ...args: S extends undefined
-      ? Parameters<T>
-      : [data: InferSchemaData<S>, ...args: any[]]
+    ...args: SuiteRunArguments<S, T>
   ): SuiteResult<F, G, S> {
     const runTime = new Date();
-    const { resolve, promise } = withResolvers<SuiteResult<F, G, S>>();
+    const { resolve: rawResolve, promise } =
+      withResolvers<SuiteResult<F, G, S>>();
+    const suiteState = VestRuntime.useXAppData();
+
+    // Ownership: a newer run of the same suite supersedes older
+    // still-pending runs (plain or changed()). Superseded runs adopt the
+    // successor's promise when it starts, so awaiting a stale run settles
+    // with the latest outcome instead of hanging forever. First settlement
+    // wins over any later completion of the stale run.
+    // Registration is deliberately deferred until all synchronous schema and
+    // suite setup has completed. If setup throws, an older pending run must
+    // remain owned by itself instead of adopting an unreachable promise.
+    let forgetPendingRun = (): void => {};
+    const resolve = (
+      result: SuiteResult<F, G, S> | PromiseLike<SuiteResult<F, G, S>>,
+    ): void => {
+      forgetPendingRun();
+      rawResolve(result);
+    };
 
     const schemaInput = args[0];
+    // If suite was created via changed(), resolve test-selection focus
+    // using the actual run data (enables root->array fan-out). Suite-test
+    // focus needs the expanded affected set so dependents' user tests
+    // execute. The exact same resolved set is passed to n4s below.
+    let transformedModifiers = transformedModifiersBase;
+    let changedAffected: string[] | null = null;
+    let mappedAffected = mappedFocusPaths<F, G>(transformedModifiersBase);
+    if (changedFields) {
+      const focus = useChangedRunFocus<F, G>(
+        changedFields,
+        modifiers,
+        schema,
+        schemaInput,
+      );
+      transformedModifiers = focus.transformedModifiers;
+      changedAffected = focus.changedAffected;
+      mappedAffected = focus.mappedAffected;
+    }
+
+    // Dependency-aware schema execution is owned by n4s. Vest resolves the
+    // plan once through n4s, then gives that exact set to both suite focus
+    // and schema execution so direct dependencies never fan out twice.
     const schemaRunResult = shouldRunSchema(schema)
-      ? runSchemaWithParse(schema, schemaInput, transformedModifiers)
+      ? runSchemaPaths(schema, schemaInput, {
+          resolvedAffected: changedAffected,
+          only: transformedModifiers.only,
+          skip: transformedModifiers.__skipAll || transformedModifiers.skip,
+        })
       : undefined;
 
     const parsedDataChunk = getParsedDataChunk(schemaRunResult);
@@ -74,9 +202,27 @@ export function useCreateSuiteRunner<
       schema ? snapshotParsedData(parsedDataChunk) : undefined
     ) as Partial<InferSchemaOutput<S>> | undefined;
 
-    const callbackInput = getCallbackInput(schemaRunResult, schemaInput);
+    const callbackMapping = getCallbackMapping({
+      affected: mappedAffected,
+      fallback: schemaInput,
+      previous: usePreviousMappedSchemaOutput(),
+      schema,
+      schemaRunResult,
+    });
+    const callbackInput = callbackMapping.input;
     const callbackArgs = [callbackInput, ...args.slice(1)] as Parameters<T>;
-    const runData = callbackInput;
+    const runData =
+      schema && schemaRunResult?.every(result => result.pass)
+        ? parsedDataChunk
+        : schemaInput;
+    // Schema-mapped callback data, public output, and the retained cache must
+    // never share mutable containers. Preserve the established raw-input
+    // identity for schema failures and schema-less suites.
+    const resultOutput = schema ? cloneDataTree(callbackInput) : callbackInput;
+    const runDataSnapshot =
+      schema && schemaRunResult?.every(result => result.pass)
+        ? cloneDataTree(runData)
+        : runData;
 
     const suiteResult = SuiteContext.run(
       {
@@ -90,8 +236,8 @@ export function useCreateSuiteRunner<
         const useResolver = () => {
           const result = useCreateSuiteResult<F, G, S>(
             schema,
-            callbackInput,
-            runData,
+            resultOutput,
+            runDataSnapshot,
             runTime,
             parsedData,
             snapshotFocus(transformedModifiers),
@@ -114,12 +260,110 @@ export function useCreateSuiteRunner<
             useResolver,
           }),
           useResolver,
+          callbackMapping.retained,
         ).output;
       },
     );
 
-    return bindSuiteResultMethods(promise, suiteResult, runData, runTime);
+    const boundResult = bindSuiteResultMethods(
+      promise,
+      suiteResult,
+      runDataSnapshot,
+      runTime,
+    );
+    forgetPendingRun = chainSupersededRuns(
+      suiteCallback,
+      suiteState,
+      promise,
+      rawResolve,
+    );
+    if (!suiteResult.isPending()) forgetPendingRun();
+    return boundResult;
   };
+}
+
+/**
+ * Resolves changed() run focus from the raw changed names and run data:
+ * the expanded affected set drives suite-test selection (dependents' user
+ * tests must execute), while the schema input stays raw — the unexpanded
+ * changed names plus base `only` names (so combined only+changed still
+ * validates the base fields). n4s resolves the changed names here and the
+ * resulting plan is reused by both execution layers; expanding it again
+ * would compose transitively and break the pinned non-transitive changed()
+ * contract.
+ */
+function useChangedRunFocus<F extends TFieldName, G extends TGroupName>(
+  changedFields: string[],
+  modifiers: InternalSuiteModifiers<F, G>,
+  schema: unknown,
+  schemaInput: unknown,
+): {
+  transformedModifiers: ReturnType<typeof useTransformedModifiers<F, G>>;
+  changedAffected: string[];
+  mappedAffected: string[];
+} {
+  const affected = getAffectedFields(changedFields, schema, schemaInput);
+  const baseOnly = modifiers.only;
+  const baseList = baseOnlyListOf(baseOnly);
+  const mergedOnly: string[] = baseOnly
+    ? [...new Set([...baseList, ...affected])]
+    : affected;
+  // mergedOnly carries dynamic dotted names (e.g. 'profile.state')
+  // that escape the suite's static field vocabulary F by design —
+  // changed() affected paths are runtime data, like hasErrors() names.
+  const withAffected: InternalSuiteModifiers<F, G> = {
+    ...modifiers,
+    only: mergedOnly as FieldExclusion<F>,
+  };
+  // Filter schema failures against the full focus set (base `only` +
+  // affected), not just the affected fields, so combined only+changed
+  // keeps base-only failures too.
+  if (mergedOnly.length === 0) {
+    // Explicit zero-field focus (e.g. changed([])): run no tests.
+    // `only: []` alone is a runtime no-op (no focus isolate is created),
+    // so skip-all carries the "run nothing" intent for suite tests. The
+    // schema side resolves to an empty affected set (runs nothing).
+    // Note this branch only fires when no base `only` exists either:
+    // an explicit only('a') combined with changed([]) intentionally
+    // still runs 'a'.
+    withAffected.__skipAll = true;
+  }
+  delete withAffected.__changed;
+  return {
+    transformedModifiers: useTransformedModifiers<F, G>(withAffected),
+    changedAffected: mergedOnly,
+    mappedAffected: mappedFocusPaths(withAffected) ?? [],
+  };
+}
+
+// Non-string entries (e.g. a runtime boolean) never reach field-name
+// normalization, which would throw on them — same guard as skip-all.
+function baseOnlyListOf<F extends TFieldName, G extends TGroupName>(
+  only: InternalSuiteModifiers<F, G>['only'],
+): string[] {
+  if (!only) return [];
+  return asArray(only).filter(entry => typeof entry === 'string');
+}
+
+/**
+ * Focus paths whose parsed values this run is allowed to replace in the
+ * retained callback mapping. null means an unfocused full schema run.
+ */
+function mappedFocusPaths<F extends TFieldName, G extends TGroupName>(
+  modifiers: Pick<InternalSuiteModifiers<F, G>, 'only' | 'skip' | '__skipAll'>,
+): string[] | null {
+  if (modifiers.__skipAll) return [];
+  if (modifiers.only == null) return null;
+  const skipped = new Set(
+    modifiers.skip
+      ? asArray(modifiers.skip).filter(
+          (entry): entry is F => typeof entry === 'string',
+        )
+      : [],
+  );
+  return asArray(modifiers.only).filter(
+    (entry): entry is F => typeof entry === 'string' && !skipped.has(entry),
+  );
 }
 
 /**
@@ -141,28 +385,184 @@ function getParsedDataChunk(
  * in the suite callback from affecting the result object.
  */
 function snapshotParsedData(data: unknown): unknown {
-  if (isArray(data)) {
-    return Object.freeze([...(data as unknown[])]);
+  return cloneDataTree(data, true);
+}
+
+type CallbackInputParams = {
+  affected: string[] | null;
+  fallback: unknown;
+  previous: MappedSchemaOutput | undefined;
+  schema: unknown;
+  schemaRunResult: SchemaRunResult[] | undefined;
+};
+
+type CallbackMapping = {
+  input: unknown;
+  retained?: MappedSchemaOutput;
+};
+
+/**
+ * Resolves the value passed into the user suite callback.
+ *
+ * Full successful schema runs replace the retained mapped value. Focused
+ * successful runs patch only their executed paths into that retained value.
+ * This keeps the callback's schema-output type truthful without changing the
+ * intentionally per-run semantics of SuiteResult.run.data.parsed.
+ * Validation failures keep the established raw-input fallback and do not
+ * poison the last successful mapped value.
+ */
+function getCallbackMapping(params: CallbackInputParams): CallbackMapping {
+  const { affected, fallback, previous, schema, schemaRunResult } = params;
+  if (!schema) return { input: fallback };
+  const successfulResult = successfulSchemaResult(schemaRunResult);
+  if (successfulResult === null) {
+    return failedCallbackMapping(affected, fallback, previous);
   }
-  if (isObject(data)) {
-    return freezeAssign({}, data as object);
+  return successfulCallbackMapping({
+    affected,
+    fallback,
+    previous,
+    schema,
+    schemaRunResult: successfulResult,
+  });
+}
+
+function successfulSchemaResult(
+  schemaRunResult: SchemaRunResult[] | undefined,
+): SchemaRunResult[] | null {
+  return schemaRunResult?.every(result => result.pass) ? schemaRunResult : null;
+}
+
+function failedCallbackMapping(
+  affected: string[] | null,
+  fallback: unknown,
+  previous: MappedSchemaOutput | undefined,
+): CallbackMapping {
+  return {
+    input: cloneDataTree(fallback),
+    ...(affected === null || previous === undefined
+      ? {}
+      : { retained: previous }),
+  };
+}
+
+function successfulCallbackMapping(
+  params: Omit<CallbackInputParams, 'schemaRunResult'> & {
+    schemaRunResult: SchemaRunResult[];
+  },
+): CallbackMapping {
+  const { affected, fallback, previous, schema, schemaRunResult } = params;
+  const [firstResult] = schemaRunResult;
+  const current = firstResult?.type ?? fallback;
+  if (affected === null) {
+    const retained = cloneDataTree(current);
+    return mappedCallbackResult(retained);
   }
-  return data;
+
+  if (previous === undefined) {
+    const initial = mapWithoutValidation(schema, fallback);
+    const merged = mergeMappedPaths(initial, current, affected);
+    return mappedCallbackResult(merged);
+  }
+
+  return mappedCallbackResult(
+    mergeMappedPaths(previous.value, current, affected),
+  );
+}
+
+function mappedCallbackResult(value: unknown): CallbackMapping {
+  const retained = cloneDataTree(value);
+  return {
+    input: cloneDataTree(retained),
+    retained: { hasValue: true, value: retained },
+  };
+}
+
+function usePreviousMappedSchemaOutput(): MappedSchemaOutput | undefined {
+  const previous =
+    VestRuntime.useAvailableRoot<TIsolateSuite>()?.data.mappedSchemaOutput;
+  return previous?.hasValue === true ? previous : undefined;
+}
+
+function mergeMappedPaths(
+  previous: unknown,
+  current: unknown,
+  affected: readonly string[],
+): unknown {
+  if (affected.length === 0) return previous;
+  let merged = previous;
+  for (const field of affected) {
+    const path = retainedMergePath(concreteFieldPath(field));
+    if (path.length === 0) return current;
+    if (path.some(isUnsafePathSegment)) continue;
+    merged = setPathValue(merged, current, path, 0);
+  }
+  return merged;
 }
 
 /**
- * Resolves the value that should be passed into the suite callback.
+ * Array indices describe positions, not stable identities. When a focused
+ * path enters an array, replace the containing array from the current mapped
+ * input so reorder/insert/remove operations cannot leave the callback with a
+ * stale structure assembled from the previous run.
  */
-function getCallbackInput(
-  schemaRunResult: SchemaRunResult[] | undefined,
-  fallback: unknown,
-): unknown {
-  if (!schemaRunResult || schemaRunResult.some(result => !result.pass)) {
-    return fallback;
-  }
+function retainedMergePath(
+  path: readonly ConcretePathSegment[],
+): ConcretePathSegment[] {
+  const firstIndex = path.findIndex(segment => typeof segment === 'number');
+  return firstIndex === -1 ? [...path] : path.slice(0, firstIndex);
+}
 
-  const [firstResult] = schemaRunResult;
-  return firstResult?.type ?? fallback;
+type ConcretePathSegment = string | number;
+
+function concreteFieldPath(field: string): ConcretePathSegment[] {
+  return parseAffectedFieldName(field).map(segment => {
+    if (segment.type === 'property') return String(segment.key);
+    const index = Number(segment.binding);
+    return Number.isSafeInteger(index) && index >= 0 ? index : segment.binding;
+  });
+}
+
+function isUnsafePathSegment(segment: ConcretePathSegment): boolean {
+  return typeof segment === 'string' && isUnsafeKey(segment);
+}
+
+function setPathValue(
+  previous: unknown,
+  current: unknown,
+  path: readonly ConcretePathSegment[],
+  index: number,
+): unknown {
+  if (index >= path.length) return current;
+  const key = path[index];
+  if (key === undefined) return previous;
+
+  const previousChild = readPathValue(previous, key);
+  const currentChild = readPathValue(current, key);
+  const nextChild = setPathValue(previousChild, currentChild, path, index + 1);
+  return writePathValue(previous, key, nextChild);
+}
+
+function readPathValue(value: unknown, key: ConcretePathSegment): unknown {
+  if (!isObject(value) && !isArray(value)) return undefined;
+  return (value as Record<PropertyKey, unknown>)[key];
+}
+
+function writePathValue(
+  value: unknown,
+  key: ConcretePathSegment,
+  nextChild: unknown,
+): unknown {
+  if (isArray(value)) {
+    const copy = [...value];
+    copy[Number(key)] = nextChild;
+    return copy;
+  }
+  const copy: Record<string, unknown> = isObject(value)
+    ? { ...(value as Record<string, unknown>) }
+    : {};
+  copy[String(key)] = nextChild;
+  return copy;
 }
 
 /**
@@ -194,8 +594,8 @@ function useRunSuiteCallback<
   return () => {
     // Focused modifiers are applied before user callback so every test in this run
     // observes the same focus context.
-    only(modifiers.only);
-    skip(modifiers.skip);
+    only(withSchemaFailureFocus(modifiers.only, schemaRunResult));
+    skip(modifiers.__skipAll || modifiers.skip);
     (suiteCallback as CB)(...args);
 
     IsolateReorderable(
@@ -215,7 +615,7 @@ function useRunSuiteCallback<
  * Normalizes user-provided modifiers into deterministic sets for O(1) membership checks.
  */
 function useTransformedModifiers<F extends TFieldName, G extends TGroupName>(
-  modifiers: SuiteModifiers<F, G>,
+  modifiers: InternalSuiteModifiers<F, G>,
 ) {
   return {
     ...modifiers,
@@ -262,6 +662,82 @@ function snapshotGroup<F extends TFieldName, G extends TGroupName>(
 }
 
 /**
+ * Widens execution focus to cover already-narrowed schema failures reported
+ * above the affected leaves (e.g. a union element failure at 'rows.1' for
+ * changed('rows.1.kind')). The post-filter keeps failures parent-either-way,
+ * but suite focus matches test names exactly, so a coarser attribution would
+ * be emitted and then excluded — reported nowhere. Only strict parents of
+ * focused names are added: leaf failures already match exactly, and child
+ * failures keep their existing behavior, so user-test execution is otherwise
+ * unchanged.
+ */
+function withSchemaFailureFocus<F extends TFieldName>(
+  only: FieldExclusion<F>,
+  schemaRunResult: readonly SchemaRunResult[] | undefined,
+): FieldExclusion<F> {
+  if (schemaRunResult === undefined) {
+    return only;
+  }
+  const base = focusBaseNames(only);
+  if (base === null) {
+    return only;
+  }
+  const additions = parentFocusAdditions<F>(base.map(String), schemaRunResult);
+  if (additions.length === 0) {
+    return only;
+  }
+  return [...base, ...additions];
+}
+
+function focusBaseNames<F extends TFieldName>(
+  only: FieldExclusion<F>,
+): F[] | null {
+  if (only === undefined || only === null) return null;
+  const base = asArray(only);
+  return base.length === 0 ? null : base;
+}
+
+/**
+ * Failure paths that are strict parents of a focused name. A coarser schema
+ * attribution (e.g. 'rows.1' for changed('rows.1.kind')) would otherwise be
+ * emitted and then excluded by exact focus matching — reported nowhere.
+ */
+function parentFocusAdditions<F extends TFieldName>(
+  baseNames: string[],
+  schemaRunResult: readonly SchemaRunResult[],
+): F[] {
+  const seen = new Set<string>(baseNames);
+  const additions: F[] = [];
+  for (const result of schemaRunResult) {
+    const failureName = schemaFailureName(result);
+    if (failureName === '' || seen.has(failureName)) {
+      continue;
+    }
+    if (isParentOfFocusedName(baseNames, failureName)) {
+      seen.add(failureName);
+      additions.push(failureName as unknown as F);
+    }
+  }
+  return additions;
+}
+
+function schemaFailureName(result: SchemaRunResult): string {
+  if (result.pass) {
+    return '';
+  }
+  return (result.path ?? []).map(String).join('.');
+}
+
+function isParentOfFocusedName(
+  baseNames: readonly string[],
+  failureName: string,
+): boolean {
+  return baseNames.some((baseName: string): boolean =>
+    baseName.startsWith(`${failureName}.`),
+  );
+}
+
+/**
  * Emits schema failures into vest test tree.
  */
 function runSchemaValidation<S extends TSchema = undefined>(
@@ -287,201 +763,9 @@ function runSchemaValidation<S extends TSchema = undefined>(
   };
 }
 
-/**
- * Attempts to parse the schema. Returns null if parse fails gracefully,
- * so the caller can fall back to schema.run.
- */
-function tryParseSchema(
-  executableSchema: any,
-  data: unknown,
-): SchemaRunResult[] | null {
-  if (!isFunction(executableSchema.parse)) return null;
-
-  try {
-    const parsedValue = executableSchema.parse(data);
-
-    return shouldRunAfterParse(executableSchema)
-      ? normalizeSchemaRunResult(executableSchema.run(parsedValue), parsedValue)
-      : [{ pass: true, type: parsedValue }];
-  } catch (error) {
-    if (isExpectedSchemaParseError(error)) return null;
-    throw error;
-  }
-}
-
-/**
- * Runs schema parsing/validation in a safe order:
- * 1) try parse
- * 2) if parse succeeds, treat it as the authoritative validation output
- * 3) on expected parse validation failures, fallback to run(raw)
- */
-function runSchemaWithParse(
-  schema: any,
-  data: unknown,
-  modifiers: { only?: unknown; skip?: unknown },
-): SchemaRunResult[] {
-  const executableSchema = applySchemaFocus(schema, modifiers);
-
-  const parseResult = tryParseSchema(executableSchema, data);
-  if (parseResult) {
-    return parseResult;
-  }
-
-  if (isFunction(executableSchema.run)) {
-    return normalizeSchemaRunResult(executableSchema.run(data), data);
-  }
-
-  return [
-    {
-      pass: true,
-      type: data,
-    },
-  ];
-}
-
-const N4S_VENDOR = 'n4s';
-
-function isN4sSchema(schema: any): boolean {
-  return schema?.['~standard']?.vendor === N4S_VENDOR && !!schema?.__schema;
-}
-
-function applySchemaFocus(
-  schema: any,
-  modifiers: { only?: unknown; skip?: unknown },
-): any {
-  if (!isN4sSchema(schema)) {
-    return schema;
-  }
-
-  const only = buildArrayProp(modifiers.only);
-  const skip = buildArrayProp(modifiers.skip);
-
-  return buildFocusedSchemaInstance(schema, only, skip);
-}
-
-function buildArrayProp(prop: unknown): string[] | null {
-  if (!prop) return null;
-  const arr = asArray(prop) as string[];
-  return arr.length > 0 ? arr : null;
-}
-
-function buildIntersectedSchemaInstance(
-  schema: any,
-  only: string[],
-  skip: string[],
-): any {
-  const skipSet = new Set(skip);
-  return enforce.pick(
-    schema.__schema,
-    only.filter(f => !skipSet.has(f)),
-  );
-}
-
-function buildFocusedSchemaInstance(
-  schema: any,
-  only: string[] | null,
-  skip: string[] | null,
-): any {
-  if (only) {
-    return skip
-      ? buildIntersectedSchemaInstance(schema, only, skip)
-      : enforce.pick(schema.__schema, only);
-  }
-
-  return skip ? enforce.omit(schema.__schema, skip) : schema;
-}
-
-/**
- * Converts unknown schema.run return value into a stable internal representation.
- */
-function normalizeSchemaRunResult(
-  candidate: unknown,
-  fallbackType: unknown,
-): SchemaRunResult[] {
-  if (isArray(candidate)) {
-    return candidate.map(entry =>
-      normalizeSingleSchemaRunResult(entry, fallbackType),
-    );
-  }
-
-  return [normalizeSingleSchemaRunResult(candidate, fallbackType)];
-}
-
-/**
- * Converts a single unknown run payload into a safe result shape.
- */
-function normalizeSingleSchemaRunResult(
-  candidate: unknown,
-  fallbackType: unknown,
-): SchemaRunResult {
-  if (!isSchemaRunResult(candidate)) {
-    return {
-      pass: false,
-      type: fallbackType,
-    };
-  }
-
-  return {
-    message: candidate.message,
-    pass: candidate.pass,
-    path: candidate.path,
-    type: candidate.type ?? fallbackType,
-  };
-}
-
-/**
- * Runtime type guard for schema run payloads.
- */
-function isSchemaRunResult(candidate: unknown): candidate is SchemaRunResult {
-  if (!isObject(candidate)) {
-    return false;
-  }
-
-  const value = candidate as Partial<SchemaRunResult>;
-
-  const hasPass = typeof value.pass === 'boolean';
-  const hasPath =
-    value.path === undefined ||
-    (isArray(value.path) && value.path.every(item => typeof item === 'string'));
-
-  return hasPass && hasPath;
-}
-
-/**
- * Detects parse errors that represent expected validation failures.
- */
-function isExpectedSchemaParseError(error: unknown): boolean {
-  if (error instanceof TypeError) {
-    return true;
-  }
-
-  if (!isObject(error)) {
-    return false;
-  }
-
-  const typedError = error as { isValidation?: unknown; name?: unknown };
-  return typedError.isValidation === true || typedError.name === 'TypeError';
-}
-
-/**
- * Determines whether schema.run should execute after a successful parse call.
- *
- * For n4s StandardSchema-backed rules, parse already performs full validation.
- * Re-running run(parsed) can break coercion chains where post-parse types differ
- * from pre-parse input expectations.
- */
-function shouldRunAfterParse(schema: any): boolean {
-  if (!isFunction(schema.run)) {
-    return false;
-  }
-
-  return schema?.['~standard']?.vendor !== N4S_VENDOR;
-}
-
 function shouldRunSchema(schema: unknown): boolean {
   return !!schema;
 }
-
 function bindSuiteResultMethods<
   F extends TFieldName,
   G extends TGroupName,

--- a/packages/vest/src/suiteResult/selectors/__tests__/nestedFieldPaths.test.ts
+++ b/packages/vest/src/suiteResult/selectors/__tests__/nestedFieldPaths.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+
+import { enforce } from 'n4s';
+
+import { create } from '../../../vest';
+import { invokeWithUnknown } from '../../../__tests__/runtimeTestUtils';
+
+describe('selectors with nested field paths', () => {
+  const schema = enforce.shape({
+    profile: enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString(),
+    }),
+  });
+
+  it('reports failures under nested dotted paths', () => {
+    const suite = create(() => {}, schema);
+    const result = invokeWithUnknown(suite.run, {
+      profile: {
+        country: 'US',
+        state: 42,
+      },
+    });
+
+    expect(result.hasErrors()).toBe(true);
+    expect(result.hasErrors('profile.state')).toBe(true);
+    expect(result.hasErrors('profile.country')).toBe(false);
+  });
+
+  it('unknown dotted paths typecheck but never match (documented)', () => {
+    // InputFieldName<F> deliberately accepts `${F}.${string}` so nested
+    // schema paths are queryable. The tradeoff: a dotted typo also compiles
+    // and, because runtime matching is exact, quietly reports no errors.
+    const suite = create(() => {}, schema);
+    const result = invokeWithUnknown(suite.run, {
+      profile: {
+        country: 'US',
+        state: 42,
+      },
+    });
+
+    expect(result.hasErrors('profile.state')).toBe(true);
+    expect(result.hasErrors('profile.typo')).toBe(false);
+  });
+});

--- a/packages/vest/src/suiteResult/selectors/suiteSelectors.ts
+++ b/packages/vest/src/suiteResult/selectors/suiteSelectors.ts
@@ -23,7 +23,13 @@ import { SummaryFailure } from '../SummaryFailure';
 
 import { gatherFailures } from './collectFailures';
 
-type InputFieldName<F extends TFieldName> = F;
+/**
+ * Selectors accept top-level field names plus `${field}.${string}` dotted
+ * paths so nested schema failures (e.g. 'profile.state') are queryable.
+ * Deliberate tradeoff: an unknown dotted path also typechecks and, because
+ * runtime matching is exact, reports no errors instead of failing to compile.
+ */
+type InputFieldName<F extends TFieldName> = F | `${F}.${string}`;
 type InputGroupName<G extends TGroupName> = G;
 
 export function bindSuiteSelectors<

--- a/packages/vest/vitest.config.ts
+++ b/packages/vest/vitest.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
   resolve: {
     alias: {
       vest: resolve(__dirname, 'src/vest.ts'),
+      'n4s/exports/internal': resolve(
+        __dirname,
+        '../n4s/src/exports/internal.ts',
+      ),
       n4s: resolve(__dirname, '../n4s/src/n4s.ts'),
     },
   },

--- a/website/docs/api_reference.md
+++ b/website/docs/api_reference.md
@@ -78,6 +78,7 @@ Runs the suite. Passes arguments to the suite callback.
 - **Returns**: A `SuiteResult` object.
   - If the suite contains async tests, the result object **also implements the Promise interface**, allowing you to `await` it.
   - You can always access synchronous result data immediately (e.g., `result.hasErrors()`), even if the promise is pending.
+  - If another stateful `suite.run()` starts while an earlier run is pending, awaiting the earlier handle resolves to the newer run's result. This prevents obsolete async work from exposing stale state. `runStatic()` remains independent.
 - [Read more about `suite.run`](./writing_your_suite/vests_suite.md#running-validations)
 
 #### `suite.runStatic(...args)`

--- a/website/docs/enforce/creating_custom_rules.md
+++ b/website/docs/enforce/creating_custom_rules.md
@@ -64,6 +64,24 @@ enforce.extend({
 enforce(user.email).isValidEmail();
 ```
 
+### Parser-style custom rules and selective runs
+
+Custom rules are validators by default: Vest never executes them speculatively. That matters for dependency-aware runs — when `suite.changed()` revalidates an affected subset, untouched fields are mapped without running their validators. If your custom rule is really a **parser** (a pure transformation that cannot fail on its own, like upper-casing or trimming), declare it in `parsers` so selective runs can apply it to untouched fields:
+
+```js
+enforce.extend(
+  {
+    normalizeId: value => ({
+      pass: true,
+      type: value.trim().toUpperCase(),
+    }),
+  },
+  { parsers: ['normalizeId'] },
+);
+```
+
+Rules left out of `parsers` keep validator treatment. Field-level validators run when their field is in the affected set; validators attached to a retained container can also run when a descendant changes. See [Input vs output types with parsers](../writing_your_suite/schema_validation#input-vs-output-types-with-parsers) and [Custom Parsers and Selective Runs](../writing_your_suite/schema_relationships#custom-parsers-and-selective-runs).
+
 ## Custom rules return value
 
 Rules can return a boolean or a rule-result object. `pass` indicates success, and `message` may be a string or a function that returns the failure message.

--- a/website/docs/guides/async-validation-race-conditions.md
+++ b/website/docs/guides/async-validation-race-conditions.md
@@ -8,7 +8,11 @@ keywords: [async form validation, race condition, AbortSignal, TypeScript, Vest]
 
 Async validation becomes incorrect when requests finish in a different order from the one in which they started. A slow response for an old value can otherwise replace the answer for the value currently on screen.
 
-Vest associates async work with the run that created it. When a newer focused run supersedes an older one, the older result cannot update the current suite state.
+Vest associates async work with the run that created it. When a newer stateful
+run supersedes an older one—focused or full—the older result cannot update the
+current suite state. Awaiting the older run handle resolves to the newer run's
+result, so callers cannot accidentally observe an obsolete result. Independent
+`runStatic()` calls do not share this ownership chain.
 
 ```ts
 import { create, enforce, skipWhen, test } from 'vest';

--- a/website/docs/suite_serialization.md
+++ b/website/docs/suite_serialization.md
@@ -23,6 +23,12 @@ import { SuiteSerializer } from 'vest/exports/SuiteSerializer';
 
 Takes a result object (for example, from `suite.runStatic(data)`) and returns a serializable string (safe for JSON transport).
 
+For schema-backed suites, the serialized state includes the last mapped schema
+output. This allows the first focused client run after `resume()` to retain
+untouched parsed fields exactly as a stateful run would. Treat the serialized
+string as application data: do not expose or log it where the validated values
+would be sensitive.
+
 ### `SuiteSerializer.resume(suite, serializedData)`
 
 Takes a suite instance and serialized data, and applies that state to the suite.

--- a/website/docs/writing_your_suite/dirty_checking.md
+++ b/website/docs/writing_your_suite/dirty_checking.md
@@ -59,6 +59,20 @@ Combine `suite.only()` with `isTested()` for the best UX:
 - Use `isTested(fieldName)` when rendering to decide whether to show errors
   :::
 
+:::tip Related fields
+`suite.only()` runs exactly the field you name. When fields depend on each other through a schema [`dependsOn()`](./schema_relationships) relationship (e.g. `confirmPassword` depends on `password`), prefer `suite.changed()` in the handler — it revalidates the blurred field **plus its dependents**, so related errors refresh together:
+
+```javascript
+function handleBlur(fieldName, formData) {
+  // Re-runs the blurred field and anything that depends on it
+  const res = suite.changed(fieldName).run(formData);
+  setResult(res);
+}
+```
+
+Without a schema, `changed()` simply behaves like `only()` for that run.
+:::
+
 ## Complete Example
 
 ```javascript
@@ -113,10 +127,12 @@ function Form() {
 | :--------------------------- | :---------------------------- | :----------------------------------- |
 | **Did the user touch this?** | Check `field.isDirty`         | Check `result.isTested('field')`     |
 | **Validate on Blur**         | Call `validateField('field')` | Call `suite.only('field').run(data)` |
+| **Revalidate dependents**    | Manually track field links    | `suite.changed('field').run(data)`   |
 
 By combining `isTested()` (to hide premature errors) and `suite.only()` (to update specific fields), you get precise control over the user experience without tightly coupling your validation to the DOM.
 
 ## Related
 
+- [Schema Relationships](./schema_relationships.md) - `dependsOn()` and dependency-aware revalidation with `suite.changed()`
 - [Focused Updates](./focused_updates.md) - Deep dive into `suite.only()` and `suite.focus()`
 - [Accessing the Result](./accessing_the_result.md) - Learn about `isTested()` and other result methods

--- a/website/docs/writing_your_suite/focused_updates.md
+++ b/website/docs/writing_your_suite/focused_updates.md
@@ -136,6 +136,22 @@ When multiple modifiers are used, they are evaluated in the following order of p
 
 > **Note**: A test is run only if it passes _all_ active filters. For example, if you use `onlyGroup: 'A'` and `skip: 'field1'`, `field1` inside `Group A` will be skipped.
 
+### Dependency-Aware Focus with `suite.changed()`
+
+`only()` runs exactly the fields you name — nothing more. When your suite has a schema with [`dependsOn()`](./schema_relationships) relationships, `suite.changed()` goes one step further: it runs the named fields **plus every field the relationship graph marks as affected**, so dependents never go stale:
+
+```javascript
+// Re-runs `password` and, via dependsOn, `confirmPassword` too.
+suite.changed('password').run(formData);
+
+// Arrays, chaining, and nested paths all work.
+suite.changed(['password', 'country']).run(formData);
+suite.changed('password').only('confirmPassword').run(formData);
+suite.changed('travelers[1].passportCountry').run(formData);
+```
+
+Use `only()` for explicit execution selection and `changed()` for interaction-driven revalidation. See [Schema Relationships](./schema_relationships) for the full reference, including the affected-set rules and end-to-end examples.
+
 ## Fluent Chain API
 
 `focus()` returns a "runnable" interface, allowing you to chain it with `afterEach`, `afterField`, or `run`.
@@ -336,6 +352,7 @@ suite.focus({ onlyGroup: 'groupA' }).run(formData); // ✅
 
 ## Related
 
+- [Schema Relationships](./schema_relationships) - Dependency-aware revalidation with `suite.changed()` and `dependsOn()`
 - [Including and Excluding Fields](./including_and_excluding/skip_and_only) - Using `only()` and `skip()` inside suites
 - [Include](./including_and_excluding/include) - Link related fields to run together
 - [Test Groups](../writing_tests/advanced_test_features/grouping_tests) - Grouping tests together

--- a/website/docs/writing_your_suite/schema_relationships.md
+++ b/website/docs/writing_your_suite/schema_relationships.md
@@ -1,0 +1,499 @@
+---
+sidebar_position: 4
+title: Schema Relationships
+description: Declare validation relationships between fields in Enforce schemas.
+keywords: [Vest, Enforce, Schema, Relationships, dependsOn, cross-field]
+---
+
+# Schema Relationships
+
+Validation rules frequently depend on values outside the field they validate. A password confirmation depends on the password. A state depends on the selected country. A passport number may depend on the passport country of the same traveler.
+
+Vest can express these rules today because suites are arbitrary JavaScript:
+
+```js
+test('confirmPassword', 'Passwords must match', () => {
+  enforce(data.confirmPassword).equals(data.password);
+});
+```
+
+What Vest cannot know from this code is that the validity of `confirmPassword` depends on the value of `password` — that relationship exists only inside a closure.
+
+Schema Relationships make that relationship an optional, declarative part of an Enforce schema. The schema remains responsible for describing data **and relationships between data**. The suite remains responsible for execution, retained state, warnings, async work, groups, and interaction behavior.
+
+The model is dependency-aware invalidation of retained validation state — not dependency-driven execution. As an invariant: a validation result remains cached until its field changes or a value it depends on changes. `dependsOn()` declares the dependency half of that invariant; `suite.changed()` supplies the change event. The schema never says how to validate, in what order, or what the rule is — only which remembered results may have become stale.
+
+`dependsOn` is the first relationship primitive. The internal representation is a single directed graph (`source → target`, `effect: 'invalidate'`) that can later host other effects without redesigning the schema API.
+
+A relationship declaration should be: ergonomic, runtime-validated during composition, composable through nested schemas, meaningful for repeated/array schemas (same-item scoped), machine-readable without parsing source, small enough that users are not maintaining a second copy of their form, colocated with the field it describes, useful to Vest itself (not just metadata), and extensible.
+
+## Cross-field Dependencies
+
+Sometimes validating one field depends on another.
+
+For example, `confirmPassword` must be validated again whenever `password` changes.
+
+Declare that relationship **inline on the field schema** — references are resolved by the containing schema:
+
+```ts
+const registrationSchema = enforce.shape({
+  email: enforce.isString().isEmail(),
+  password: enforce.isString().longerThanOrEquals(8),
+  confirmPassword: enforce.isString().dependsOn($ => $.password),
+});
+```
+
+`$` does not contain your form values.
+
+It is an ergonomic symbolic reference to sibling fields in the **current schema scope**, runtime-validated during composition. TypeScript does not restrict property names to existing fields — any property access on `$` typechecks.
+
+This means:
+
+> The validation result for `confirmPassword` may become stale when the value of `password` changes.
+
+It does **not** add a validation rule by itself.
+
+Your suite still contains the actual business rule — and that may be arbitrary logic:
+
+```ts
+const suite = create(data => {
+  test('confirmPassword', 'Passwords must match', () => {
+    enforce(data.confirmPassword).equals(data.password);
+  });
+}, registrationSchema);
+```
+
+The schema says _that_ the two fields are related; the suite says _why and how_. This works equally for equality checks, conditional business rules, async API checks, feature-flagged validation, and warnings. The schema never encodes execution logic.
+
+So a field can declare a dependency even when its own Enforce rule is not the one reading the other field:
+
+```ts
+username: enforce.isString().dependsOn($ => $.organizationId);
+// suite:
+test('username', 'Username unavailable', async () => {
+  const available = await api.checkUsername({
+    organizationId: data.organizationId,
+    username: data.username,
+  });
+  enforce(available).isTruthy();
+});
+```
+
+> Schema: `username` validity depends on `organizationId`.
+> Suite: here is why and how.
+
+## Multiple Dependencies
+
+A field may depend on more than one value. Return an array:
+
+```ts
+const schema = enforce.shape({
+  quantity: enforce.isNumber(),
+  unitPrice: enforce.isNumber(),
+  currency: enforce.isString(),
+  total: enforce
+    .isNumber()
+    .dependsOn($ => [$.quantity, $.unitPrice, $.currency]),
+});
+```
+
+Changing any of `quantity`, `unitPrice`, or `currency` may make `total` stale. Always return refs — `($) => $.a` for one, `($) => [$.a, $.b]` for many — so the API has room to grow.
+
+## Nested Fields — Scoped Refs
+
+`$` is scoped to the **current schema**. References are local by default:
+
+```ts
+const accountSchema = enforce.shape({
+  password: enforce.isString(),
+  confirmPassword: enforce.isString().dependsOn($ => $.password),
+});
+```
+
+No dotted strings to keep synchronized. A misspelled or stale field name (e.g. renaming `password` without updating `$ => $.password`) throws `EnforceSchemaError` when the containing schema is composed — a runtime check during composition, not a TypeScript compile-time error. No ESLint rule for this exists in V1.
+
+## Reusable Nested Schemas
+
+Dependencies declared inside a nested schema are relative to that schema and **rebase automatically** when mounted:
+
+```ts
+const addressSchema = enforce.shape({
+  country: enforce.isString(),
+  state: enforce.isString().dependsOn($ => $.country),
+});
+
+const checkoutSchema = enforce.shape({
+  billingAddress: addressSchema,
+  shippingAddress: addressSchema,
+});
+```
+
+Conceptually:
+
+```text
+billingAddress.country  → billingAddress.state
+shippingAddress.country → shippingAddress.state
+```
+
+The reusable schema does not know where it will be mounted.
+
+## Arrays and Repeated Schemas
+
+Dependencies inside an item schema remain scoped to the **same item** — no array syntax needed:
+
+```ts
+const travelerSchema = enforce.shape({
+  passportCountry: enforce.isString(),
+  passportNumber: enforce.isString().dependsOn($ => $.passportCountry),
+});
+
+const bookingSchema = enforce.shape({
+  travelers: enforce.isArrayOf(travelerSchema),
+});
+```
+
+If `travelers[3].passportCountry` changes, only `travelers[3].passportNumber` is affected:
+
+```text
+travelers[3].passportCountry → travelers[3].passportNumber
+```
+
+Internally:
+
+```text
+travelers[$item].passportCountry → travelers[$item].passportNumber
+```
+
+The concrete index is bound at runtime. The binding is structural, not numeric.
+
+Records work the same way with dynamic keys: a dependency inside a record
+value stays scoped to the **same key** — no key syntax needed:
+
+```ts
+const schema = enforce.shape({
+  dictionary: enforce.record(
+    enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    }),
+  ),
+});
+```
+
+If `dictionary.home.country` changes, only `dictionary.home.state` is
+affected. Numeric record keys (`'0'`, `'1'`) are matched the same way;
+a key containing a dot cannot be addressed unambiguously with dotted
+`changed()` names — prefer non-dotted keys when using `suite.changed()`.
+
+## Dependencies Across Nesting Levels
+
+Most relationships are local. For the unusual case that must reference outside its scope, use `$.root`:
+
+```ts
+const schema = enforce.shape({
+  accountType: enforce.isString(),
+  company: enforce.shape({
+    country: enforce.isString(),
+    taxId: enforce.isString().dependsOn($ => [$.country, $.root.accountType]),
+  }),
+});
+```
+
+Semantics:
+
+- `$` — current schema scope
+- `$.root` — top-level schema scope
+
+`$.root` should be explicit and rare. Reusable locals should prefer local refs.
+
+> **Validation timing for `$.root` paths**
+>
+> Local references are validated when the containing schema is composed
+> (unknown siblings throw `EnforceSchemaError` immediately). Rooted paths are
+> validated lazily instead: composition and `describe()` stay lenient so
+> focused fragments keep composing, and an unknown `$.root` field throws on
+> the first `test` / `validate` / `run` — or at suite creation, which
+> finalizes the graph. `describe()` may therefore show a dangling rooted
+> edge until the schema is executed.
+
+> **Deferred to v2 — `$.parent`**
+>
+> `$.parent` (parent-scope escape) is **intentionally deferred** — add only if a real use case demands it.
+> In V1, a resolver that touches `$.parent` throws at schema composition time with `err.message` exactly `Failed to resolve dependency for "a": $.parent deferred to v2` (an `EnforceSchemaError`).
+>
+> ```ts
+> enforce.shape({
+>   a: enforce.isString().dependsOn($ => $.parent.sibling), // throws in V1
+> });
+> ```
+
+## Dependencies and Focused Validation
+
+A dependency does not change `only()`.
+
+```ts
+suite.only('password').run(data);
+```
+
+means exactly that — run only `password`.
+
+Dependencies answer a different question:
+
+> A field changed. Which validation results may now be stale?
+
+Use the available interaction API which consumes the relationship graph:
+
+```ts
+suite.changed('password').run(data);
+```
+
+Given:
+
+```ts
+confirmPassword: enforce.isString().dependsOn($ => $.password);
+```
+
+Vest derives:
+
+```text
+password
+confirmPassword
+```
+
+as the affected set. This preserves `only()` semantics while giving frameworks an interaction-aware operation. Keep them separate:
+
+- `only()` — explicit execution selection
+- `changed()` — dependency-aware affected-set selection
+
+`include()` then becomes a lower-level escape hatch, not the primary way to express cross-field behavior.
+
+`schema.run()` reports only the first failure (pre-existing n4s behavior): with both `a` and `b` invalid, the result carries `path: ['a']` only, so surfacing every error takes repeated runs. Selective schema execution additionally re-runs the projected rule per affected array index / record key, so an affected member failure hidden behind an earlier unaffected one is still surfaced.
+
+Split of responsibilities: Enforce owns spatial and structural truth (the graph, schema paths, selective execution); Vest owns temporal truth (retained state, test focus, reconciliation). The handshake between them is narrow — Vest hands n4s the schema, the run data, and the raw changed names; n4s returns the concrete affected set. Vest resolves that set once through the canonical planner, then gives the exact same set to both suite focus and schema execution via `runSchemaPaths(schema, data, options?)`. Everything after that is n4s-owned — container-kind detection, fragment projection, short-circuit supplementation, chain-validator preservation, and member execution. Vest never reverse-engineers container semantics.
+
+Selective execution holds for focused runs: members outside the affected set never execute, and each affected single-rule or tuple member executes exactly once — safe for stateful validators. Union (`isArrayOf` with several members) elements instead resolve whole-member any-match: each affected element is checked against the members in order until one matches, so member validators may execute more than once (once per affected element) — do not rely on exactly-once for stateful validators inside union members. Tuple members run positionally and union elements resolve whole-member any-match, both with the same attribution a full run would report. Shapes whose fields are all `optional()` are still ordinary required-semantics containers (only `partial()` skips missing keys). Validators chained onto a container itself, or a `partial()` top-level schema, cannot be projected safely: those runs validate the full schema and narrow the failures to the affected paths instead, so results always match the full run.
+
+To decide whether a container can be projected, n4s reads construction-time markers (`partial()`, `optional()`) only. Introspection never executes user validators: no synthetic probe values (`{}`, `undefined`, `null`) are ever passed to validation code, so validators with observable side effects only ever fire with real run data inside a suite run. Schemas without recognizable metadata (unknown or exotic rules) are not projected: those runs validate the full schema and narrow the failures to the affected paths instead — slower, but with results always matching the full run.
+
+### `suite.changed()` Reference
+
+`suite.changed()` is the interaction API that consumes the relationship graph. It takes the fields the user touched and runs them plus everything the graph marks as affected:
+
+```ts
+suite.changed('password').run(data);
+```
+
+Accepted field arguments:
+
+- `suite.changed('password')` — expand the affected set from one field.
+- `suite.changed(['password', 'country'])` — expand from several fields (union of affected sets).
+- `suite.changed(undefined)` — legal no-op that runs without changed focus, mirroring `only(undefined)`.
+- `suite.changed([])` — explicit empty focus: runs no tests.
+
+Behavior notes:
+
+- Returns a focused suite, so it chains with the other focus APIs: `suite.changed('password').only('confirmPassword').run(data)`. Combining `only()` with `changed()` runs the union — the `only()` base fields plus the affected set.
+- Changed names may be nested paths in either spelling — `suite.changed('company.country')` and `suite.changed('travelers[1].passportCountry')` resolve to the same affected set.
+- Without a schema, or when the schema declares no `dependsOn` edges, `changed()` degrades gracefully: the affected set is the named fields themselves, equivalent to `only()` for that run.
+
+### End-to-End: Revalidating a Form on Change
+
+A complete blur-handler flow. The schema declares the relationship once; every keystroke handler stays the same shape:
+
+```ts
+import { create, test, enforce } from 'vest';
+
+const schema = enforce.shape({
+  password: enforce.isString().longerThanOrEquals(8),
+  confirmPassword: enforce.isString().dependsOn($ => $.password),
+});
+
+const suite = create(data => {
+  test('password', 'Password must be at least 8 characters', () => {
+    enforce(data.password).longerThanOrEquals(8);
+  });
+  test('confirmPassword', 'Passwords must match', () => {
+    enforce(data.confirmPassword).equals(data.password);
+  });
+}, schema);
+
+// Initial full run on submit or mount.
+let result = suite.run({ password: 'hunter22', confirmPassword: 'hunter22' });
+
+// The user edits the password field. Re-run for the changed field:
+// Vest re-runs `password` plus the affected `confirmPassword` test
+// and preserves every other result.
+result = suite.changed('password').run({
+  password: 'hunter2',
+  confirmPassword: 'hunter22',
+});
+
+result.hasErrors('confirmPassword'); // true — the stale dependent was re-evaluated
+```
+
+With several changed fields at once, pass an array — the affected set is the union:
+
+```ts
+result = suite.changed(['password', 'email']).run(nextData);
+```
+
+### Custom Parsers and Selective Runs
+
+Selective runs apply parser steps (built-in steps like `trim()` or `toNumber()`, which only transform data) to untouched fields without executing validation predicates — so those transforms must be pure. Custom rules added with `enforce.extend` are treated as validators by default and are never executed speculatively. If a custom rule is really a parser — a pure transformation that cannot fail on its own — register it explicitly so selective runs can apply it:
+
+```ts
+enforce.extend(
+  {
+    normalizeId: (value: string) => ({
+      pass: true,
+      type: value.trim().toUpperCase(),
+    }),
+  },
+  { parsers: ['normalizeId'] },
+);
+```
+
+Unlisted custom rules keep validator treatment: they run only when their own field is in the affected set, never as mapping helpers. See [Input vs output types with parsers](./schema_validation#input-vs-output-types-with-parsers) for the full typing story.
+
+## Dependencies Are Not Automatically Transitive
+
+```text
+A → B
+B → C
+```
+
+where `A → B` means "target `B` may be stale when `A` changes."
+
+If `A` changes, `B` must be reconsidered. `C` does not — `B`'s value didn't change. Expansion is on changed values, not transitive closure. If `C` also depends on `A`, declare it explicitly. Revalidation does not imply mutation: rerunning `B` because `A` changed does not mean `B` changed, so `B`'s dependents remain valid.
+
+## Circular Dependencies
+
+Cycles are valid.
+
+```ts
+const schema = enforce.shape({
+  startDate: enforce.isString().dependsOn($ => $.endDate),
+  endDate: enforce.isString().dependsOn($ => $.startDate),
+});
+```
+
+Changing `startDate` invalidates `endDate` and vice versa. No loop occurs because dependencies describe invalidation, not imperative calls.
+
+> **Deferred to v2 — `effect: 'revalidate'`**
+>
+> V1: only `effect: 'invalidate'` ("previous result is stale") is supported.
+> Supplying `effect: 'revalidate'` (immediately rerun vs stale) is **deferred to v2** and will throw with `err.message` exactly `effect:'revalidate' deferred to v2 — only 'invalidate' supported in V1`.
+> The assertion is at composition time (`enforce` + `lazy.ts`):
+>
+> ```ts
+> /** @deferred v2 — effect:'revalidate' deferred, only 'invalidate' supported in V1 */
+> if (effect !== 'invalidate')
+>   throw new Error(
+>     `effect:'${effect}' deferred to v2 — only 'invalidate' supported in V1`,
+>   );
+> ```
+>
+> Future `revalidate` vs `invalidate` distinction (immediately rerun vs stale) is deferred.
+>
+> `revalidates()` was removed before V1; use `.dependsOn()` for the same edge.
+
+## Introspection
+
+Dependency information is part of the Enforce schema and inspectable without running a suite:
+
+```ts
+schema.describe();
+```
+
+Serializable form:
+
+```json
+{
+  "dependencies": [
+    {
+      "target": [{ "type": "property", "key": "confirmPassword" }],
+      "sources": [[{ "type": "property", "key": "password" }]]
+    }
+  ],
+  "relationships": [
+    {
+      "source": [{ "type": "property", "key": "password" }],
+      "target": [{ "type": "property", "key": "confirmPassword" }],
+      "effect": "invalidate"
+    }
+  ]
+}
+```
+
+Array item (the item binding is `<arrayKey>.$item`):
+
+```json
+{
+  "target": [
+    { "type": "property", "key": "travelers" },
+    { "type": "item", "binding": "travelers.$item" },
+    { "type": "property", "key": "passportNumber" }
+  ],
+  "sources": [
+    [
+      { "type": "property", "key": "travelers" },
+      { "type": "item", "binding": "travelers.$item" },
+      { "type": "property", "key": "passportCountry" }
+    ]
+  ]
+}
+```
+
+The representation is:
+
+```ts
+type PropertySegment = { type: 'property'; key: PropertyKey };
+type ItemSegment = { type: 'item'; binding: string };
+type SchemaPath = readonly (PropertySegment | ItemSegment)[];
+interface SchemaRelationship {
+  source: SchemaPath;
+  target: SchemaPath;
+  effect: 'invalidate';
+  metadata?: { reason?: string };
+}
+interface SchemaDependency {
+  target: SchemaPath;
+  sources: readonly SchemaPath[];
+}
+```
+
+Consumable by Vest, framework adapters, devtools, docs, and agents. Relationships stay out of `~standard`.
+
+## What Dependencies Intentionally Do Not Do
+
+- Does not execute anything or impose validation order — purely invalidation metadata.
+- Does not inspect suite closures.
+- Does not make arbitrary JS declarative.
+- Does not replicate `test()`/`group()`/`warn()`/`only()`/`skipWhen`/async inside Enforce.
+- Does not require deps for every cross-field test.
+- Does not change Standard Schema.
+- Does not change `only()` — `changed()` is separate.
+
+## Interaction with Other Features
+
+Schema Relationships are **metadata + `suite.changed()` in V1**. `describe()` records the graph without running a suite; `suite.changed()` consumes it to select affected tests.
+
+| Feature                                     | Effect on `describe()`                                                                                                                  | Effect on suite `run()` / `suite.changed()` in V1                                                                                                                                   |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `skipWhen` (retains)                        | records                                                                                                                                 | `run()` unchanged; `changed()` treats dependent as candidate but Vest skips if `skipWhen` hides it                                                                                  |
+| `omitWhen` (removes)                        | records                                                                                                                                 | `run()` unchanged; `changed()` still records edge but omitted test never runs                                                                                                       |
+| `optional('field')`                         | records                                                                                                                                 | `run()` unchanged — edge exists even if optional field is absent; `changed()` includes it when source changes                                                                       |
+| `include().when()`                          | **does not record** — `include` is a Vest suite modifier, not an n4s schema relationship; `schema.describe()` has no `include` metadata | `changed()` remains the interaction-aware operation                                                                                                                                 |
+| `only` / `skip` / `onlyGroup` / `skipGroup` | records (expansion ignores focus: `only('password')` does not auto-include `confirmPassword`)                                           | `changed('password')` does include it; `only` merges into the affected set; synthesized failures are top-level tests, so field focus and the documented top-level group rules apply |
+| `group` / `each`                            | records (rebased)                                                                                                                       | `run()` unchanged; `changed()` respects rebasing and same-item scoping; keyed `each` results follow item identity across reordered array positions                                  |
+| `warn`                                      | records                                                                                                                                 | `run()` unchanged; `changed()` includes warn dependents as normal tests                                                                                                             |
+
+V1 ships `suite.changed(field).run(data)` with dependency-aware affected-set expansion (flat, nested, reusable, array same-item, and root→array fan-out via run-time `data`). Abortable changed runs are not part of the V1 API.
+
+## Related
+
+- [Schema Validation](./schema_validation) — passing a schema to `create()`, parsed data, and registering custom `parsers`.
+- [Focused Updates](./focused_updates) — the `only()` / `skip()` / `focus()` semantics that `changed()` builds on.
+- [Handling User Interaction](./dirty_checking) — the `onBlur` / `onChange` patterns where `changed()` fits.
+- [Creating Custom Rules](../enforce/creating_custom_rules) — `enforce.extend`, including parser-style rules.
+- [Data Parsers](../enforce/builtin-enforce-plugins/data_parsers) — the built-in parser steps selective runs can apply safely.

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -99,11 +99,50 @@ result.value; // typed as { age: number; name: string }
 
 The first rule in a chain determines the input type, and the last parser in the chain determines the output type. This means you never need `@ts-expect-error` or `as any` for valid parser coercion inputs.
 
+Focused runs still pass the complete parsed output to the suite callback. On a
+first focused run, Vest applies parser steps to untouched fields without
+running their validation predicates. Parser transforms should therefore be
+pure and must return their declared output type even when their `pass` verdict
+is false. The mapped output keeps the callback type sound; an untouched
+parser's failure does not become part of that focused run's validation result.
+If a custom `enforce.extend` rule is a parser, register it explicitly so
+focused mapping can recognize it:
+
+```typescript
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      normalizeId: (value: string) => { pass: boolean; type: string };
+    }
+  }
+}
+
+enforce.extend(
+  {
+    normalizeId: (value: string) => ({
+      pass: true,
+      type: value.trim().toUpperCase(),
+    }),
+  },
+  { parsers: ['normalizeId'] },
+);
+```
+
+Custom extension rules are treated as validators unless they are listed in
+`parsers`. The per-run `result.run.data.parsed` value still reflects only the
+schema work performed by that run; the callback receives the complete mapped
+output assembled for the suite.
+
+When a focused path enters an array, Vest refreshes that containing array from
+the current input. Array positions are not identities, so this prevents an
+insert, removal, or reorder from combining the current item with a stale array
+layout retained from an earlier run.
+
 ### What becomes typed from the schema
 
 With `create(callback, schema)`, TypeScript narrows:
 
-- callback data (`data`) to the schema input shape.
+- callback data (`data`) to the schema output shape.
 - `suite.run(...)` / `suite.runStatic(...)` first argument to the schema input shape.
 - the Standard Schema `~standard.validate(...)` input and output types.
 - field-oriented happy-path APIs (`test`, `optional`, `include`) to schema keys.
@@ -128,6 +167,7 @@ When using `create(callback, schema)`, the current TypeScript standard is:
   - `suite.remove(fieldName)`
   - `suite.resetField(fieldName)`
   - `suite.only(fieldName)`
+  - `suite.changed(fieldName)` (single name, array, or `undefined`; see [Schema Relationships](./schema_relationships#suitechanged-reference))
   - `suite.afterField(fieldName, callback)`
   - `only(fieldName)` / `skip(fieldName)` hooks
 
@@ -156,6 +196,8 @@ suite.only('username').run({
 });
 ```
 
+For interaction-driven revalidation that also refreshes dependent fields, use `suite.changed()` instead — see [Schema Relationships](./schema_relationships).
+
 :::
 
 ## Schema Types
@@ -172,7 +214,7 @@ The suite result includes typed properties for accessing validated and parsed da
 - `result.value` — The parsed output when the suite is valid. Typed as the schema's output type. `undefined` when invalid.
 - `result.types.input` — Carries the schema's input type for static analysis. At runtime, holds the parsed output value.
 - `result.types.output` — Carries the schema's output type. At runtime, holds the parsed output value.
-- `result.run.data.raw` — The current run data passed into the suite callback (parsed when schema validation succeeds; original input when it fails).
+- `result.run.data.raw` — The current run's parsed chunk when schema validation succeeds, or its original input when validation fails. A focused callback may receive a fuller retained mapped output than this per-run metadata.
 - `result.run.data.parsed` — Parsed data for the current run.
 
 ```typescript

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -84,6 +84,21 @@ const config = {
 
   projectName: 'vest', // Usually your repo name.
 
+  plugins: [
+    () => ({
+      name: 'exclude-node-module',
+      configureWebpack() {
+        return {
+          resolve: {
+            fallback: {
+              'node:module': false,
+            },
+          },
+        };
+      },
+    }),
+  ],
+
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -28,6 +28,7 @@ Runs the suite. Passes arguments to the suite callback.
 - **Returns**: A `SuiteResult` object.
   - If the suite contains async tests, the result object **also implements the Promise interface**, allowing you to `await` it.
   - You can always access synchronous result data immediately (e.g., `result.hasErrors()`), even if the promise is pending.
+  - If another stateful `suite.run()` starts while an earlier run is pending, awaiting the earlier handle resolves to the newer run's result. This prevents obsolete async work from exposing stale state. `runStatic()` remains independent.
 - [Read more about `suite.run`](https://vestjs.dev/docs/writing_your_suite/vests_suite#running-validations)
 
 #### `suite.runStatic(...args)`
@@ -1782,6 +1783,24 @@ enforce.extend({
 
 enforce(user.email).isValidEmail();
 ```
+
+### Parser-style custom rules and selective runs
+
+Custom rules are validators by default: Vest never executes them speculatively. That matters for dependency-aware runs — when `suite.changed()` revalidates an affected subset, untouched fields are mapped without running their validators. If your custom rule is really a **parser** (a pure transformation that cannot fail on its own, like upper-casing or trimming), declare it in `parsers` so selective runs can apply it to untouched fields:
+
+```js
+enforce.extend(
+  {
+    normalizeId: value => ({
+      pass: true,
+      type: value.trim().toUpperCase(),
+    }),
+  },
+  { parsers: ['normalizeId'] },
+);
+```
+
+Rules left out of `parsers` keep validator treatment. Field-level validators run when their field is in the affected set; validators attached to a retained container can also run when a descendant changes. See [Input vs output types with parsers](https://vestjs.dev/docs/writing_your_suite/schema_validation#input-vs-output-types-with-parsers) and [Custom Parsers and Selective Runs](https://vestjs.dev/docs/writing_your_suite/schema_relationships#custom-parsers-and-selective-runs).
 
 ## Custom rules return value
 
@@ -3553,7 +3572,11 @@ If you only need to parse an API payload once, an Enforce schema's `.parse()` me
 
 Async validation becomes incorrect when requests finish in a different order from the one in which they started. A slow response for an old value can otherwise replace the answer for the value currently on screen.
 
-Vest associates async work with the run that created it. When a newer focused run supersedes an older one, the older result cannot update the current suite state.
+Vest associates async work with the run that created it. When a newer stateful
+run supersedes an older one—focused or full—the older result cannot update the
+current suite state. Awaiting the older run handle resolves to the newer run's
+result, so callers cannot accidentally observe an obsolete result. Independent
+`runStatic()` calls do not share this ownership chain.
 
 ```ts
 import { create, enforce, skipWhen, test } from 'vest';
@@ -5263,6 +5286,12 @@ import { SuiteSerializer } from 'vest/exports/SuiteSerializer';
 ### `SuiteSerializer.serialize(result)`
 
 Takes a result object (for example, from `suite.runStatic(data)`) and returns a serializable string (safe for JSON transport).
+
+For schema-backed suites, the serialized state includes the last mapped schema
+output. This allows the first focused client run after `resume()` to retain
+untouched parsed fields exactly as a stateful run would. Treat the serialized
+string as application data: do not expose or log it where the validated values
+would be sensitive.
 
 ### `SuiteSerializer.resume(suite, serializedData)`
 
@@ -8210,6 +8239,20 @@ Combine `suite.only()` with `isTested()` for the best UX:
 - Use `isTested(fieldName)` when rendering to decide whether to show errors
   :::
 
+:::tip Related fields
+`suite.only()` runs exactly the field you name. When fields depend on each other through a schema [`dependsOn()`](https://vestjs.dev/docs/writing_your_suite/schema_relationships) relationship (e.g. `confirmPassword` depends on `password`), prefer `suite.changed()` in the handler — it revalidates the blurred field **plus its dependents**, so related errors refresh together:
+
+```javascript
+function handleBlur(fieldName, formData) {
+  // Re-runs the blurred field and anything that depends on it
+  const res = suite.changed(fieldName).run(formData);
+  setResult(res);
+}
+```
+
+Without a schema, `changed()` simply behaves like `only()` for that run.
+:::
+
 ## Complete Example
 
 ```javascript
@@ -8264,11 +8307,13 @@ function Form() {
 | :--------------------------- | :---------------------------- | :----------------------------------- |
 | **Did the user touch this?** | Check `field.isDirty`         | Check `result.isTested('field')`     |
 | **Validate on Blur**         | Call `validateField('field')` | Call `suite.only('field').run(data)` |
+| **Revalidate dependents**    | Manually track field links    | `suite.changed('field').run(data)`   |
 
 By combining `isTested()` (to hide premature errors) and `suite.only()` (to update specific fields), you get precise control over the user experience without tightly coupling your validation to the DOM.
 
 ## Related
 
+- [Schema Relationships](https://vestjs.dev/docs/writing_your_suite/schema_relationships) - `dependsOn()` and dependency-aware revalidation with `suite.changed()`
 - [Focused Updates](https://vestjs.dev/docs/writing_your_suite/focused_updates) - Deep dive into `suite.only()` and `suite.focus()`
 - [Accessing the Result](https://vestjs.dev/docs/writing_your_suite/accessing_the_result) - Learn about `isTested()` and other result methods
 
@@ -8478,6 +8523,22 @@ When multiple modifiers are used, they are evaluated in the following order of p
 
 > **Note**: A test is run only if it passes _all_ active filters. For example, if you use `onlyGroup: 'A'` and `skip: 'field1'`, `field1` inside `Group A` will be skipped.
 
+### Dependency-Aware Focus with `suite.changed()`
+
+`only()` runs exactly the fields you name — nothing more. When your suite has a schema with [`dependsOn()`](https://vestjs.dev/docs/writing_your_suite/schema_relationships) relationships, `suite.changed()` goes one step further: it runs the named fields **plus every field the relationship graph marks as affected**, so dependents never go stale:
+
+```javascript
+// Re-runs `password` and, via dependsOn, `confirmPassword` too.
+suite.changed('password').run(formData);
+
+// Arrays, chaining, and nested paths all work.
+suite.changed(['password', 'country']).run(formData);
+suite.changed('password').only('confirmPassword').run(formData);
+suite.changed('travelers[1].passportCountry').run(formData);
+```
+
+Use `only()` for explicit execution selection and `changed()` for interaction-driven revalidation. See [Schema Relationships](https://vestjs.dev/docs/writing_your_suite/schema_relationships) for the full reference, including the affected-set rules and end-to-end examples.
+
 ## Fluent Chain API
 
 `focus()` returns a "runnable" interface, allowing you to chain it with `afterEach`, `afterField`, or `run`.
@@ -8678,6 +8739,7 @@ suite.focus({ onlyGroup: 'groupA' }).run(formData); // ✅
 
 ## Related
 
+- [Schema Relationships](https://vestjs.dev/docs/writing_your_suite/schema_relationships) - Dependency-aware revalidation with `suite.changed()` and `dependsOn()`
 - [Including and Excluding Fields](https://vestjs.dev/docs/writing_your_suite/including_and_excluding/skip_and_only) - Using `only()` and `skip()` inside suites
 - [Include](https://vestjs.dev/docs/writing_your_suite/including_and_excluding/include) - Link related fields to run together
 - [Test Groups](https://vestjs.dev/docs/writing_tests/advanced_test_features/grouping_tests) - Grouping tests together
@@ -9415,6 +9477,500 @@ Another notable distinction is that tests marked as warnings do not make the sui
 In some rare instances, you might have a field that is both optional and a warning. In these cases, you can combine the two options.
 
 
+# Schema Relationships
+
+Validation rules frequently depend on values outside the field they validate. A password confirmation depends on the password. A state depends on the selected country. A passport number may depend on the passport country of the same traveler.
+
+Vest can express these rules today because suites are arbitrary JavaScript:
+
+```js
+test('confirmPassword', 'Passwords must match', () => {
+  enforce(data.confirmPassword).equals(data.password);
+});
+```
+
+What Vest cannot know from this code is that the validity of `confirmPassword` depends on the value of `password` — that relationship exists only inside a closure.
+
+Schema Relationships make that relationship an optional, declarative part of an Enforce schema. The schema remains responsible for describing data **and relationships between data**. The suite remains responsible for execution, retained state, warnings, async work, groups, and interaction behavior.
+
+The model is dependency-aware invalidation of retained validation state — not dependency-driven execution. As an invariant: a validation result remains cached until its field changes or a value it depends on changes. `dependsOn()` declares the dependency half of that invariant; `suite.changed()` supplies the change event. The schema never says how to validate, in what order, or what the rule is — only which remembered results may have become stale.
+
+`dependsOn` is the first relationship primitive. The internal representation is a single directed graph (`source → target`, `effect: 'invalidate'`) that can later host other effects without redesigning the schema API.
+
+A relationship declaration should be: ergonomic, runtime-validated during composition, composable through nested schemas, meaningful for repeated/array schemas (same-item scoped), machine-readable without parsing source, small enough that users are not maintaining a second copy of their form, colocated with the field it describes, useful to Vest itself (not just metadata), and extensible.
+
+## Cross-field Dependencies
+
+Sometimes validating one field depends on another.
+
+For example, `confirmPassword` must be validated again whenever `password` changes.
+
+Declare that relationship **inline on the field schema** — references are resolved by the containing schema:
+
+```ts
+const registrationSchema = enforce.shape({
+  email: enforce.isString().isEmail(),
+  password: enforce.isString().longerThanOrEquals(8),
+  confirmPassword: enforce.isString().dependsOn($ => $.password),
+});
+```
+
+`$` does not contain your form values.
+
+It is an ergonomic symbolic reference to sibling fields in the **current schema scope**, runtime-validated during composition. TypeScript does not restrict property names to existing fields — any property access on `$` typechecks.
+
+This means:
+
+> The validation result for `confirmPassword` may become stale when the value of `password` changes.
+
+It does **not** add a validation rule by itself.
+
+Your suite still contains the actual business rule — and that may be arbitrary logic:
+
+```ts
+const suite = create(data => {
+  test('confirmPassword', 'Passwords must match', () => {
+    enforce(data.confirmPassword).equals(data.password);
+  });
+}, registrationSchema);
+```
+
+The schema says _that_ the two fields are related; the suite says _why and how_. This works equally for equality checks, conditional business rules, async API checks, feature-flagged validation, and warnings. The schema never encodes execution logic.
+
+So a field can declare a dependency even when its own Enforce rule is not the one reading the other field:
+
+```ts
+username: enforce.isString().dependsOn($ => $.organizationId);
+// suite:
+test('username', 'Username unavailable', async () => {
+  const available = await api.checkUsername({
+    organizationId: data.organizationId,
+    username: data.username,
+  });
+  enforce(available).isTruthy();
+});
+```
+
+> Schema: `username` validity depends on `organizationId`.
+> Suite: here is why and how.
+
+## Multiple Dependencies
+
+A field may depend on more than one value. Return an array:
+
+```ts
+const schema = enforce.shape({
+  quantity: enforce.isNumber(),
+  unitPrice: enforce.isNumber(),
+  currency: enforce.isString(),
+  total: enforce
+    .isNumber()
+    .dependsOn($ => [$.quantity, $.unitPrice, $.currency]),
+});
+```
+
+Changing any of `quantity`, `unitPrice`, or `currency` may make `total` stale. Always return refs — `($) => $.a` for one, `($) => [$.a, $.b]` for many — so the API has room to grow.
+
+## Nested Fields — Scoped Refs
+
+`$` is scoped to the **current schema**. References are local by default:
+
+```ts
+const accountSchema = enforce.shape({
+  password: enforce.isString(),
+  confirmPassword: enforce.isString().dependsOn($ => $.password),
+});
+```
+
+No dotted strings to keep synchronized. A misspelled or stale field name (e.g. renaming `password` without updating `$ => $.password`) throws `EnforceSchemaError` when the containing schema is composed — a runtime check during composition, not a TypeScript compile-time error. No ESLint rule for this exists in V1.
+
+## Reusable Nested Schemas
+
+Dependencies declared inside a nested schema are relative to that schema and **rebase automatically** when mounted:
+
+```ts
+const addressSchema = enforce.shape({
+  country: enforce.isString(),
+  state: enforce.isString().dependsOn($ => $.country),
+});
+
+const checkoutSchema = enforce.shape({
+  billingAddress: addressSchema,
+  shippingAddress: addressSchema,
+});
+```
+
+Conceptually:
+
+```text
+billingAddress.country  → billingAddress.state
+shippingAddress.country → shippingAddress.state
+```
+
+The reusable schema does not know where it will be mounted.
+
+## Arrays and Repeated Schemas
+
+Dependencies inside an item schema remain scoped to the **same item** — no array syntax needed:
+
+```ts
+const travelerSchema = enforce.shape({
+  passportCountry: enforce.isString(),
+  passportNumber: enforce.isString().dependsOn($ => $.passportCountry),
+});
+
+const bookingSchema = enforce.shape({
+  travelers: enforce.isArrayOf(travelerSchema),
+});
+```
+
+If `travelers[3].passportCountry` changes, only `travelers[3].passportNumber` is affected:
+
+```text
+travelers[3].passportCountry → travelers[3].passportNumber
+```
+
+Internally:
+
+```text
+travelers[$item].passportCountry → travelers[$item].passportNumber
+```
+
+The concrete index is bound at runtime. The binding is structural, not numeric.
+
+Records work the same way with dynamic keys: a dependency inside a record
+value stays scoped to the **same key** — no key syntax needed:
+
+```ts
+const schema = enforce.shape({
+  dictionary: enforce.record(
+    enforce.shape({
+      country: enforce.isString(),
+      state: enforce.isString().dependsOn($ => $.country),
+    }),
+  ),
+});
+```
+
+If `dictionary.home.country` changes, only `dictionary.home.state` is
+affected. Numeric record keys (`'0'`, `'1'`) are matched the same way;
+a key containing a dot cannot be addressed unambiguously with dotted
+`changed()` names — prefer non-dotted keys when using `suite.changed()`.
+
+## Dependencies Across Nesting Levels
+
+Most relationships are local. For the unusual case that must reference outside its scope, use `$.root`:
+
+```ts
+const schema = enforce.shape({
+  accountType: enforce.isString(),
+  company: enforce.shape({
+    country: enforce.isString(),
+    taxId: enforce.isString().dependsOn($ => [$.country, $.root.accountType]),
+  }),
+});
+```
+
+Semantics:
+
+- `$` — current schema scope
+- `$.root` — top-level schema scope
+
+`$.root` should be explicit and rare. Reusable locals should prefer local refs.
+
+> **Validation timing for `$.root` paths**
+>
+> Local references are validated when the containing schema is composed
+> (unknown siblings throw `EnforceSchemaError` immediately). Rooted paths are
+> validated lazily instead: composition and `describe()` stay lenient so
+> focused fragments keep composing, and an unknown `$.root` field throws on
+> the first `test` / `validate` / `run` — or at suite creation, which
+> finalizes the graph. `describe()` may therefore show a dangling rooted
+> edge until the schema is executed.
+
+> **Deferred to v2 — `$.parent`**
+>
+> `$.parent` (parent-scope escape) is **intentionally deferred** — add only if a real use case demands it.
+> In V1, a resolver that touches `$.parent` throws at schema composition time with `err.message` exactly `Failed to resolve dependency for "a": $.parent deferred to v2` (an `EnforceSchemaError`).
+>
+> ```ts
+> enforce.shape({
+>   a: enforce.isString().dependsOn($ => $.parent.sibling), // throws in V1
+> });
+> ```
+
+## Dependencies and Focused Validation
+
+A dependency does not change `only()`.
+
+```ts
+suite.only('password').run(data);
+```
+
+means exactly that — run only `password`.
+
+Dependencies answer a different question:
+
+> A field changed. Which validation results may now be stale?
+
+Use the available interaction API which consumes the relationship graph:
+
+```ts
+suite.changed('password').run(data);
+```
+
+Given:
+
+```ts
+confirmPassword: enforce.isString().dependsOn($ => $.password);
+```
+
+Vest derives:
+
+```text
+password
+confirmPassword
+```
+
+as the affected set. This preserves `only()` semantics while giving frameworks an interaction-aware operation. Keep them separate:
+
+- `only()` — explicit execution selection
+- `changed()` — dependency-aware affected-set selection
+
+`include()` then becomes a lower-level escape hatch, not the primary way to express cross-field behavior.
+
+`schema.run()` reports only the first failure (pre-existing n4s behavior): with both `a` and `b` invalid, the result carries `path: ['a']` only, so surfacing every error takes repeated runs. Selective schema execution additionally re-runs the projected rule per affected array index / record key, so an affected member failure hidden behind an earlier unaffected one is still surfaced.
+
+Split of responsibilities: Enforce owns spatial and structural truth (the graph, schema paths, selective execution); Vest owns temporal truth (retained state, test focus, reconciliation). The handshake between them is narrow — Vest hands n4s the schema, the run data, and the raw changed names; n4s returns the concrete affected set. Vest resolves that set once through the canonical planner, then gives the exact same set to both suite focus and schema execution via `runSchemaPaths(schema, data, options?)`. Everything after that is n4s-owned — container-kind detection, fragment projection, short-circuit supplementation, chain-validator preservation, and member execution. Vest never reverse-engineers container semantics.
+
+Selective execution holds for focused runs: members outside the affected set never execute, and each affected single-rule or tuple member executes exactly once — safe for stateful validators. Union (`isArrayOf` with several members) elements instead resolve whole-member any-match: each affected element is checked against the members in order until one matches, so member validators may execute more than once (once per affected element) — do not rely on exactly-once for stateful validators inside union members. Tuple members run positionally and union elements resolve whole-member any-match, both with the same attribution a full run would report. Shapes whose fields are all `optional()` are still ordinary required-semantics containers (only `partial()` skips missing keys). Validators chained onto a container itself, or a `partial()` top-level schema, cannot be projected safely: those runs validate the full schema and narrow the failures to the affected paths instead, so results always match the full run.
+
+To decide whether a container can be projected, n4s reads construction-time markers (`partial()`, `optional()`) only. Introspection never executes user validators: no synthetic probe values (`{}`, `undefined`, `null`) are ever passed to validation code, so validators with observable side effects only ever fire with real run data inside a suite run. Schemas without recognizable metadata (unknown or exotic rules) are not projected: those runs validate the full schema and narrow the failures to the affected paths instead — slower, but with results always matching the full run.
+
+### `suite.changed()` Reference
+
+`suite.changed()` is the interaction API that consumes the relationship graph. It takes the fields the user touched and runs them plus everything the graph marks as affected:
+
+```ts
+suite.changed('password').run(data);
+```
+
+Accepted field arguments:
+
+- `suite.changed('password')` — expand the affected set from one field.
+- `suite.changed(['password', 'country'])` — expand from several fields (union of affected sets).
+- `suite.changed(undefined)` — legal no-op that runs without changed focus, mirroring `only(undefined)`.
+- `suite.changed([])` — explicit empty focus: runs no tests.
+
+Behavior notes:
+
+- Returns a focused suite, so it chains with the other focus APIs: `suite.changed('password').only('confirmPassword').run(data)`. Combining `only()` with `changed()` runs the union — the `only()` base fields plus the affected set.
+- Changed names may be nested paths in either spelling — `suite.changed('company.country')` and `suite.changed('travelers[1].passportCountry')` resolve to the same affected set.
+- Without a schema, or when the schema declares no `dependsOn` edges, `changed()` degrades gracefully: the affected set is the named fields themselves, equivalent to `only()` for that run.
+
+### End-to-End: Revalidating a Form on Change
+
+A complete blur-handler flow. The schema declares the relationship once; every keystroke handler stays the same shape:
+
+```ts
+import { create, test, enforce } from 'vest';
+
+const schema = enforce.shape({
+  password: enforce.isString().longerThanOrEquals(8),
+  confirmPassword: enforce.isString().dependsOn($ => $.password),
+});
+
+const suite = create(data => {
+  test('password', 'Password must be at least 8 characters', () => {
+    enforce(data.password).longerThanOrEquals(8);
+  });
+  test('confirmPassword', 'Passwords must match', () => {
+    enforce(data.confirmPassword).equals(data.password);
+  });
+}, schema);
+
+// Initial full run on submit or mount.
+let result = suite.run({ password: 'hunter22', confirmPassword: 'hunter22' });
+
+// The user edits the password field. Re-run for the changed field:
+// Vest re-runs `password` plus the affected `confirmPassword` test
+// and preserves every other result.
+result = suite.changed('password').run({
+  password: 'hunter2',
+  confirmPassword: 'hunter22',
+});
+
+result.hasErrors('confirmPassword'); // true — the stale dependent was re-evaluated
+```
+
+With several changed fields at once, pass an array — the affected set is the union:
+
+```ts
+result = suite.changed(['password', 'email']).run(nextData);
+```
+
+### Custom Parsers and Selective Runs
+
+Selective runs apply parser steps (built-in steps like `trim()` or `toNumber()`, which only transform data) to untouched fields without executing validation predicates — so those transforms must be pure. Custom rules added with `enforce.extend` are treated as validators by default and are never executed speculatively. If a custom rule is really a parser — a pure transformation that cannot fail on its own — register it explicitly so selective runs can apply it:
+
+```ts
+enforce.extend(
+  {
+    normalizeId: (value: string) => ({
+      pass: true,
+      type: value.trim().toUpperCase(),
+    }),
+  },
+  { parsers: ['normalizeId'] },
+);
+```
+
+Unlisted custom rules keep validator treatment: they run only when their own field is in the affected set, never as mapping helpers. See [Input vs output types with parsers](https://vestjs.dev/docs/writing_your_suite/schema_validation#input-vs-output-types-with-parsers) for the full typing story.
+
+## Dependencies Are Not Automatically Transitive
+
+```text
+A → B
+B → C
+```
+
+where `A → B` means "target `B` may be stale when `A` changes."
+
+If `A` changes, `B` must be reconsidered. `C` does not — `B`'s value didn't change. Expansion is on changed values, not transitive closure. If `C` also depends on `A`, declare it explicitly. Revalidation does not imply mutation: rerunning `B` because `A` changed does not mean `B` changed, so `B`'s dependents remain valid.
+
+## Circular Dependencies
+
+Cycles are valid.
+
+```ts
+const schema = enforce.shape({
+  startDate: enforce.isString().dependsOn($ => $.endDate),
+  endDate: enforce.isString().dependsOn($ => $.startDate),
+});
+```
+
+Changing `startDate` invalidates `endDate` and vice versa. No loop occurs because dependencies describe invalidation, not imperative calls.
+
+> **Deferred to v2 — `effect: 'revalidate'`**
+>
+> V1: only `effect: 'invalidate'` ("previous result is stale") is supported.
+> Supplying `effect: 'revalidate'` (immediately rerun vs stale) is **deferred to v2** and will throw with `err.message` exactly `effect:'revalidate' deferred to v2 — only 'invalidate' supported in V1`.
+> The assertion is at composition time (`enforce` + `lazy.ts`):
+>
+> ```ts
+> /** @deferred v2 — effect:'revalidate' deferred, only 'invalidate' supported in V1 */
+> if (effect !== 'invalidate')
+>   throw new Error(
+>     `effect:'${effect}' deferred to v2 — only 'invalidate' supported in V1`,
+>   );
+> ```
+>
+> Future `revalidate` vs `invalidate` distinction (immediately rerun vs stale) is deferred.
+>
+> `revalidates()` was removed before V1; use `.dependsOn()` for the same edge.
+
+## Introspection
+
+Dependency information is part of the Enforce schema and inspectable without running a suite:
+
+```ts
+schema.describe();
+```
+
+Serializable form:
+
+```json
+{
+  "dependencies": [
+    {
+      "target": [{ "type": "property", "key": "confirmPassword" }],
+      "sources": [[{ "type": "property", "key": "password" }]]
+    }
+  ],
+  "relationships": [
+    {
+      "source": [{ "type": "property", "key": "password" }],
+      "target": [{ "type": "property", "key": "confirmPassword" }],
+      "effect": "invalidate"
+    }
+  ]
+}
+```
+
+Array item (the item binding is `<arrayKey>.$item`):
+
+```json
+{
+  "target": [
+    { "type": "property", "key": "travelers" },
+    { "type": "item", "binding": "travelers.$item" },
+    { "type": "property", "key": "passportNumber" }
+  ],
+  "sources": [
+    [
+      { "type": "property", "key": "travelers" },
+      { "type": "item", "binding": "travelers.$item" },
+      { "type": "property", "key": "passportCountry" }
+    ]
+  ]
+}
+```
+
+The representation is:
+
+```ts
+type PropertySegment = { type: 'property'; key: PropertyKey };
+type ItemSegment = { type: 'item'; binding: string };
+type SchemaPath = readonly (PropertySegment | ItemSegment)[];
+interface SchemaRelationship {
+  source: SchemaPath;
+  target: SchemaPath;
+  effect: 'invalidate';
+  metadata?: { reason?: string };
+}
+interface SchemaDependency {
+  target: SchemaPath;
+  sources: readonly SchemaPath[];
+}
+```
+
+Consumable by Vest, framework adapters, devtools, docs, and agents. Relationships stay out of `~standard`.
+
+## What Dependencies Intentionally Do Not Do
+
+- Does not execute anything or impose validation order — purely invalidation metadata.
+- Does not inspect suite closures.
+- Does not make arbitrary JS declarative.
+- Does not replicate `test()`/`group()`/`warn()`/`only()`/`skipWhen`/async inside Enforce.
+- Does not require deps for every cross-field test.
+- Does not change Standard Schema.
+- Does not change `only()` — `changed()` is separate.
+
+## Interaction with Other Features
+
+Schema Relationships are **metadata + `suite.changed()` in V1**. `describe()` records the graph without running a suite; `suite.changed()` consumes it to select affected tests.
+
+| Feature                                     | Effect on `describe()`                                                                                                                  | Effect on suite `run()` / `suite.changed()` in V1                                                                                                                                   |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `skipWhen` (retains)                        | records                                                                                                                                 | `run()` unchanged; `changed()` treats dependent as candidate but Vest skips if `skipWhen` hides it                                                                                  |
+| `omitWhen` (removes)                        | records                                                                                                                                 | `run()` unchanged; `changed()` still records edge but omitted test never runs                                                                                                       |
+| `optional('field')`                         | records                                                                                                                                 | `run()` unchanged — edge exists even if optional field is absent; `changed()` includes it when source changes                                                                       |
+| `include().when()`                          | **does not record** — `include` is a Vest suite modifier, not an n4s schema relationship; `schema.describe()` has no `include` metadata | `changed()` remains the interaction-aware operation                                                                                                                                 |
+| `only` / `skip` / `onlyGroup` / `skipGroup` | records (expansion ignores focus: `only('password')` does not auto-include `confirmPassword`)                                           | `changed('password')` does include it; `only` merges into the affected set; synthesized failures are top-level tests, so field focus and the documented top-level group rules apply |
+| `group` / `each`                            | records (rebased)                                                                                                                       | `run()` unchanged; `changed()` respects rebasing and same-item scoping; keyed `each` results follow item identity across reordered array positions                                  |
+| `warn`                                      | records                                                                                                                                 | `run()` unchanged; `changed()` includes warn dependents as normal tests                                                                                                             |
+
+V1 ships `suite.changed(field).run(data)` with dependency-aware affected-set expansion (flat, nested, reusable, array same-item, and root→array fan-out via run-time `data`). Abortable changed runs are not part of the V1 API.
+
+## Related
+
+- [Schema Validation](https://vestjs.dev/docs/writing_your_suite/schema_validation) — passing a schema to `create()`, parsed data, and registering custom `parsers`.
+- [Focused Updates](https://vestjs.dev/docs/writing_your_suite/focused_updates) — the `only()` / `skip()` / `focus()` semantics that `changed()` builds on.
+- [Handling User Interaction](https://vestjs.dev/docs/writing_your_suite/dirty_checking) — the `onBlur` / `onChange` patterns where `changed()` fits.
+- [Creating Custom Rules](https://vestjs.dev/docs/enforce/creating_custom_rules) — `enforce.extend`, including parser-style rules.
+- [Data Parsers](https://vestjs.dev/docs/enforce/builtin-enforce-plugins/data_parsers) — the built-in parser steps selective runs can apply safely.
+
+
 # Schema Validation
 
 Vest introduces optional schema validation using `n4s` (enforce).
@@ -9509,11 +10065,50 @@ result.value; // typed as { age: number; name: string }
 
 The first rule in a chain determines the input type, and the last parser in the chain determines the output type. This means you never need `@ts-expect-error` or `as any` for valid parser coercion inputs.
 
+Focused runs still pass the complete parsed output to the suite callback. On a
+first focused run, Vest applies parser steps to untouched fields without
+running their validation predicates. Parser transforms should therefore be
+pure and must return their declared output type even when their `pass` verdict
+is false. The mapped output keeps the callback type sound; an untouched
+parser's failure does not become part of that focused run's validation result.
+If a custom `enforce.extend` rule is a parser, register it explicitly so
+focused mapping can recognize it:
+
+```typescript
+declare global {
+  namespace n4s {
+    interface EnforceMatchers {
+      normalizeId: (value: string) => { pass: boolean; type: string };
+    }
+  }
+}
+
+enforce.extend(
+  {
+    normalizeId: (value: string) => ({
+      pass: true,
+      type: value.trim().toUpperCase(),
+    }),
+  },
+  { parsers: ['normalizeId'] },
+);
+```
+
+Custom extension rules are treated as validators unless they are listed in
+`parsers`. The per-run `result.run.data.parsed` value still reflects only the
+schema work performed by that run; the callback receives the complete mapped
+output assembled for the suite.
+
+When a focused path enters an array, Vest refreshes that containing array from
+the current input. Array positions are not identities, so this prevents an
+insert, removal, or reorder from combining the current item with a stale array
+layout retained from an earlier run.
+
 ### What becomes typed from the schema
 
 With `create(callback, schema)`, TypeScript narrows:
 
-- callback data (`data`) to the schema input shape.
+- callback data (`data`) to the schema output shape.
 - `suite.run(...)` / `suite.runStatic(...)` first argument to the schema input shape.
 - the Standard Schema `~standard.validate(...)` input and output types.
 - field-oriented happy-path APIs (`test`, `optional`, `include`) to schema keys.
@@ -9538,6 +10133,7 @@ When using `create(callback, schema)`, the current TypeScript standard is:
   - `suite.remove(fieldName)`
   - `suite.resetField(fieldName)`
   - `suite.only(fieldName)`
+  - `suite.changed(fieldName)` (single name, array, or `undefined`; see [Schema Relationships](https://vestjs.dev/docs/writing_your_suite/schema_relationships#suitechanged-reference))
   - `suite.afterField(fieldName, callback)`
   - `only(fieldName)` / `skip(fieldName)` hooks
 
@@ -9566,6 +10162,8 @@ suite.only('username').run({
 });
 ```
 
+For interaction-driven revalidation that also refreshes dependent fields, use `suite.changed()` instead — see [Schema Relationships](https://vestjs.dev/docs/writing_your_suite/schema_relationships).
+
 :::
 
 ## Schema Types
@@ -9582,7 +10180,7 @@ The suite result includes typed properties for accessing validated and parsed da
 - `result.value` — The parsed output when the suite is valid. Typed as the schema's output type. `undefined` when invalid.
 - `result.types.input` — Carries the schema's input type for static analysis. At runtime, holds the parsed output value.
 - `result.types.output` — Carries the schema's output type. At runtime, holds the parsed output value.
-- `result.run.data.raw` — The current run data passed into the suite callback (parsed when schema validation succeeds; original input when it fails).
+- `result.run.data.raw` — The current run's parsed chunk when schema validation succeeds, or its original input when validation fails. A focused callback may receive a fuller retained mapped output than this per-run metadata.
 - `result.run.data.parsed` — Parsed data for the current run.
 
 ```typescript

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -84,6 +84,7 @@ Vest composes with schema validators and form managers; these categories are not
 - [Handling Suite Completion](https://vestjs.dev/docs/writing_your_suite/handling_completion)
 - [conditionally omit tests from the suite](https://vestjs.dev/docs/writing_your_suite/including_and_excluding/omitWhen)
 - [Optional fields](https://vestjs.dev/docs/writing_your_suite/optional_fields)
+- [Schema Relationships](https://vestjs.dev/docs/writing_your_suite/schema_relationships)
 - [Execution Modes](https://vestjs.dev/docs/writing_your_suite/execution_modes)
 - [Linking fields together](https://vestjs.dev/docs/writing_your_suite/including_and_excluding/include)
 - [Handling User Interaction](https://vestjs.dev/docs/writing_your_suite/dirty_checking)


### PR DESCRIPTION
Clean-history replacement for #1321.

This branch preserves the ready implementation while rebuilding it from the current `latest` base as a dependency-ordered, package-scoped stack:

1. `context`: exception-safe parent-context restoration
2. `n4s`: relationship model primitives
3. `n4s`: dependency composition and introspection
4. `n4s`: selective schema-path execution and internal boundary
5. `vest`: keyed reconciliation after collection reorders
6. `vest`: immutable schema-data cloning
7. `vest`: nested schema field selectors
8. `vest`: dependency-aware `suite.changed()` execution and acceptance coverage
9. `vest`: relationship benchmarks and design fixture
10. documentation
11. repository typecheck gate

`vest-utils` and `vestjs-runtime` remain unchanged because the ready diff requires no changes in those layers; no placeholder churn was introduced.

Equivalence and validation:

- The reconstructed final tree is exactly the recorded ready merge result on current `latest`: `c0f3e5fbd21ab83259c3f3c3538881c2e8deaa63`.
- Production build passed.
- 317 test files and 2,959 tests passed.
- Typechecking reported no errors.
- Every source commit passed the repository pre-commit ESLint and formatting hooks.
- `git diff --check` passed.

The implementation and behavior are intentionally unchanged from the reviewed head of #1321; this PR changes the review shape and commit topology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dependency-aware `suite.changed()` validation for nested, array, record, and cross-field relationships.
  * Added schema relationship introspection through `describe()` and new metadata types.
  * Improved focused-run parsing while preserving complete mapped callback data.
  * Added dotted field-path support for suite selectors.
  * Strengthened type inference for schemas, custom rules, composition, and `pick`/`omit`.
  * Improved handling of superseded stateful runs.

* **Bug Fixes**
  * Context values now restore correctly when nested callbacks throw.
  * Keyed repeated tests retain their current field identity after reordering.

* **Documentation**
  * Expanded guidance for schema relationships, focused updates, parser rules, serialization, and async validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->