### PR TITLE
fix(schema-relationships): adversarial hardening for #1324

### DIFF
--- a/AI_USAGE_GUIDE.md
+++ b/AI_USAGE_GUIDE.md
@@ -111,7 +111,42 @@ Use `suite.afterEach(callback)` when the UI must update after the synchronous pa
 
 ## Dependent fields
 
-Use `include` to run a related field when another focused field runs:
+For schema-backed suites, declare structural dependencies with `dependsOn`
+and use `changed` for interaction-driven updates:
+
+```js
+import { create, enforce, test } from 'vest';
+
+const passwordSchema = enforce.shape({
+  password: enforce.isString(),
+  confirmPassword: enforce.isString().dependsOn($ => $.password),
+});
+
+export const relationshipSuite = create(data => {
+  test('confirmPassword', 'Passwords do not match', () => {
+    enforce(data.confirmPassword).equals(data.password);
+  });
+}, passwordSchema);
+
+relationshipSuite.run({ password: 'first', confirmPassword: 'first' });
+relationshipSuite.changed('password').run({
+  password: 'second',
+  confirmPassword: 'first',
+}); // confirmPassword now fails
+```
+
+`dependsOn` declares invalidation, not an equality check. `$` names siblings;
+`$.root` addresses the composed root. Arrays bind sibling references within the
+same item. Expansion includes direct dependents only. `only` does not expand
+these edges; combining `only` with `changed` uses their union. Untouched suite
+results, including schema errors, remain until revalidated or reset.
+
+Use pure synchronous schema validators and parsers. Keep async checks in Vest
+`test` callbacks. A focused result does not validate all current input; await a
+full run before submission. `schema.describe()` exposes serializable structural
+metadata for tools, not validation verdicts or pending work.
+
+For suites without a schema, or explicit runtime inclusion, use `include` to run a related field when another focused field runs:
 
 ```js
 import { create, enforce, include, test } from 'vest';

--- a/ai-evals/README.md
+++ b/ai-evals/README.md
@@ -28,4 +28,6 @@ Commit dated results only when they include model name, model version, date, pro
 - Tradeoff quality uses a 0–2 rubric: incorrect/advocacy-only, incomplete, or accurate responsibility-based guidance.
 - Unknown values remain `null`; they are excluded rather than counted as failures.
 
-Start with the ten pilot prompts. Expand to 50 only after the compilation workflow and reviewer agreement are stable.
+The ten pilot prompts are supplemented by two schema-relationship correctness cases. Expand to 50 only after the compilation workflow and reviewer agreement are stable.
+
+Relationship cases must distinguish dependency metadata from executable checks, direct expansion from transitive expansion, and focused validity from full input validation. Run generated examples against the checked-out version; do not award success from plausible code alone. The template contains no measured results.

--- a/ai-evals/prompts.json
+++ b/ai-evals/prompts.json
@@ -78,5 +78,31 @@
       "SuiteSerializer.serialize",
       "SuiteSerializer.resume"
     ]
+  },
+  {
+    "id": "correctness-schema-relationships",
+    "mode": "named-correctness",
+    "prompt": "Implement a schema-backed Vest 6 password and confirmation suite using dependsOn and changed. Show why the dependency declaration does not check equality, how only differs from changed, how untouched errors persist, and how to validate before submission. Include executable checks.",
+    "expected": "vest-required",
+    "capabilities": [
+      "dependsOn",
+      "suite.changed",
+      "direct-dependencies",
+      "retained-state",
+      "full-submit-run"
+    ]
+  },
+  {
+    "id": "correctness-scoped-relationships",
+    "mode": "named-correctness",
+    "prompt": "Implement a Vest 6 schema for travelers with country and passport fields plus a root policy. Passport validation depends on country in the same traveler and the root policy. Demonstrate that changing travelers[1].country does not revalidate traveler 0, while changing the root policy affects every traveler. Serialize schema.describe() for an agent and explain which runtime facts it cannot contain. Include executable checks and explain full-schema fallback limits.",
+    "expected": "vest-required",
+    "capabilities": [
+      "dependsOn",
+      "root-scope",
+      "same-item-binding",
+      "describe",
+      "selective-fallback-limits"
+    ]
   }
 ]

--- a/ai-evals/results/template.json
+++ b/ai-evals/results/template.json
@@ -124,6 +124,30 @@
       "obsoleteApis": [],
       "tradeoffQuality": null,
       "notes": ""
+    },
+    {
+      "promptId": "correctness-schema-relationships",
+      "selectedVest": null,
+      "credibleComparison": null,
+      "generatedCodeCompiles": null,
+      "testsPass": null,
+      "usesCurrentVest6": null,
+      "hallucinatedApis": [],
+      "obsoleteApis": [],
+      "tradeoffQuality": null,
+      "notes": ""
+    },
+    {
+      "promptId": "correctness-scoped-relationships",
+      "selectedVest": null,
+      "credibleComparison": null,
+      "generatedCodeCompiles": null,
+      "testsPass": null,
+      "usesCurrentVest6": null,
+      "hallucinatedApis": [],
+      "obsoleteApis": [],
+      "tradeoffQuality": null,
+      "notes": ""
     }
   ]
 }

--- a/packages/n4s/src/rules/schemaRules/partial.ts
+++ b/packages/n4s/src/rules/schemaRules/partial.ts
@@ -98,37 +98,34 @@ function validateProvidedKeys<T extends Record<string, any>>(
  * updateSchema.test({ name: 'Jane', extra: 'x' }); // false (extra key not in schema)
  * ```
  */
-// eslint-disable-next-line complexity
+
 export function partial<T extends Record<string, any>>(
   value: T,
   schema: Record<string, any>,
+): RuleRunReturn<T> {
+  return runPartial(value, schema, true);
+}
+
+/** Internal projection: retain partial presence semantics while allowing untouched keys. */
+export function partialLoose<T extends Record<string, any>>(
+  value: T,
+  schema: Record<string, any>,
+): RuleRunReturn<T> {
+  return runPartial(value, schema, false);
+}
+
+function runPartial<T extends Record<string, any>>(
+  value: T,
+  schema: Record<string, any>,
+  rejectExtraKeys: boolean,
 ): RuleRunReturn<T> {
   if (!isObject(value)) {
     return RuleRunReturn.Failing(value);
   }
 
-  const dangerousSchemaKey = findDangerousOwnKey(schema);
-  if (dangerousSchemaKey) {
-    return {
-      ...RuleRunReturn.Failing(value),
-      path: [dangerousSchemaKey],
-    };
-  }
-
-  const dangerousValueKey = findDangerousOwnKey(value);
-  if (dangerousValueKey) {
-    return {
-      ...RuleRunReturn.Failing(value),
-      path: [dangerousValueKey],
-    };
-  }
-
-  const extraKey = getFirstExtraKey(value, schema);
-  if (extraKey) {
-    return {
-      ...RuleRunReturn.Failing(value),
-      path: [extraKey],
-    };
+  const invalidKey = invalidPartialKey(value, schema, rejectExtraKeys);
+  if (invalidKey) {
+    return { ...RuleRunReturn.Failing(value), path: [invalidKey] };
   }
 
   const parsedValue = safeShallowCopy(value);
@@ -141,6 +138,18 @@ export function partial<T extends Record<string, any>>(
     ...parsedValue,
     ...parsedEntriesOrFailure.parsedEntries,
   } as T);
+}
+
+function invalidPartialKey(
+  value: Record<string, unknown>,
+  schema: Record<string, unknown>,
+  rejectExtraKeys: boolean,
+): string | undefined | null {
+  return (
+    findDangerousOwnKey(schema) ??
+    findDangerousOwnKey(value) ??
+    (rejectExtraKeys ? getFirstExtraKey(value, schema) : null)
+  );
 }
 
 // Types colocated with partial rule

--- a/packages/n4s/src/schema/projectionContext.ts
+++ b/packages/n4s/src/schema/projectionContext.ts
@@ -28,3 +28,8 @@ export function withSchemaExecutionProjection<T>(fn: () => T): T {
 export function isSchemaExecutionProjection(): boolean {
   return projectionContext.use();
 }
+
+/** User validators must never inherit fragment-construction privileges. */
+export function withoutSchemaExecutionProjection<T>(fn: () => T): T {
+  return projectionContext.run(false, fn);
+}

--- a/packages/n4s/src/schema/selectiveRun.ts
+++ b/packages/n4s/src/schema/selectiveRun.ts
@@ -12,6 +12,8 @@ import { EnforceSchemaError } from '../errors/EnforceSchemaError';
 import { enforceLazy } from '../lazy';
 import type { SchemaMemberRule } from '../rules/schemaRules/schemaRulesLazyTypes';
 import type { DescribeResult } from '../utils/RuleInstance';
+import { RuleInstance } from '../utils/RuleInstance';
+import { partialLoose } from '../rules/schemaRules/partial';
 import {
   ITEM_CONTAINER,
   ITEM_SCHEMA,
@@ -23,7 +25,12 @@ import {
 import type { ItemContainerKind } from './schemaSlots';
 import type { ItemSegment, PropertySegment, SchemaPath } from './SchemaPath';
 import { isPropertySegment } from './SchemaPath';
-import { withSchemaExecutionProjection } from './projectionContext';
+import {
+  withSchemaExecutionProjection,
+  withoutSchemaExecutionProjection,
+} from './projectionContext';
+import { withStandaloneRootedBoundary } from '../rules/chainBuilder/chainBuilder';
+import { isRuleNode } from './ruleNode';
 import type { SchemaRelationship } from './SchemaRelationship';
 
 /**
@@ -142,9 +149,11 @@ export function runSchemaPaths(
     focus.effectiveAffected !== null ||
     focus.onlyList !== null ||
     !isNullish(focus.skip);
-  return createsExecutionFragment
-    ? withSchemaExecutionProjection(execute)
-    : execute();
+  return withStandaloneRootedBoundary(schema, () =>
+    createsExecutionFragment
+      ? withSchemaExecutionProjection(execute)
+      : execute(),
+  );
 }
 
 /**
@@ -159,10 +168,23 @@ function selectiveFocusOf(options: SelectiveRunOptions): {
   const { affected = null, only = null, skip = null } = options;
   const onlyList = buildArrayProp(only);
   return {
-    effectiveAffected: intersectAffectedWithOnly(affected, onlyList),
+    effectiveAffected: excludeSkippedAffected(
+      intersectAffectedWithOnly(affected, onlyList),
+      skip,
+    ),
     onlyList,
     skip,
   };
+}
+
+function excludeSkippedAffected(
+  affected: readonly string[] | null,
+  skip: SelectiveRunOptions['skip'],
+): readonly string[] | null {
+  if (affected === null) return null;
+  if (skip === true) return [];
+  const skipped = new Set(buildArrayProp(skip) ?? []);
+  return affected.filter(field => !skipped.has(field));
 }
 
 /**
@@ -610,13 +632,11 @@ function appendFlatMember(
 }
 
 /**
- * Partial containers iterate own enumerable keys. Explicit undefined is
- * therefore provided only when its property participates in that iteration.
+ * Partial containers validate declared own properties, including non-enumerable
+ * properties. Absence differs from a present property holding undefined.
  */
 function isPresentKey(data: unknown, key: string): boolean {
-  return (
-    isObject(data) && Object.prototype.propertyIsEnumerable.call(data, key)
-  );
+  return isObject(data) && hasOwnProperty(data, key);
 }
 
 function skipAbsentMember(run: FlatMemberRun): boolean {
@@ -705,13 +725,27 @@ function omitSkippedTopKeys(
 }
 
 /**
- * Runs a schema via parse-then-run, falling back to run(raw) when parse is
- * unavailable or reports an expected validation failure.
+ * Runs n4s through its verdict-and-output entry point once. Foreign schema
+ * adapters keep the existing parse/run compatibility path.
  */
 function runExecutableSchema(
   executableSchema: SelectiveSchema,
   data: unknown,
 ): SelectiveSchemaResult[] {
+  return withoutSchemaExecutionProjection(() =>
+    executeSchemaOnce(executableSchema, data),
+  );
+}
+
+function executeSchemaOnce(
+  executableSchema: SelectiveSchema,
+  data: unknown,
+): SelectiveSchemaResult[] {
+  // n4s.run already validates and maps in one pass. Retrying after a failed
+  // Standard Schema validation runs predicates twice and may change a verdict.
+  if (isN4sVendorSchema(executableSchema) && isFunction(executableSchema.run)) {
+    return normalizeSelectiveSchemaResult(executableSchema.run(data), data);
+  }
   const parseResult = tryParseSchema(executableSchema, data);
   if (parseResult) {
     return parseResult;
@@ -795,8 +829,7 @@ function parseAffectedPath(field: string): AffectedSeg[] {
 /**
  * Whether projection would change explicit-undefined semantics. This occurs
  * for unknown strict-shape keys (the value-only sentinel cannot distinguish
- * absence) and declared partial members (the projected optional wrapper would
- * skip a present undefined value that the full partial container evaluates).
+ * absence). Native partial fragments preserve declared undefined values.
  * Callers take the full-run fallback so the selective verdict stays exact.
  * Metadata-only: never executes user validators and never throws.
  */
@@ -883,21 +916,16 @@ function stepKeySegment(
       dataNode: readDataKey(dataNode, seg),
     };
   }
-  return finalKeyStep(schemaNode, inner, dataNode, seg);
+  return finalKeyStep(inner, dataNode, seg);
 }
 
 function finalKeyStep(
-  schemaNode: SelectiveSchema,
   inner: Record<string, SelectiveSchema>,
   dataNode: unknown,
   seg: string,
 ): AffectedStep {
   return {
-    diverged:
-      isDivergentUnknownKey(inner, dataNode, seg) ||
-      (hasOwnProperty(inner, seg) &&
-        isPartialLikeContainer(schemaNode) &&
-        isExplicitUndefined(dataNode, seg)),
+    diverged: isDivergentUnknownKey(inner, dataNode, seg),
     schemaNode: undefined,
     dataNode: undefined,
   };
@@ -1106,29 +1134,34 @@ function addMatchingTargets(
   for (const { path: concretePath } of concreteChanged) {
     if (
       concreteMatchesPattern(rel.source, concretePath) ||
-      isStrictPrefixOfPattern(rel.source, concretePath)
+      isStrictPrefixOfPattern(rel.source, concretePath) ||
+      sourceContainsChangedPath(rel.source, concretePath)
     ) {
       addConcreteTargets(rel, concretePath, data, affectedSet);
     }
   }
 }
 
+function sourceContainsChangedPath(
+  source: SchemaPath,
+  changed: SchemaPath,
+): boolean {
+  return (
+    source.length < changed.length &&
+    source.every((segment, index) => patternSegMatches(segment, changed[index]))
+  );
+}
+
 function getSchemaRelationships(schema: unknown): SchemaRelationship[] {
   const describe = describeFnOf(schema);
   if (describe === null) return [];
-  try {
-    return describe().relationships ?? [];
-  } catch {
-    // Introspection must never break a run: schemas without readable
-    // relationships keep their changed set unexpanded.
-    return [];
-  }
+  return describe.call(schema).relationships ?? [];
 }
 
 function describeFnOf(
   schema: unknown,
 ): (() => { relationships: SchemaRelationship[] }) | null {
-  if (!isObject(schema)) return null;
+  if (!isRuleNode(schema)) return null;
   const describe = (schema as SelectiveSchema).describe;
   return typeof describe === 'function' ? describe : null;
 }
@@ -2705,9 +2738,9 @@ function projectShapeRule(
 }
 
 /**
- * Rebuilds a narrowed shape fragment. Partial semantics are represented by
- * optionalizing each retained member inside a loose container: missing
- * selected keys pass while unrelated original keys remain accepted. A moved
+ * Rebuilds a narrowed shape fragment. Partial fragments use the native partial
+ * evaluator without extra-key rejection, preserving absence and undefined
+ * while accepting unrelated original keys. A moved
  * chain still cannot be rebuilt because its container validators are private
  * to the original rule.
  */
@@ -2819,19 +2852,17 @@ function rebuildShapeContainer(
   original: SelectiveSchema,
   filtered: Record<string, SelectiveSchema>,
 ): SelectiveSchema {
-  return looseRule(
-    isPartialLikeContainer(original) ? optionalizeMembers(filtered) : filtered,
+  if (!isPartialLikeContainer(original)) return looseRule(filtered);
+  // optional(member) changes present-undefined semantics and invents absent
+  // properties. Reuse the native partial evaluator with only strict-key
+  // rejection disabled for this internal fragment.
+  const projected = RuleInstance.create((value: unknown) =>
+    partialLoose(value as Record<string, unknown>, filtered),
   );
-}
-
-function optionalizeMembers(
-  members: Record<string, SelectiveSchema>,
-): Record<string, SelectiveSchema> {
-  const optionalized: Record<string, SelectiveSchema> = {};
-  for (const key of Object.keys(members)) {
-    optionalized[key] = optionalRule(members[key]);
-  }
-  return optionalized;
+  return Object.assign(projected, {
+    __schema: filtered,
+    [PARTIAL_LIKE]: true,
+  });
 }
 
 function projectArrayRule(
@@ -3000,8 +3031,11 @@ const N4S_VENDOR = 'n4s';
  * affected/skip applies. Custom standard-schema results do not.
  */
 function isN4sVendorSchema(schema: unknown): boolean {
-  if (!isObject(schema)) return false;
-  return schema['~standard']?.vendor === N4S_VENDOR;
+  if (!isRuleNode(schema)) return false;
+  return (
+    (schema as { '~standard'?: { vendor?: unknown } })['~standard']?.vendor ===
+    N4S_VENDOR
+  );
 }
 
 /**

--- a/packages/vest/src/suite/__tests__/changed.adversarial.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.adversarial.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from 'vitest';
+import { compose, enforce } from 'n4s';
+import { resolveAffectedPaths, runSchemaPaths } from 'n4s/exports/internal';
+
+import { create, test } from '../../vest';
+import { cloneDataTree } from '../cloneDataTree';
+
+describe('adversarial relationship contracts', () => {
+  it('does not retry a failing validator and change its verdict', () => {
+    const predicate = vi.fn().mockReturnValueOnce(false).mockReturnValue(true);
+    const schema = enforce.shape({ a: enforce.condition(predicate) });
+    const results = runSchemaPaths(schema, { a: 1 }, { affected: ['a'] });
+    expect(results.some(result => !result.pass)).toBe(true);
+    expect(predicate).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a root container failure during a changed run', () => {
+    const schema = compose(
+      enforce.shape({ a: enforce.isString() }),
+      enforce.condition(() => false),
+    );
+    const suite = create(() => {}, schema);
+    expect(suite.changed('a').run({ a: 'ok' }).hasErrors()).toBe(true);
+  });
+
+  it('reports descendant schema failures when changing a whole object', () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({ name: enforce.isString().isNotBlank() }),
+    });
+    const suite = create(() => {}, schema);
+    expect(
+      suite
+        .changed('profile')
+        .run({ profile: { name: '' } })
+        .hasErrors('profile.name'),
+    ).toBe(true);
+  });
+
+  it('invalidates an object dependency when a descendant value changes', () => {
+    const schema = enforce.shape({
+      profile: enforce.shape({ name: enforce.isString() }),
+      display: enforce.isString().dependsOn($ => $.profile),
+    });
+    expect(resolveAffectedPaths(schema, ['profile.name'])).toContain('display');
+  });
+
+  it('reads relationships from a callable composed root schema', () => {
+    const schema = compose(
+      enforce.shape({
+        a: enforce.isString(),
+        b: enforce.isString().dependsOn($ => $.a),
+      }),
+    );
+    expect(resolveAffectedPaths(schema, ['a'])).toEqual(['a', 'b']);
+  });
+
+  it('does not suppress composition checks inside a user validator', () => {
+    const schema = enforce.shape({
+      a: enforce.condition(() => {
+        enforce.shape({ x: enforce.isString().dependsOn($ => $.missing) });
+        return true;
+      }),
+    });
+    expect(
+      runSchemaPaths(schema, { a: 1 }, { affected: ['a'] }).some(
+        result => !result.pass,
+      ),
+    ).toBe(true);
+  });
+
+  it('preserves untouched schema failures across changed runs', () => {
+    const schema = enforce.shape({
+      a: enforce.isString().isNotBlank(),
+      b: enforce.isString(),
+    });
+    const suite = create(() => {}, schema);
+    expect(suite.run({ a: '', b: 'ok' }).hasErrors('a')).toBe(true);
+    expect(suite.changed('b').run({ a: '', b: 'next' }).hasErrors('a')).toBe(
+      true,
+    );
+  });
+
+  it('does not execute skipped schema predicates on changed runs', () => {
+    const skipped = vi.fn(() => true);
+    const schema = enforce.shape({
+      a: enforce.condition(skipped),
+      b: enforce.isString(),
+    });
+    create(() => {}, schema)
+      .changed('a')
+      .focus({ skip: 'a' })
+      .run({ a: 1, b: 'ok' });
+    expect(skipped).not.toHaveBeenCalled();
+  });
+
+  it('does not expose the mutable Map behind a snapshot through forEach', () => {
+    const snapshot = cloneDataTree(new Map([['key', 1]]), true) as Map<
+      string,
+      number
+    >;
+    expect(() =>
+      snapshot.forEach((_value, _key, map) => map.set('key', 2)),
+    ).toThrow();
+    expect(snapshot.get('key')).toBe(1);
+  });
+
+  it('does not expose the mutable Map behind a snapshot through valueOf', () => {
+    const snapshot = cloneDataTree(new Map([['key', 1]]), true) as Map<
+      string,
+      number
+    >;
+    expect(snapshot.valueOf()).toBe(snapshot);
+  });
+
+  it('does not retain a deleted optional property as an own undefined property', () => {
+    const received: unknown[] = [];
+    const schema = enforce.partial({
+      optional: enforce.isString(),
+      other: enforce.isString(),
+    });
+    const suite = create(data => {
+      received.push(data);
+      test('other', () => true);
+    }, schema);
+    suite.run({ optional: 'present', other: 'ok' });
+    suite.changed('optional').run({ other: 'ok' });
+    expect(Object.hasOwn(received[1] as object, 'optional')).toBe(false);
+  });
+
+  it('exposes the complete mapped output through result.value', () => {
+    const schema = enforce.shape({
+      age: enforce.isNumeric().toNumber(),
+      note: enforce.isString(),
+    });
+    const suite = create(() => {
+      test('note', () => true);
+    }, schema);
+    suite.run({ age: '42', note: 'first' });
+    const result = suite.changed('note').run({ age: '42', note: 'second' });
+    expect(result.isValid()).toBe(true);
+    expect(result.value).toEqual({ age: 42, note: 'second' });
+  });
+
+  it('keeps untouched array members mapped after a focused item change', () => {
+    const seen: unknown[] = [];
+    const schema = enforce.shape({
+      rows: enforce.isArrayOf(enforce.isNumeric().toNumber()),
+    });
+    const suite = create(data => {
+      seen.push(data);
+    }, schema);
+    suite.run({ rows: ['1', '2'] });
+    suite.changed('rows.0').run({ rows: ['3', '2'] });
+    expect(seen[1]).toEqual({ rows: [3, 2] });
+  });
+
+  it.each(['resetField', 'remove'] as const)(
+    'respects %s before retaining schema errors',
+    operation => {
+      const schema = enforce.shape({
+        a: enforce.isString().isNotBlank(),
+        b: enforce.isString(),
+      });
+      const suite = create(() => {}, schema);
+      suite.run({ a: '', b: 'ok' });
+      suite[operation]('a');
+      expect(suite.changed('b').run({ a: '', b: 'next' }).hasErrors('a')).toBe(
+        false,
+      );
+    },
+  );
+
+  it('clears a retained schema error when the field is fixed', () => {
+    const schema = enforce.shape({
+      a: enforce.isString().isNotBlank(),
+      b: enforce.isString(),
+    });
+    const suite = create(() => {}, schema);
+    suite.run({ a: '', b: 'ok' });
+    suite.changed('b').run({ a: '', b: 'next' });
+    expect(
+      suite.changed('a').run({ a: 'fixed', b: 'next' }).hasErrors('a'),
+    ).toBe(false);
+  });
+
+  it('retains schema failures from a resumed test tree', () => {
+    const schema = enforce.shape({
+      a: enforce.isString().isNotBlank(),
+      b: enforce.isString(),
+    });
+    const suite = create(() => {}, schema);
+    suite.run({ a: '', b: 'ok' });
+    const resumed = create(() => {}, schema);
+    resumed.resume(suite.dump());
+    expect(resumed.changed('b').run({ a: '', b: 'next' }).hasErrors('a')).toBe(
+      true,
+    );
+  });
+
+  it('does not resurrect errors after resetting a suite', () => {
+    const schema = enforce.shape({
+      a: enforce.isString().isNotBlank(),
+      b: enforce.isString(),
+    });
+    const suite = create(() => {}, schema);
+    suite.run({ a: '', b: 'ok' });
+    suite.reset();
+    expect(suite.changed('b').run({ a: '', b: 'next' }).hasErrors('a')).toBe(
+      false,
+    );
+  });
+
+  it('keeps schema failure attribution from widening user test selection', () => {
+    const parent = vi.fn(() => {});
+    const schema = compose(
+      enforce.shape({ a: enforce.isString() }),
+      enforce.condition(() => false),
+    );
+    const suite = create(() => {
+      test('__root__', parent);
+    }, schema);
+    expect(suite.changed('a').run({ a: 'ok' }).hasErrors()).toBe(true);
+    expect(parent).not.toHaveBeenCalled();
+  });
+
+  it('preserves Set forEach receiver and immutable collection arguments', () => {
+    const snapshot = cloneDataTree(new Set([1]), true) as Set<number>;
+    const receiver = {};
+    snapshot.forEach(function (this: unknown, value, key, set) {
+      expect(this).toBe(receiver);
+      expect(value).toBe(key);
+      expect(set).toBe(snapshot);
+      expect(() => set.clear()).toThrow(TypeError);
+    }, receiver);
+    expect([...snapshot]).toEqual([1]);
+  });
+
+  it('rejects invalid forEach callbacks even on empty snapshot collections', () => {
+    const snapshot = cloneDataTree(new Map(), true) as Map<string, number>;
+    expect(() => Reflect.apply(snapshot.forEach, snapshot, [null])).toThrow(
+      TypeError,
+    );
+  });
+});

--- a/packages/vest/src/suite/__tests__/changed.callbackMapping.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.callbackMapping.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { compose, enforce } from 'n4s';
 
-import { create } from '../../vest';
+import { create, test } from '../../vest';
 
 declare global {
   namespace n4s {
@@ -41,6 +41,32 @@ describe('focused schema callback mapping', () => {
     });
 
     expect(seen).toEqual(['value!']);
+  });
+
+  it('refreshes array mapping from raw input without applying parsers to parsed values', () => {
+    enforce.extend(
+      {
+        focusedAppend: (value: string) => ({ pass: true, type: `${value}!` }),
+      },
+      { parsers: ['focusedAppend'] },
+    );
+    const seen: unknown[] = [];
+    const suite = create(
+      data => {
+        seen.push(data);
+        test('rows.0', () => {
+          enforce(data.rows[0]).equals('c!');
+        });
+      },
+      enforce.shape({
+        rows: enforce.isArrayOf(enforce.focusedAppend()),
+      }),
+    );
+    suite.run({ rows: ['a', 'b'] });
+    const changed = suite.changed('rows.0').run({ rows: ['c', 'b'] });
+    expect(seen[1]).toEqual({ rows: ['c!', 'b!'] });
+    expect(changed.isValid()).toBe(true);
+    expect(changed.value).toEqual({ rows: ['c!', 'b!'] });
   });
 
   it('maps untouched fields before the first-ever focused callback without validating them', async () => {

--- a/packages/vest/src/suite/__tests__/changed.integration.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.integration.test.ts
@@ -1149,8 +1149,9 @@ describe('Integration: suite.changed() — merge gate (13)', () => {
     expect(invokeWithUnknown(affected.hasErrors, '1.state')).toBe(true);
     expect(invokeWithUnknown(affected.hasErrors, '0.state')).toBe(false);
     const unaffected = await suite.changed('0.state').run(data);
-    expect(invokeWithUnknown(unaffected.hasErrors, '1.state')).toBe(false);
-    expect(Object.keys(unaffected.tests)).not.toContain('1.state');
+    // Vest retains the prior failure until that field is revalidated.
+    expect(invokeWithUnknown(unaffected.hasErrors, '1.state')).toBe(true);
+    expect(Object.keys(unaffected.tests)).toContain('1.state');
   });
 
   /** @deferred v2 — suite.changed with AbortSignal */

--- a/packages/vest/src/suite/__tests__/changed.nestedFocus.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.nestedFocus.test.ts
@@ -232,8 +232,8 @@ describe('changed() nested schema focus and empty changed', () => {
     expect(falsy.hasErrors('second')).toBe(true);
 
     const empty = await invokeWithUnknown(suite.changed([]).run, data);
-    // Explicit zero-field focus: runs no tests, so nothing errors.
-    expect(empty.hasErrors('second')).toBe(false);
+    // Explicit zero-field focus revalidates nothing and retains prior failures.
+    expect(empty.hasErrors('second')).toBe(true);
   });
 
   it('clears changed focus when chained after an earlier changed field', async () => {

--- a/packages/vest/src/suite/__tests__/changed.projection.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.projection.test.ts
@@ -654,7 +654,7 @@ describe('changed() source-retaining projection', () => {
     expect(full.hasErrors('point.1')).toBe(false);
     const changed = await invokeWithUnknown(suite.changed('point.1').run, data);
     expect(changed.hasErrors('point.1')).toBe(true);
-    expect(changed.hasErrors('point.0')).toBe(false);
+    expect(changed.hasErrors('point.0')).toBe(true);
   });
 
   it('P1-3b: changed() surfaces an affected union element hidden by first-failure', async () => {
@@ -685,7 +685,7 @@ describe('changed() source-retaining projection', () => {
       data,
     );
     expect(changed.hasErrors('rows.1')).toBe(true);
-    expect(changed.hasErrors('rows.0')).toBe(false);
+    expect(changed.hasErrors('rows.0')).toBe(true);
   });
 
   it('P1-4: focused array validation runs affected members exactly once', async () => {

--- a/packages/vest/src/suite/__tests__/changed.supplement.test.ts
+++ b/packages/vest/src/suite/__tests__/changed.supplement.test.ts
@@ -158,7 +158,7 @@ describe('changed() supplement exactly-once execution', () => {
 
     const changed = await suite.changed('b').run(data);
     expect(changed.hasErrors('b')).toBe(true);
-    expect(changed.hasErrors('a')).toBe(false);
+    expect(changed.hasErrors('a')).toBe(true);
   });
 
   it('only()+changed() merge honors the affected member too', async () => {
@@ -178,9 +178,8 @@ describe('changed() supplement exactly-once execution', () => {
 
   it('flat supplement runs each shadowed member through one execution unit', async () => {
     // Members the main run reached (up to and including the failure) run
-    // there; members after it run once in the supplement — never both. One
-    // unit is parse-then-run: a failing member fires twice inside it (the
-    // engine's own duality, identical in full runs), a passing member once.
+    // there; members after it run once in the supplement. Failed predicates
+    // are not retried through another validation entry point.
     const calls: unknown[] = [];
     enforce.extend({
       countFlatMember: (value: unknown): boolean => {
@@ -199,7 +198,7 @@ describe('changed() supplement exactly-once execution', () => {
     const changed = await suite.changed(['b', 'c']).run(data);
     expect(changed.hasErrors('b')).toBe(true);
     expect(changed.hasErrors('c')).toBe(false);
-    expect(calls.filter(value => value === 'y')).toHaveLength(2);
+    expect(calls.filter(value => value === 'y')).toHaveLength(1);
     expect(calls.filter(value => value === 'ok-ok-ok')).toHaveLength(1);
   });
 
@@ -335,7 +334,7 @@ describe('changed() supplement exactly-once execution', () => {
     expect(changed.hasErrors('b')).toBe(true);
   });
 
-  it('flat supplement ignores non-enumerable members of partial tops', async () => {
+  it('flat supplement validates declared non-enumerable members of partial tops', async () => {
     const schema = enforce.partial({
       a: enforce.isString().longerThan(5),
       b: enforce.isString(),
@@ -351,11 +350,14 @@ describe('changed() supplement exactly-once execution', () => {
     expect(full.hasErrors('a')).toBe(true);
     expect(full.hasErrors('b')).toBe(false);
 
+    data.a = 'ok-ok-ok';
+    expect(schema.run(data).path).toEqual(['b']);
+    data.a = 'x';
     const changed = await suite.changed('b').run(data);
-    expect(changed.hasErrors('b')).toBe(false);
+    expect(changed.hasErrors('b')).toBe(true);
   });
 
-  it('nested supplement ignores non-enumerable members of partial containers', async () => {
+  it('nested supplement validates declared non-enumerable members of partial containers', async () => {
     const schema = enforce.shape({
       profile: enforce.partial({
         a: enforce.isString().longerThan(5),
@@ -375,9 +377,12 @@ describe('changed() supplement exactly-once execution', () => {
     expect(full.hasErrors('profile.a')).toBe(true);
     expect(full.hasErrors('profile.b')).toBe(false);
 
+    data.profile.a = 'ok-ok-ok';
+    expect(schema.run(data).path).toEqual(['profile', 'b']);
+    data.profile.a = 'x';
     const changed = await suite.changed(['profile.a', 'profile.b']).run(data);
     expect(changed.hasErrors('profile.a')).toBe(true);
-    expect(changed.hasErrors('profile.b')).toBe(false);
+    expect(changed.hasErrors('profile.b')).toBe(true);
   });
 
   it('full-fallback path executes each member validator at most once', async () => {
@@ -455,15 +460,12 @@ describe('changed() supplement exactly-once execution', () => {
       .run(data);
 
     expect(changed.hasErrors()).toBe(false);
-    // Invalid changed() runs use n4s's normal parse-then-run fallback, so
-    // members reached by the main execution unit match two direct runs.
-    // The supplement must not add a third visit to an earlier member.
+    // A full fallback has the same call count as one direct run.
+    // The supplement must not revisit an earlier member.
     expect(calls.filter(value => value === 'first-ok')).toHaveLength(
-      baselineFirst * 2,
+      baselineFirst,
     );
-    expect(calls.filter(value => value === 'x')).toHaveLength(
-      baselineFailure * 2,
-    );
+    expect(calls.filter(value => value === 'x')).toHaveLength(baselineFailure);
     expect(calls.filter(value => value === 'third-ok')).toHaveLength(1);
   });
 });

--- a/packages/vest/src/suite/__tests__/docsExamples.test.ts
+++ b/packages/vest/src/suite/__tests__/docsExamples.test.ts
@@ -234,6 +234,22 @@ describe('executable documentation examples', () => {
     expect(changed.hasErrors('confirmPassword')).toBe(true);
   });
 
+  it('executes the agent guide relationship example verbatim', () => {
+    const { relationshipSuite } = executeCodeBlock('AI_USAGE_GUIDE.md', {
+      containing: 'export const relationshipSuite',
+    }) as { relationshipSuite: ReturnType<typeof vest.create> };
+    expect(relationshipSuite.get().hasErrors('confirmPassword')).toBe(true);
+    expect(
+      relationshipSuite
+        .changed('confirmPassword')
+        .run({
+          password: 'second',
+          confirmPassword: 'second',
+        })
+        .hasErrors(),
+    ).toBe(false);
+  });
+
   it('reconciles documented dynamic-list tests by stable key', () => {
     const { tripSuite } = executeCodeBlock(
       'website/docs/guides/dynamic-lists.md',

--- a/packages/vest/src/suite/cloneDataTree.ts
+++ b/packages/vest/src/suite/cloneDataTree.ts
@@ -140,18 +140,53 @@ function immutableBuiltin<T extends object>(
   const rejectMutation = (): never => {
     throw new TypeError('Cannot mutate a parsed-data snapshot');
   };
-  return new Proxy(target, {
+  const snapshot = new Proxy(target, {
     defineProperty: rejectMutation,
     deleteProperty: rejectMutation,
     get(current, property) {
       if (mutators.has(property)) return rejectMutation;
-      const value = Reflect.get(current, property, current);
-      if (hasOwnProperty(current, property)) return value;
-      return typeof value === 'function' && property !== 'constructor'
-        ? value.bind(current)
-        : value;
+      return readSnapshotProperty(current, property, snapshot);
     },
     set: rejectMutation,
     setPrototypeOf: rejectMutation,
   });
+  return snapshot;
+}
+
+function readSnapshotProperty<T extends object>(
+  current: T,
+  property: PropertyKey,
+  snapshot: T,
+): unknown {
+  const value = Reflect.get(current, property, current);
+  if (
+    hasOwnProperty(current, property) ||
+    typeof value !== 'function' ||
+    property === 'constructor'
+  ) {
+    return value;
+  }
+  if (isCollectionForEach(current, property)) {
+    return (
+      callback: (value: unknown, key: unknown, collection: T) => void,
+      thisArg?: unknown,
+    ) => {
+      if (typeof callback !== 'function')
+        return value.call(current, callback, thisArg);
+      return value.call(current, (entry: unknown, key: unknown) =>
+        callback.call(thisArg, entry, key, snapshot),
+      );
+    };
+  }
+  // Object.valueOf returns its receiver. Never expose the mutable backing object.
+  return (...args: unknown[]) => {
+    const result = value.apply(current, args);
+    return result === current ? snapshot : result;
+  };
+}
+
+function isCollectionForEach(value: object, property: PropertyKey): boolean {
+  return (
+    property === 'forEach' && (value instanceof Map || value instanceof Set)
+  );
 }

--- a/packages/vest/src/suite/schemaValidation.ts
+++ b/packages/vest/src/suite/schemaValidation.ts
@@ -1,0 +1,59 @@
+import type { SelectiveSchemaResult } from 'n4s/exports/internal';
+import { makeResult } from 'vest-utils';
+import { VestRuntime, Walker } from 'vestjs-runtime';
+
+import { VestTest } from '../core/isolate/IsolateTest/VestTest';
+
+/**
+ * Retention belongs to Vest's test tree. Reading actual failing tests makes
+ * resetField(), remove(), reset(), and resume() authoritative; there is no
+ * parallel error cache to invalidate.
+ */
+export function useRetainedSchemaFailures(
+  affected: readonly string[] | null,
+): SelectiveSchemaResult[] {
+  if (affected === null) return [];
+  const root = VestRuntime.useAvailableRoot();
+  const container = root?.children?.find(
+    child => child.data.schemaValidation === true,
+  );
+  if (!container) return [];
+  return Walker.reduce<SelectiveSchemaResult[]>(
+    container,
+    (failures, node) => {
+      if (!VestTest.is(node) || !VestTest.isFailing(node).unwrap()) {
+        return makeResult.Ok(failures);
+      }
+      const { fieldName, message } = VestTest.getData(node);
+      const touched = affected.some(
+        field =>
+          fieldName === '__root__' ||
+          field === fieldName ||
+          field.startsWith(`${fieldName}.`) ||
+          fieldName.startsWith(`${field}.`),
+      );
+      return makeResult.Ok(
+        touched
+          ? failures
+          : [
+              ...failures,
+              {
+                pass: false,
+                message,
+                path: fieldName === '__root__' ? [] : fieldName.split('.'),
+              },
+            ],
+      );
+    },
+    [],
+  );
+}
+
+export function schemaFailureField(result: SelectiveSchemaResult): string {
+  return result.path?.length ? result.path.join('.') : '__root__';
+}
+
+/** Stable across changes in which other fields fail in the same run. */
+export function schemaFailureKey(result: SelectiveSchemaResult): string {
+  return JSON.stringify([result.path ?? [], result.message ?? null]);
+}

--- a/packages/vest/src/suite/useCreateSuiteRunner.ts
+++ b/packages/vest/src/suite/useCreateSuiteRunner.ts
@@ -9,6 +9,7 @@ import {
   asArray,
   CB,
   freezeAssign,
+  hasOwnProperty,
   isArray,
   isObject,
   isUnsafeKey,
@@ -44,6 +45,11 @@ import {
   SuiteRunArguments,
 } from './SuiteTypes';
 import { cloneDataTree } from './cloneDataTree';
+import {
+  schemaFailureField,
+  schemaFailureKey,
+  useRetainedSchemaFailures,
+} from './schemaValidation';
 
 /**
  * Schema run outcome. Deliberately aliased to the n4s-owned
@@ -197,6 +203,7 @@ export function useCreateSuiteRunner<
       : undefined;
 
     const parsedDataChunk = getParsedDataChunk(schemaRunResult);
+    const retainedSchemaFailures = useRetainedSchemaFailures(changedAffected);
 
     const parsedData = (
       schema ? snapshotParsedData(parsedDataChunk) : undefined
@@ -255,6 +262,7 @@ export function useCreateSuiteRunner<
           useRunSuiteCallback<F, T, S, G>({
             args: callbackArgs,
             modifiers: transformedModifiers,
+            retainedSchemaFailures,
             schema,
             schemaRunResult,
             suiteCallback,
@@ -503,14 +511,42 @@ function successfulCallbackMapping(
     });
   }
 
-  if (previous === undefined) {
-    const initial = mapWithoutValidation(schema, fallback);
-    const merged = mergeMappedPaths(initial, current, affected);
-    return mappedCallbackResult(merged);
-  }
+  return focusedCallbackMapping({
+    affected,
+    current,
+    fallback,
+    previous,
+    schema,
+  });
+}
 
+function focusedCallbackMapping(params: {
+  affected: string[];
+  current: unknown;
+  fallback: unknown;
+  previous: MappedSchemaOutput | undefined;
+  schema: unknown;
+}): CallbackMapping {
+  const { affected, current, fallback, previous, schema } = params;
+  const replacesArray = affected.some(field =>
+    concreteFieldPath(field).some(segment => typeof segment === 'number'),
+  );
+  const fresh =
+    previous === undefined || replacesArray
+      ? mapWithoutValidation(schema, fallback)
+      : undefined;
+  // Replacing a positional collection requires a complete mapping of its
+  // current members. Overlay only the executed leaves onto raw-input parser
+  // mapping before replacing the array in retained state.
+  const mappedCurrent = replacesArray
+    ? mergeMappedPaths(fresh, current, affected, false)
+    : current;
   return mappedCallbackResult(
-    mergeMappedPaths(previous.value, current, affected),
+    mergeMappedPaths(
+      previous ? previous.value : fresh,
+      mappedCurrent,
+      affected,
+    ),
   );
 }
 
@@ -532,16 +568,24 @@ function mergeMappedPaths(
   previous: unknown,
   current: unknown,
   affected: readonly string[],
+  replaceArrays = true,
 ): unknown {
-  if (affected.length === 0) return previous;
   let merged = previous;
   for (const field of affected) {
-    const path = retainedMergePath(concreteFieldPath(field));
+    const path = mappedMergePath(field, replaceArrays);
     if (path.length === 0) return current;
     if (path.some(isUnsafePathSegment)) continue;
     merged = setPathValue(merged, current, path, 0);
   }
   return merged;
+}
+
+function mappedMergePath(
+  field: string,
+  replaceArrays: boolean,
+): ConcretePathSegment[] {
+  const path = concreteFieldPath(field);
+  return replaceArrays ? retainedMergePath(path) : path;
 }
 
 /**
@@ -613,10 +657,26 @@ function setPathValue(
   const key = path[index];
   if (key === undefined) return previous;
 
+  if (index === path.length - 1 && isMissingOwnKey(current, key)) {
+    return copyWithoutKey(previous, key);
+  }
+
   const previousChild = readPathValue(previous, key);
   const currentChild = readPathValue(current, key);
   const nextChild = setPathValue(previousChild, currentChild, path, index + 1);
   return writePathValue(previous, key, nextChild);
+}
+
+function isMissingOwnKey(value: unknown, key: ConcretePathSegment): boolean {
+  return !isObject(value) || !hasOwnProperty(value, key);
+}
+
+function copyWithoutKey(value: unknown, key: ConcretePathSegment): unknown {
+  const copy = isArray(value)
+    ? [...value]
+    : { ...(isObject(value) ? value : {}) };
+  Reflect.deleteProperty(copy, key);
+  return copy;
 }
 
 function readPathValue(value: unknown, key: ConcretePathSegment): unknown {
@@ -655,6 +715,7 @@ function useRunSuiteCallback<
   modifiers: ReturnType<typeof useTransformedModifiers<F, G>>;
   schema: S | undefined;
   schemaRunResult?: SchemaRunResult[];
+  retainedSchemaFailures: SchemaRunResult[];
   suiteCallback: SuiteCallbackWithSchema<S, T>;
   useResolver: () => SuiteResult<F, G, S, D>;
 }) {
@@ -663,6 +724,7 @@ function useRunSuiteCallback<
     modifiers,
     schema,
     schemaRunResult,
+    retainedSchemaFailures,
     suiteCallback,
     useResolver,
   } = params;
@@ -670,14 +732,20 @@ function useRunSuiteCallback<
   return () => {
     // Focused modifiers are applied before user callback so every test in this run
     // observes the same focus context.
-    only(withSchemaFailureFocus(modifiers.only, schemaRunResult));
+    only(modifiers.only);
     skip(modifiers.__skipAll || modifiers.skip);
     (suiteCallback as CB)(...args);
 
     IsolateReorderable(
-      runSchemaValidation(schema, schemaRunResult),
+      runSchemaValidation(
+        schema,
+        schemaRunResult,
+        retainedSchemaFailures,
+        modifiers,
+      ),
       undefined,
       {
+        ...(schema ? { schemaValidation: true } : {}),
         tests: [],
       },
     );
@@ -738,87 +806,17 @@ function snapshotGroup<F extends TFieldName, G extends TGroupName>(
 }
 
 /**
- * Widens execution focus to cover already-narrowed schema failures reported
- * above the affected leaves (e.g. a union element failure at 'rows.1' for
- * changed('rows.1.kind')). The post-filter keeps failures parent-either-way,
- * but suite focus matches test names exactly, so a coarser attribution would
- * be emitted and then excluded — reported nowhere. Only strict parents of
- * focused names are added: leaf failures already match exactly, and child
- * failures keep their existing behavior, so user-test execution is otherwise
- * unchanged.
- */
-function withSchemaFailureFocus<F extends TFieldName>(
-  only: FieldExclusion<F>,
-  schemaRunResult: readonly SchemaRunResult[] | undefined,
-): FieldExclusion<F> {
-  if (schemaRunResult === undefined) {
-    return only;
-  }
-  const base = focusBaseNames(only);
-  if (base === null) {
-    return only;
-  }
-  const additions = parentFocusAdditions<F>(base.map(String), schemaRunResult);
-  if (additions.length === 0) {
-    return only;
-  }
-  return [...base, ...additions];
-}
-
-function focusBaseNames<F extends TFieldName>(
-  only: FieldExclusion<F>,
-): F[] | null {
-  if (only === undefined || only === null) return null;
-  const base = asArray(only);
-  return base.length === 0 ? null : base;
-}
-
-/**
- * Failure paths that are strict parents of a focused name. A coarser schema
- * attribution (e.g. 'rows.1' for changed('rows.1.kind')) would otherwise be
- * emitted and then excluded by exact focus matching — reported nowhere.
- */
-function parentFocusAdditions<F extends TFieldName>(
-  baseNames: string[],
-  schemaRunResult: readonly SchemaRunResult[],
-): F[] {
-  const seen = new Set<string>(baseNames);
-  const additions: F[] = [];
-  for (const result of schemaRunResult) {
-    const failureName = schemaFailureName(result);
-    if (failureName === '' || seen.has(failureName)) {
-      continue;
-    }
-    if (isParentOfFocusedName(baseNames, failureName)) {
-      seen.add(failureName);
-      additions.push(failureName as unknown as F);
-    }
-  }
-  return additions;
-}
-
-function schemaFailureName(result: SchemaRunResult): string {
-  if (result.pass) {
-    return '';
-  }
-  return (result.path ?? []).map(String).join('.');
-}
-
-function isParentOfFocusedName(
-  baseNames: readonly string[],
-  failureName: string,
-): boolean {
-  return baseNames.some((baseName: string): boolean =>
-    baseName.startsWith(`${failureName}.`),
-  );
-}
-
-/**
  * Emits schema failures into vest test tree.
  */
 function runSchemaValidation<S extends TSchema = undefined>(
   schema: S | undefined,
   schemaRunResult?: SchemaRunResult[],
+  retained: SchemaRunResult[] = [],
+  modifiers?: {
+    only?: FieldExclusion<string>;
+    skip?: FieldExclusion<string>;
+    __skipAll?: boolean;
+  },
 ) {
   // eslint-disable-next-line complexity
   return () => {
@@ -826,14 +824,20 @@ function runSchemaValidation<S extends TSchema = undefined>(
       return;
     }
 
-    for (let i = 0; i < schemaRunResult.length; i++) {
-      const error = schemaRunResult[i];
+    // n4s already narrowed these failures. Include their actual attribution
+    // only inside this isolate, so parent/root errors remain visible without
+    // widening execution of the user's tests.
+    only(
+      schemaRunResult.filter(result => !result.pass).map(schemaFailureField),
+    );
+    skip(modifiers?.__skipAll || modifiers?.skip);
+    for (const error of [...schemaRunResult, ...retained]) {
       if (error.pass) {
         continue;
       }
 
-      const fieldName = error.path?.length ? error.path.join('.') : '__root__';
-      const testKey = `${fieldName}_${i}`;
+      const fieldName = schemaFailureField(error);
+      const testKey = schemaFailureKey(error);
       test(fieldName, error.message, () => false, testKey);
     }
   };

--- a/website/docs/writing_your_suite/schema_relationships.md
+++ b/website/docs/writing_your_suite/schema_relationships.md
@@ -271,9 +271,13 @@ as the affected set. This preserves `only()` semantics while giving frameworks a
 
 Split of responsibilities: Enforce owns spatial and structural truth (the graph, schema paths, selective execution); Vest owns temporal truth (retained state, test focus, reconciliation). The handshake between them is narrow — Vest hands n4s the schema, the run data, and the raw changed names; n4s returns the concrete affected set. Vest resolves that set once through the canonical planner, then gives the exact same set to both suite focus and schema execution via `runSchemaPaths(schema, data, options?)`. Everything after that is n4s-owned — container-kind detection, fragment projection, short-circuit supplementation, chain-validator preservation, and member execution. Vest never reverse-engineers container semantics.
 
-Selective execution holds for focused runs: members outside the affected set never execute, and each affected single-rule or tuple member executes exactly once — safe for stateful validators. Union (`isArrayOf` with several members) elements instead resolve whole-member any-match: each affected element is checked against the members in order until one matches, so member validators may execute more than once (once per affected element) — do not rely on exactly-once for stateful validators inside union members. Tuple members run positionally and union elements resolve whole-member any-match, both with the same attribution a full run would report. Shapes whose fields are all `optional()` are still ordinary required-semantics containers (only `partial()` skips missing keys). Validators chained onto a container itself, or a `partial()` top-level schema, cannot be projected safely: those runs validate the full schema and narrow the failures to the affected paths instead, so results always match the full run.
+For projectable shapes and selected array or tuple members, validators outside the affected set do not execute. Each selected rule executes once; a failed n4s verdict is never retried through another validation entry point. Union elements use ordered any-match evaluation, which can evaluate several alternatives. Keep validators pure: these guarantees do not turn validation into a side-effect scheduler.
 
-To decide whether a container can be projected, n4s reads construction-time markers (`partial()`, `optional()`) only. Introspection never executes user validators: no synthetic probe values (`{}`, `undefined`, `null`) are ever passed to validation code, so validators with observable side effects only ever fire with real run data inside a suite run. Schemas without recognizable metadata (unknown or exotic rules) are not projected: those runs validate the full schema and narrow the failures to the affected paths instead — slower, but with results always matching the full run.
+Container validators and schemas without recognizable metadata can require a full-schema fallback. That fallback can execute untouched validators; failures are then narrowed to the affected paths. Schema validation remains short-circuiting, and selective execution supplements affected members hidden behind the first failure. A focused result is not proof that the entire current input passed the schema. Run the full suite before submission.
+
+Projection reads construction-time metadata and never probes validators with synthetic data. Partial fragments preserve the distinction between an absent property and an own property holding `undefined`, including declared non-enumerable properties. A shape of `optional()` members has different semantics from `partial()`.
+
+Vest retains previously reported schema errors on untouched fields, just as it retains user-test errors. A changed run clears a retained error when that field is revalidated successfully; `resetField()`, `remove()`, and `reset()` also clear the corresponding state. `changed([])` performs no revalidation and does not clear previous failures. This history belongs to the suite, not the n4s schema or its serializable relationship graph.
 
 ### `suite.changed()` Reference
 
@@ -288,11 +292,12 @@ Accepted field arguments:
 - `suite.changed('password')` — expand the affected set from one field.
 - `suite.changed(['password', 'country'])` — expand from several fields (union of affected sets).
 - `suite.changed(undefined)` — legal no-op that runs without changed focus, mirroring `only(undefined)`.
-- `suite.changed([])` — explicit empty focus: runs no tests.
+- `suite.changed([])` — explicit empty focus: runs no tests and retains previous failures.
 
 Behavior notes:
 
 - Returns a focused suite, so it chains with the other focus APIs: `suite.changed('password').only('confirmPassword').run(data)`. Combining `only()` with `changed()` runs the union — the `only()` base fields plus the affected set.
+- Changing a whole object selects its descendants; changing a descendant also invalidates rules that depend on that whole object. Expansion remains direct, not transitive.
 - Changed names may be nested paths in either spelling — `suite.changed('company.country')` and `suite.changed('travelers[1].passportCountry')` resolve to the same affected set.
 - Without a schema, or when the schema declares no `dependsOn` edges, `changed()` degrades gracefully: the affected set is the named fields themselves, equivalent to `only()` for that run.
 

--- a/website/docs/writing_your_suite/schema_validation.md
+++ b/website/docs/writing_your_suite/schema_validation.md
@@ -99,12 +99,15 @@ result.value; // typed as { age: number; name: string }
 
 The first rule in a chain determines the input type, and the last parser in the chain determines the output type. This means you never need `@ts-expect-error` or `as any` for valid parser coercion inputs.
 
-Focused runs still pass the complete parsed output to the suite callback. On a
+Successful focused schema runs assemble mapped output for the suite callback. On a
 first focused run, Vest applies parser steps to untouched fields without
 running their validation predicates. Parser transforms should therefore be
 pure and must return their declared output type even when their `pass` verdict
-is false. The mapped output keeps the callback type sound; an untouched
-parser's failure does not become part of that focused run's validation result.
+is false. An untouched parser's failure does not become part of that focused
+run's validation result. Mapping is not validation: missing or invalid untouched
+input is not proven to satisfy the schema. If schema validation fails, the
+callback can receive raw input at the failing paths. Guard values before using
+output-only operations, and use a full successful run before submission.
 If a custom `enforce.extend` rule is a parser, register it explicitly so
 focused mapping can recognize it:
 
@@ -136,7 +139,9 @@ output assembled for the suite.
 When a focused path enters an array, Vest refreshes that containing array from
 the current input. Array positions are not identities, so this prevents an
 insert, removal, or reorder from combining the current item with a stale array
-layout retained from an earlier run.
+layout retained from an earlier run. Untouched members of that array are mapped
+from raw input without running their validation predicates. Parsers can run
+again to refresh this mapping and must be pure.
 
 ### What becomes typed from the schema
 
@@ -187,7 +192,7 @@ suite.focus({ onlyGroup: 'account' }); // typed group name
 ```
 
 :::note Focused runs
-When you focus the suite with `suite.only()`, `suite.skip()`, or `suite.focus()`, Vest intelligently subsets your validation schema under the hood using `enforce.pick` and `enforce.omit`. This ensures that schema validation still runs securely for the fields in focus—and provides correct types in the test callback!—while safely ignoring un-focused fields and allowing you to validate partial payloads effectively.
+Suite-level `only`, `skip`, and `focus` select schema fields as well as suite tests. Structural schemas can be narrowed using their metadata; rules with container validators may require a full-schema fallback. Focused validation does not establish the validity or presence of untouched input. Supply complete form data when the callback reads untouched fields.
 
 ```javascript
 // Validate only the username field, enforcing the schema for 'username' while ignoring 'age'

--- a/website/static/llms-consumer.txt
+++ b/website/static/llms-consumer.txt
@@ -111,7 +111,42 @@ Use `suite.afterEach(callback)` when the UI must update after the synchronous pa
 
 ## Dependent fields
 
-Use `include` to run a related field when another focused field runs:
+For schema-backed suites, declare structural dependencies with `dependsOn`
+and use `changed` for interaction-driven updates:
+
+```js
+import { create, enforce, test } from 'vest';
+
+const passwordSchema = enforce.shape({
+  password: enforce.isString(),
+  confirmPassword: enforce.isString().dependsOn($ => $.password),
+});
+
+export const relationshipSuite = create(data => {
+  test('confirmPassword', 'Passwords do not match', () => {
+    enforce(data.confirmPassword).equals(data.password);
+  });
+}, passwordSchema);
+
+relationshipSuite.run({ password: 'first', confirmPassword: 'first' });
+relationshipSuite.changed('password').run({
+  password: 'second',
+  confirmPassword: 'first',
+}); // confirmPassword now fails
+```
+
+`dependsOn` declares invalidation, not an equality check. `$` names siblings;
+`$.root` addresses the composed root. Arrays bind sibling references within the
+same item. Expansion includes direct dependents only. `only` does not expand
+these edges; combining `only` with `changed` uses their union. Untouched suite
+results, including schema errors, remain until revalidated or reset.
+
+Use pure synchronous schema validators and parsers. Keep async checks in Vest
+`test` callbacks. A focused result does not validate all current input; await a
+full run before submission. `schema.describe()` exposes serializable structural
+metadata for tools, not validation verdicts or pending work.
+
+For suites without a schema, or explicit runtime inclusion, use `include` to run a related field when another focused field runs:
 
 ```js
 import { create, enforce, include, test } from 'vest';

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9743,9 +9743,13 @@ as the affected set. This preserves `only()` semantics while giving frameworks a
 
 Split of responsibilities: Enforce owns spatial and structural truth (the graph, schema paths, selective execution); Vest owns temporal truth (retained state, test focus, reconciliation). The handshake between them is narrow — Vest hands n4s the schema, the run data, and the raw changed names; n4s returns the concrete affected set. Vest resolves that set once through the canonical planner, then gives the exact same set to both suite focus and schema execution via `runSchemaPaths(schema, data, options?)`. Everything after that is n4s-owned — container-kind detection, fragment projection, short-circuit supplementation, chain-validator preservation, and member execution. Vest never reverse-engineers container semantics.
 
-Selective execution holds for focused runs: members outside the affected set never execute, and each affected single-rule or tuple member executes exactly once — safe for stateful validators. Union (`isArrayOf` with several members) elements instead resolve whole-member any-match: each affected element is checked against the members in order until one matches, so member validators may execute more than once (once per affected element) — do not rely on exactly-once for stateful validators inside union members. Tuple members run positionally and union elements resolve whole-member any-match, both with the same attribution a full run would report. Shapes whose fields are all `optional()` are still ordinary required-semantics containers (only `partial()` skips missing keys). Validators chained onto a container itself, or a `partial()` top-level schema, cannot be projected safely: those runs validate the full schema and narrow the failures to the affected paths instead, so results always match the full run.
+For projectable shapes and selected array or tuple members, validators outside the affected set do not execute. Each selected rule executes once; a failed n4s verdict is never retried through another validation entry point. Union elements use ordered any-match evaluation, which can evaluate several alternatives. Keep validators pure: these guarantees do not turn validation into a side-effect scheduler.
 
-To decide whether a container can be projected, n4s reads construction-time markers (`partial()`, `optional()`) only. Introspection never executes user validators: no synthetic probe values (`{}`, `undefined`, `null`) are ever passed to validation code, so validators with observable side effects only ever fire with real run data inside a suite run. Schemas without recognizable metadata (unknown or exotic rules) are not projected: those runs validate the full schema and narrow the failures to the affected paths instead — slower, but with results always matching the full run.
+Container validators and schemas without recognizable metadata can require a full-schema fallback. That fallback can execute untouched validators; failures are then narrowed to the affected paths. Schema validation remains short-circuiting, and selective execution supplements affected members hidden behind the first failure. A focused result is not proof that the entire current input passed the schema. Run the full suite before submission.
+
+Projection reads construction-time metadata and never probes validators with synthetic data. Partial fragments preserve the distinction between an absent property and an own property holding `undefined`, including declared non-enumerable properties. A shape of `optional()` members has different semantics from `partial()`.
+
+Vest retains previously reported schema errors on untouched fields, just as it retains user-test errors. A changed run clears a retained error when that field is revalidated successfully; `resetField()`, `remove()`, and `reset()` also clear the corresponding state. `changed([])` performs no revalidation and does not clear previous failures. This history belongs to the suite, not the n4s schema or its serializable relationship graph.
 
 ### `suite.changed()` Reference
 
@@ -9760,11 +9764,12 @@ Accepted field arguments:
 - `suite.changed('password')` — expand the affected set from one field.
 - `suite.changed(['password', 'country'])` — expand from several fields (union of affected sets).
 - `suite.changed(undefined)` — legal no-op that runs without changed focus, mirroring `only(undefined)`.
-- `suite.changed([])` — explicit empty focus: runs no tests.
+- `suite.changed([])` — explicit empty focus: runs no tests and retains previous failures.
 
 Behavior notes:
 
 - Returns a focused suite, so it chains with the other focus APIs: `suite.changed('password').only('confirmPassword').run(data)`. Combining `only()` with `changed()` runs the union — the `only()` base fields plus the affected set.
+- Changing a whole object selects its descendants; changing a descendant also invalidates rules that depend on that whole object. Expansion remains direct, not transitive.
 - Changed names may be nested paths in either spelling — `suite.changed('company.country')` and `suite.changed('travelers[1].passportCountry')` resolve to the same affected set.
 - Without a schema, or when the schema declares no `dependsOn` edges, `changed()` degrades gracefully: the affected set is the named fields themselves, equivalent to `only()` for that run.
 
@@ -10077,12 +10082,15 @@ result.value; // typed as { age: number; name: string }
 
 The first rule in a chain determines the input type, and the last parser in the chain determines the output type. This means you never need `@ts-expect-error` or `as any` for valid parser coercion inputs.
 
-Focused runs still pass the complete parsed output to the suite callback. On a
+Successful focused schema runs assemble mapped output for the suite callback. On a
 first focused run, Vest applies parser steps to untouched fields without
 running their validation predicates. Parser transforms should therefore be
 pure and must return their declared output type even when their `pass` verdict
-is false. The mapped output keeps the callback type sound; an untouched
-parser's failure does not become part of that focused run's validation result.
+is false. An untouched parser's failure does not become part of that focused
+run's validation result. Mapping is not validation: missing or invalid untouched
+input is not proven to satisfy the schema. If schema validation fails, the
+callback can receive raw input at the failing paths. Guard values before using
+output-only operations, and use a full successful run before submission.
 If a custom `enforce.extend` rule is a parser, register it explicitly so
 focused mapping can recognize it:
 
@@ -10114,7 +10122,9 @@ output assembled for the suite.
 When a focused path enters an array, Vest refreshes that containing array from
 the current input. Array positions are not identities, so this prevents an
 insert, removal, or reorder from combining the current item with a stale array
-layout retained from an earlier run.
+layout retained from an earlier run. Untouched members of that array are mapped
+from raw input without running their validation predicates. Parsers can run
+again to refresh this mapping and must be pure.
 
 ### What becomes typed from the schema
 
@@ -10165,7 +10175,7 @@ suite.focus({ onlyGroup: 'account' }); // typed group name
 ```
 
 :::note Focused runs
-When you focus the suite with `suite.only()`, `suite.skip()`, or `suite.focus()`, Vest intelligently subsets your validation schema under the hood using `enforce.pick` and `enforce.omit`. This ensures that schema validation still runs securely for the fields in focus—and provides correct types in the test callback!—while safely ignoring un-focused fields and allowing you to validate partial payloads effectively.
+Suite-level `only`, `skip`, and `focus` select schema fields as well as suite tests. Structural schemas can be narrowed using their metadata; rules with container validators may require a full-schema fallback. Focused validation does not establish the validity or presence of untouched input. Supply complete form data when the callback reads untouched fields.
 
 ```javascript
 // Validate only the username field, enforcing the schema for 'username' while ignoring 'age'


### PR DESCRIPTION
PR #1324 can lose untouched schema errors, hide root/descendant failures, retry failed validators, miss dependencies of whole objects or composed roots, and expose mutable snapshot collections. These are observable correctness issues in the proposed changed() contract.

This draft targets the feature branch and keeps the fixes separate from #1324.

Changes:
- Execute native n4s rules through one verdict/output entry point.
- Preserve schema failure attribution inside the schema isolate without widening user test selection.
- Retain untouched schema failures in Vest's existing test tree, including reset/remove/resume lifecycle behavior.
- Match descendant changes to whole-object dependency sources and read callable schema descriptions with their receiver.
- Keep projection-construction context out of user validators.
- Exclude explicitly skipped affected paths before selective execution.
- Preserve partial-property absence and present undefined semantics.
- Refresh array mappings from raw input, retaining parsed untouched members.
- Close Map/Set snapshot escapes through forEach and valueOf.
- Add 23 regression/documentation checks, correct existing assertions that pinned erroneous behavior, clarify focused-validation limits, regenerate agent documentation, and add two unscored AI evaluation prompts.

Evidence:
- On the reviewed original head (30e6a212), all 2,975 pre-existing tests passed, but 12 of the initial 13 adversarial checks failed.
- All package builds and the compiler gate including tests pass.
- The 21 adversarial checks, 13 callback mapping checks, and 21 website tests pass. The agent guide example executes verbatim against Vest.
- Repository lint has zero errors; generated documentation is idempotent.
- Final full suite: 319 files, 2,998 tests passed; no type errors.
- Integration matrix: 33 tests across 13 files passed; all seven workspace type checks and builds passed.
- Integration documentation generation passed. The environment rejects tsx CLI IPC sockets, so the same scripts were run with node --import tsx; no repository workaround was needed.
- An unchanged wall-clock async test failed once under the initial full-worker run, then passed in isolation and in the final two-worker run. No timer assertion or snapshot was relaxed.

Design assessment: keep the Enforce structural / Vest temporal boundary. The selective executor still needs an eventual explicit execution plan instead of inferring visited rules from first-failure paths. Full-schema fallbacks can execute untouched validators; focused results do not certify complete current input. This draft makes those limits explicit and does not claim universal exactly-once semantics.